### PR TITLE
feat: Confirm to delete character

### DIFF
--- a/client/character.lua
+++ b/client/character.lua
@@ -334,9 +334,19 @@ local function chooseCharacter()
                         description = Lang:t('info.delete_character_description', { playerName = name }),
                         icon = 'trash',
                         onSelect = function()
-                            TriggerServerEvent('qbx_core:server:deleteCharacter', character.citizenid)
-                            destroyPreviewCam()
-                            chooseCharacter()
+                            local confirmDelete = lib.alertDialog({
+                                header = Lang:t('info.delete_character'),
+                                content = Lang:t('info.confirm_delete'),
+                                centered = true,
+                                cancel = true
+                            })
+                            if confirmDelete == 'confirm' then
+                                TriggerServerEvent('qbx_core:server:deleteCharacter', character.citizenid)
+                                destroyPreviewCam()
+                                chooseCharacter()
+                            else
+                                lib.showContext('qbx_core_multichar_character_'..i)
+                            end
                         end
                     } or nil
                 }

--- a/client/character.lua
+++ b/client/character.lua
@@ -334,13 +334,12 @@ local function chooseCharacter()
                         description = Lang:t('info.delete_character_description', { playerName = name }),
                         icon = 'trash',
                         onSelect = function()
-                            local confirmDelete = lib.alertDialog({
+                            if lib.alertDialog({
                                 header = Lang:t('info.delete_character'),
                                 content = Lang:t('info.confirm_delete'),
                                 centered = true,
                                 cancel = true
-                            })
-                            if confirmDelete == 'confirm' then
+                            }) then
                                 TriggerServerEvent('qbx_core:server:deleteCharacter', character.citizenid)
                                 destroyPreviewCam()
                                 chooseCharacter()

--- a/locale/en.lua
+++ b/locale/en.lua
@@ -56,7 +56,8 @@ local Translations = {
         nationality = 'Nationality',
         gender = 'Sex',
         birth_date = 'Birth Date',
-        select_gender = 'Select your gender...'
+        select_gender = 'Select your gender...',
+        confirm_delete = 'Are you sure you wish to delete this character?'
     },
     command = {
         tp = {


### PR DESCRIPTION
## Description
Adds confirmation when deleting characters using the core character selection. Returns to previous context menu if choosing cancel.

Closes #186 

![image](https://github.com/Qbox-project/qbx_core/assets/96954031/fe2e745f-c862-48b3-8df6-01c501f03483)


## Checklist
- [X] I have personally loaded this code into an updated Qbox project and checked all of its functionality.
- [X] My code fits the style guidelines.
- [X] My PR fits the contribution guidelines.
