### PR TITLE
Add GetVehiclesByCategory() Export

### DIFF
--- a/client/main.lua
+++ b/client/main.lua
@@ -31,6 +31,8 @@ end
 
 exports('GetVehiclesByHash', GetVehiclesByHash)
 
+exports('GetVehiclesByCategory', GetVehiclesByCategory)
+
 ---@return table<number, Weapon>
 function GetWeapons()
     return QBX.Shared.Weapons

--- a/client/main.lua
+++ b/client/main.lua
@@ -31,6 +31,12 @@ end
 
 exports('GetVehiclesByHash', GetVehiclesByHash)
 
+---@param vehicles table<string, Vehicle>
+---@return table<string, table<number, Vehicle>>
+function GetVehiclesByCategory(vehicles)
+	return MapTableBySubfield('category', vehicles)
+end
+
 exports('GetVehiclesByCategory', GetVehiclesByCategory)
 
 ---@return table<number, Weapon>

--- a/client/main.lua
+++ b/client/main.lua
@@ -31,10 +31,9 @@ end
 
 exports('GetVehiclesByHash', GetVehiclesByHash)
 
----@param vehicles table<string, Vehicle>
 ---@return table<string, Vehicle[]>
-function GetVehiclesByCategory(vehicles)
-	return MapTableBySubfield('category', vehicles)
+function GetVehiclesByCategory()
+	return MapTableBySubfield('category', QBX.Shared.Vehicles)
 end
 
 exports('GetVehiclesByCategory', GetVehiclesByCategory)

--- a/client/main.lua
+++ b/client/main.lua
@@ -32,7 +32,7 @@ end
 exports('GetVehiclesByHash', GetVehiclesByHash)
 
 ---@param vehicles table<string, Vehicle>
----@return table<string, table<number, Vehicle>>
+---@return table<string, Vehicle[]>
 function GetVehiclesByCategory(vehicles)
 	return MapTableBySubfield('category', vehicles)
 end

--- a/modules/utils.lua
+++ b/modules/utils.lua
@@ -145,7 +145,7 @@ end
 --- maps a table by the given subfield
 --- @param subfield string
 --- @param table table
---- @return table<string, table>
+--- @return table<any, table[]>
 function MapTableBySubfield(subfield, table)
 	local mappedTable = {}
 	for _, tableData in pairs(table) do

--- a/modules/utils.lua
+++ b/modules/utils.lua
@@ -142,7 +142,7 @@ function GenerateRandomPlate(pattern) -- luacheck: ignore
     return newPattern:upper()
 end
 
---- mapps a table by the given subfield
+--- maps a table by the given subfield
 --- @param subfield string
 --- @param table table
 --- @return table

--- a/modules/utils.lua
+++ b/modules/utils.lua
@@ -145,18 +145,19 @@ end
 --- maps a table by the given subfield
 --- @param subfield string
 --- @param table table
---- @return table
+--- @return table<string, table>
 function MapTableBySubfield(subfield, table)
 	local mappedTable = {}
-	for tableIndex, tableData in pairs(table) do
-		if not tableData[subfield] then
+	for _, tableData in pairs(table) do
+        local tableSubfield = tableData[subfield]
+		if not tableSubfield then
 			goto continue
 		end
-		if not mappedTable[tableData[subfield]] then
-			mappedTable[tableData[subfield]] = {}
+		if not mappedTable[tableSubfield] then
+			mappedTable[tableSubfield] = {}
 		end
 
-		mappedTable[tableData[subfield]][tableIndex] = tableData
+		mappedTable[tableSubfield][#mappedTable[tableSubfield]+1] = tableData
 		::continue::
 	end
 	return mappedTable

--- a/modules/utils.lua
+++ b/modules/utils.lua
@@ -149,7 +149,7 @@ end
 function MapTableBySubfield(subfield, table)
 	local mappedTable = {}
 	for tableIndex, tableData in pairs(table) do
-		if not vehicleData[subfield] then
+		if not tableData[subfield] then
 			goto continue
 		end
 		if not mappedTable[tableData[subfield]] then

--- a/modules/utils.lua
+++ b/modules/utils.lua
@@ -142,19 +142,24 @@ function GenerateRandomPlate(pattern) -- luacheck: ignore
     return newPattern:upper()
 end
 
---- Returns a mapped table of vehicles by category
---- @param Vehicles table
+--- mapps a table by the given subfield
+--- @param subfield string
+--- @param table table
 --- @return table
-function GetVehiclesByCategory(Vehicles)
-	local mappedVehicles = {}
-	for vehicleIndex, vehicleData in pairs(Vehicles) do
-		if not mappedVehicles[vehicleData.category] then
-			mappedVehicles[vehicleData.category] = {}
+function MapTableBySubfield(subfield, table)
+	local mappedTable = {}
+	for tableIndex, tableData in pairs(table) do
+		if not vehicleData[subfield] then
+			goto continue
+		end
+		if not mappedTable[tableData[subfield]] then
+			mappedTable[tableData[subfield]] = {}
 		end
 
-		mappedVehicles[vehicleData.category][vehicleIndex] = vehicleData
+		mappedTable[tableData[subfield]][tableIndex] = tableData
+		::continue::
 	end
-	return mappedVehicles
+	return mappedTable
 end
 
 if isServer then

--- a/modules/utils.lua
+++ b/modules/utils.lua
@@ -142,6 +142,21 @@ function GenerateRandomPlate(pattern) -- luacheck: ignore
     return newPattern:upper()
 end
 
+--- Returns a mapped table of vehicles by category
+--- @param Vehicles table
+--- @return table
+function GetVehiclesByCategory(Vehicles)
+	local mappedVehicles = {}
+	for vehicleIndex, vehicleData in pairs(Vehicles) do
+		if not mappedVehicles[vehicleData.category] then
+			mappedVehicles[vehicleData.category] = {}
+		end
+
+		mappedVehicles[vehicleData.category][vehicleIndex] = vehicleData
+	end
+	return mappedVehicles
+end
+
 if isServer then
     -- Server side vehicle creation
     -- The CreateVehicleServerSetter native uses only the server to create a vehicle instead of using the client as well

--- a/server/main.lua
+++ b/server/main.lua
@@ -114,10 +114,9 @@ end
 
 exports('GetVehiclesByHash', GetVehiclesByHash)
 
----@param vehicles table<string, Vehicle>
----@return table<string, table<number, Vehicle>>
-function GetVehiclesByCategory(vehicles)
-	return MapTableBySubfield('category', vehicles)
+---@return table<string, Vehicle[]>
+function GetVehiclesByCategory()
+	return MapTableBySubfield('category', QBX.Shared.Vehicles)
 end
 
 exports('GetVehiclesByCategory', GetVehiclesByCategory)

--- a/server/main.lua
+++ b/server/main.lua
@@ -117,7 +117,7 @@ exports('GetVehiclesByHash', GetVehiclesByHash)
 ---@param vehicles table<string, Vehicle>
 ---@return table<string, table<number, Vehicle>>
 function GetVehiclesByCategory(vehicles)
-	MapTableBySubfield('category', vehicles)
+	return MapTableBySubfield('category', vehicles)
 end
 
 exports('GetVehiclesByCategory', GetVehiclesByCategory)

--- a/server/main.lua
+++ b/server/main.lua
@@ -114,6 +114,12 @@ end
 
 exports('GetVehiclesByHash', GetVehiclesByHash)
 
+---@param vehicles table<string, Vehicle>
+---@return table<string, table<number, Vehicle>>
+function GetVehiclesByCategory(vehicles)
+	MapTableBySubfield('category', vehicles)
+end
+
 exports('GetVehiclesByCategory', GetVehiclesByCategory)
 
 ---@return table<number, Weapon>

--- a/server/main.lua
+++ b/server/main.lua
@@ -114,16 +114,11 @@ end
 
 exports('GetVehiclesByHash', GetVehiclesByHash)
 
+exports('GetVehiclesByCategory', GetVehiclesByCategory)
+
 ---@return table<number, Weapon>
 function GetWeapons()
     return QBX.Shared.Weapons
 end
 
 exports('GetWeapons', GetWeapons)
-
----@return table<string, vector4>
-function GetLocations()
-    return QBX.Shared.Locations
-end
-
-exports('GetLocations', GetLocations)

--- a/server/main.lua
+++ b/server/main.lua
@@ -128,3 +128,10 @@ function GetWeapons()
 end
 
 exports('GetWeapons', GetWeapons)
+
+---@return table<string, vector4>
+function GetLocations()
+    return QBX.Shared.Locations
+end
+
+exports('GetLocations', GetLocations)


### PR DESCRIPTION
## Description
Adds an export that returns a mapped table of shared/vehicles.lua by category.
Answers #183 

### exports.qbx_core:GetVehiclesByCategory().cycles
will return all the biccyles, one example in this table:
```lua
 {
    "brand": "Bike",
    "category": "cycles",
    "hash": -400295096,
    "model": "tribike3",
    "name": "Tri Bike 3",
    "price": 520,
    "shop": "pdm"
}
```

## Checklist

<!-- Put an x inside the [ ] to check an item, like so: [x] -->

- [x] I have personally loaded this code into an updated Qbox project and checked all of its functionality.
- [x] My code fits the style guidelines.
- [x] My PR fits the contribution guidelines.
