### PR TITLE
fix: save health & armor properly

### DIFF
--- a/client/main.lua
+++ b/client/main.lua
@@ -55,3 +55,7 @@ exports('GetLocations', GetLocations)
 AddStateBagChangeHandler('isLoggedIn', ('player:%s'):format(cache.serverId), function(_, _, value)
     QBX.IsLoggedIn = value
 end)
+
+lib.callback.register('qbx_core:client:setHealth', function(health)
+    SetEntityHealth(cache.ped, health)
+end)

--- a/server/player.lua
+++ b/server/player.lua
@@ -32,7 +32,9 @@ function LoginV2(source, citizenid, newData)
             TriggerEvent('qb-log:server:CreateLog', 'anticheat', 'Anti-Cheat', 'white', ('%s Has Been Dropped For Character Joining Exploit'):format(GetPlayerName(source)), false)
         end
     else
-        return CheckPlayerData(source, newData)
+        local player = CheckPlayerData(source, newData)
+        player.Functions.Save()
+        return player
     end
 end
 
@@ -452,8 +454,9 @@ function CreatePlayer(playerData, Offline)
 
     if not self.Offline then
         QBX.Players[self.PlayerData.source] = self
-        Save(self.PlayerData.source)
-
+        local ped = GetPlayerPed(self.PlayerData.source)
+        lib.callback.await('qbx_core:client:setHealth', self.PlayerData.source, self.PlayerData.metadata.health)
+        SetPedArmour(ped, self.PlayerData.metadata.armor)
         -- At this point we are safe to emit new instance to third party resource for load handling
         GlobalState.PlayerCount += 1
         self.Functions.UpdatePlayerData()


### PR DESCRIPTION
Fixes #207 

When saving a player, the source of truth for health and armor is the ped itself. Loading an existing character was triggering a save, which overwrote health and armor in the database with default ped values (full health, no armor). This save now only occurs for new character creation as saving the same character data that was just loaded has no purpose.

Additionally, setting the ped health & armor when playerdata is loaded to avoid reliance on any other resources to persist this from the database to the ped. Unfortunately there is no server side native for setting health, so a callback was used.
