### PR TITLE
fix(bridge/qb/server/functions): spawn vehicle returns entityId

### DIFF
--- a/bridge/qb/server/functions.lua
+++ b/bridge/qb/server/functions.lua
@@ -37,13 +37,16 @@ functions.GetIdentifier = GetPlayerIdentifierByType
 ---@deprecated use the native GetPlayers instead
 functions.GetPlayers = GetPlayers
 
----@deprecated Use functions.CreateVehicle instead.
+---@deprecated use SpawnVehicle from imports/utils.lua
+---@return number?
 function functions.SpawnVehicle(source, model, coords, warp)
-    return SpawnVehicle(source, model, coords, warp)
+    local netId = SpawnVehicle(source, model, coords, warp)
+    if not netId then return end
+    return NetworkGetEntityFromNetworkId(netId)
 end
 
 ---@deprecated use SpawnVehicle from imports/utils.lua
-functions.CreateVehicle = SpawnVehicle
+functions.CreateVehicle = functions.SpawnVehicle
 
 ---@deprecated No replacement. See https://overextended.dev/ox_inventory/Functions/Client#useitem
 ---@param source Source


### PR DESCRIPTION
- Qbox changed the spawn vehicle function to return netId instead of entityId. The bridge now correctly returns entityId instead of netId for qb compatibility.