### PR TITLE
fix(server/character): spawning players in different buckets

### DIFF
--- a/server/character.lua
+++ b/server/character.lua
@@ -39,23 +39,6 @@ lib.callback.register('qbx_core:server:getPreviewPedData', function(_, citizenId
     return ped.skin, ped.model and joaat(ped.model)
 end)
 
-AddEventHandler('playerJoining', function()
-    SetPlayerRoutingBucket(source, source)
-end)
-
-AddEventHandler('onResourceStart', function(resourceName)
-    if resourceName ~= GetCurrentResourceName() then return end
-    Wait(100)
-    local players = GetPlayers()
-    for i = 1, #players do
-        local playerId = players[i]
-        local playerIdNum = tonumber(playerId)
-        if playerIdNum then
-            SetPlayerRoutingBucket(playerId, playerIdNum)
-        end
-    end
-end)
-
 lib.callback.register('qbx_core:server:loadCharacter', function(source, citizenId)
     local player = LoginV2(source, citizenId)
     if not player then return end


### PR DESCRIPTION
- Investigated reports of players spawning in and not being able to see each other (being in different buckets)
- Observed that SetPlayerRoutingBucket doesn't seem to be consistently working. Sometimes it sets the routing bucket and other times it doesn't. It seemed to only work when multiple players connected at the same time, but this might just be a coincidence. When this actually worked to set the bucket to the player source, the second call to SetPlayerRoutingBucket to 0 had no effect. Unsure why this is, but best guess is that there is something broken about SetPlayerRoutingBucket native.
- Removed code setting the player's bucket to source. This has the effect of player's being able to see each other when in the same character selection location. However, this is preferable to players spawning in different buckets.