### PR TITLE
fix(client/events): set player logged in statebag on client

### DIFF
--- a/client/events.lua
+++ b/client/events.lua
@@ -1,6 +1,7 @@
 -- Player load and unload handling
 RegisterNetEvent('QBCore:Client:OnPlayerLoaded', function()
     ShutdownLoadingScreenNui()
+    LocalPlayer.state:set('isLoggedIn', true, false)
     QBX.IsLoggedIn = true
     if not Config.Server.PVP then return end
     SetCanAttackFriendly(cache.ped, true, false)


### PR DESCRIPTION
Setting player logged in statebag on the client. This is what QB does. #228 is due to a race condition which checks the statebag before it's been replicated from the server to the client. While this race condition in theory still exists, this reduces the latency to the point that in practice it works. The ideal future solution is to set this before the onPlayerLoad event is triggered.