### PR TITLE
fix: vehicle prop bridge compat & vehicle spawn entity not existing

### DIFF
--- a/bridge/qb/client/functions.lua
+++ b/bridge/qb/client/functions.lua
@@ -175,7 +175,7 @@ function functions.GetVehicleProperties(vehicle)
     local tireBurstCompletely = {}
 
     for i = 0, 7 do
-        local damage = props.damage.tyres[i]
+        local damage = props.tyres[i]
         tireBurstState[i] = damage == 1 or damage == 2
         tireBurstCompletely[i] = damage == 2
     end
@@ -218,39 +218,39 @@ function functions.SetVehicleProperties(vehicle, props)
         SetVehicleHeadlightsColour(vehicle, props.headlightColor)
     end
 
-    local tyres = {}
-    for i = 0, 7 do
-        tyres[i] = props.tireBurstCompletely[i] and 2 or props.tireBurstState[i] and 1 or nil
-    end
-
-    local windows = {}
-    local numWindowsDamaged = 0
-    for i, isDamaged in pairs(props.windowStatus) do
-        if isDamaged then
-            numWindowsDamaged += 1
-            windows[numWindowsDamaged] = i
+    if not props.tyres then
+        for i = 0, 7 do
+            props.tyres[i] = props.tireBurstCompletely and props.tireBurstCompletely[i] and 2 or props.tireBurstState and props.tireBurstState[i] and 1 or nil
         end
     end
 
-    local doors = {}
+    local numWindowsDamaged = 0
+    if props.windowStatus and not props.windows then
+        for i, isDamaged in pairs(props.windowStatus) do
+            if isDamaged then
+                numWindowsDamaged += 1
+                props.windows[numWindowsDamaged] = i
+            end
+        end
+    end
+
     local numDoorsDamaged = 0
-    for i, isDamaged in pairs(props.doorStatus) do
-        if isDamaged then
-            numDoorsDamaged += 1
-            doors[numDoorsDamaged] = i
+    if props.doorStatus and not props.doors then
+        for i, isDamaged in pairs(props.doorStatus) do
+            if isDamaged then
+                numDoorsDamaged += 1
+                props.doors[numDoorsDamaged] = i
+            end
         end
     end
 
     -- qb properties converted to ox
     props.modNitrous = props.modNitrous or props.modKit17
     props.modSubwoofer = props.modSubwoofer or props.modKit17
-    props.modHydraulics = props.modHydraulics or props.props.modKit21
+    props.modHydraulics = props.modHydraulics or props.modKit21
     props.modDoorR = props.modDoorR or props.modKit47
     props.modLightbar = props.modLightbar or props.modKit49
     props.modRoofLivery = props.modRoofLivery or props.liveryRoof
-    props.tyres = props.tyres or #tyres > 0 and tyres or nil
-    props.windows = props.windows or numWindowsDamaged > 0 and windows or nil
-    props.doors = props.doors or numDoorsDamaged > 0 and doors or nil
 
     return lib.setVehicleProperties(vehicle, props)
 end

--- a/client/events.lua
+++ b/client/events.lua
@@ -126,23 +126,21 @@ end)
 
 -- Vehicle Commands
 
-EntityStateHandler('initVehicle', function(entity, _, value)
-    if not value then return end
+RegisterNetEvent('qbx_core:client:vehicleSpawned', function(netId)
+    local veh = NetworkGetEntityFromNetworkId(netId)
 
     for i = -1, 0 do
-        local ped = GetPedInVehicleSeat(entity, i)
+        local ped = GetPedInVehicleSeat(veh, i)
 
         if ped ~= cache.ped and ped > 0 and NetworkGetEntityOwner(ped) == cache.playerId then
             DeleteEntity(ped)
         end
     end
 
-    if NetworkGetEntityOwner(entity) ~= cache.playerId then return end
-    SetVehicleNeedsToBeHotwired(entity, false)
-    SetVehRadioStation(entity, 'OFF')
-    SetVehicleFuelLevel(entity, 100.0)
-    SetVehicleDirtLevel(entity, 0.0)
-    Entity(entity).state:set('initVehicle', nil, true)
+    SetVehicleNeedsToBeHotwired(veh, false)
+    SetVehRadioStation(veh, 'OFF')
+    SetVehicleFuelLevel(veh, 100.0)
+    SetVehicleDirtLevel(veh, 0.0)
 end)
 
 RegisterNetEvent('QBCore:Command:DeleteVehicle', function()

--- a/modules/utils.lua
+++ b/modules/utils.lua
@@ -215,11 +215,15 @@ if isServer then
         end
 
         if warp then SetPedIntoVehicle(ped, veh, -1) end
-        lib.waitFor(function()
-            if NetworkGetEntityOwner(veh) ~= -1 then return true end
+        
+        local owner = lib.waitFor(function()
+            local owner = NetworkGetEntityOwner(veh)
+            if owner ~= -1 then return owner end
         end, 5000)
-        Entity(veh).state:set('initVehicle', true, true)
-        return NetworkGetNetworkIdFromEntity(veh)
+        
+        local netId = NetworkGetNetworkIdFromEntity(veh)
+        TriggerClientEvent('qbx_core:client:vehicleSpawned', owner, netId)
+        return netId
     end
 
     --Kick Player


### PR DESCRIPTION
- switched from using a statebag event handler to using a normal event. This seems to fix the rare entity not exist issue when spawning a vehicle
- tested and fixed some bugs regarding vehicle property bridge compatibility to set/get vehicle properties using bridge