### PR TITLE
feat: set vehicle properties on vehicle spawn & removed other default properties

### DIFF
--- a/client/events.lua
+++ b/client/events.lua
@@ -136,7 +136,9 @@ RegisterNetEvent('qbx_core:client:vehicleSpawned', function(netId, props)
         end
     end
 
-    lib.setVehicleProperties(veh, props)
+    if props then
+        lib.setVehicleProperties(veh, props)
+    end
 end)
 
 RegisterNetEvent('QBCore:Command:DeleteVehicle', function()

--- a/client/events.lua
+++ b/client/events.lua
@@ -126,21 +126,17 @@ end)
 
 -- Vehicle Commands
 
-RegisterNetEvent('qbx_core:client:vehicleSpawned', function(netId)
+RegisterNetEvent('qbx_core:client:vehicleSpawned', function(netId, props)
     local veh = NetworkGetEntityFromNetworkId(netId)
 
     for i = -1, 0 do
         local ped = GetPedInVehicleSeat(veh, i)
-
         if ped ~= cache.ped and ped > 0 and NetworkGetEntityOwner(ped) == cache.playerId then
             DeleteEntity(ped)
         end
     end
 
-    SetVehicleNeedsToBeHotwired(veh, false)
-    SetVehRadioStation(veh, 'OFF')
-    SetVehicleFuelLevel(veh, 100.0)
-    SetVehicleDirtLevel(veh, 0.0)
+    lib.setVehicleProperties(veh, props)
 end)
 
 RegisterNetEvent('QBCore:Command:DeleteVehicle', function()

--- a/modules/utils.lua
+++ b/modules/utils.lua
@@ -183,8 +183,9 @@ if isServer then
     ---@param model string | integer
     ---@param coords? vector4 defaults to player's position
     ---@param warp? boolean
+    ---@param props table vehicle properties to set https://github.com/overextended/ox_lib/blob/master/resource/vehicleProperties/client.lua#L3
     ---@return integer? netId
-    function SpawnVehicle(source, model, coords, warp) -- luacheck: ignore
+    function SpawnVehicle(source, model, coords, warp, props) -- luacheck: ignore
         model = type(model) == 'string' and joaat(model) or model
 
         if not CreateVehicleServerSetter then
@@ -222,7 +223,7 @@ if isServer then
         end, 5000)
         
         local netId = NetworkGetNetworkIdFromEntity(veh)
-        TriggerClientEvent('qbx_core:client:vehicleSpawned', owner, netId)
+        TriggerClientEvent('qbx_core:client:vehicleSpawned', owner, netId, props)
         return netId
     end
 


### PR DESCRIPTION
- Add props to SpawnVehicle function to pass this through to the entity owner. Only the entity owner can set vehicle properties so it makes sense to do this on spawn
- Remove previous default values (fuel, dirt, radio, hotwire status). We'll add them back as needed/desired.