### PR TITLE
fix: bridge SpawnVehicle uses CreateVehicle

### DIFF
--- a/bridge/qb/server/functions.lua
+++ b/bridge/qb/server/functions.lua
@@ -48,15 +48,27 @@ end
 ---@deprecated use SpawnVehicle from imports/utils.lua
 ---@return number?
 function functions.SpawnVehicle(source, model, coords, warp)
-    local netId = SpawnVehicle(source, model, coords, warp)
-    if not netId then return end
-    local veh = NetworkGetEntityFromNetworkId(netId)
+    local ped = GetPlayerPed(source)
+    model = type(model) == 'string' and joaat(model) or model
+    if not coords then coords = GetEntityCoords(ped) end
+    local heading = coords.w and coords.w or 0.0
+    local veh = CreateVehicle(model, coords.x, coords.y, coords.z, heading, true, true)
+    while not DoesEntityExist(veh) do Wait(0) end
+    if warp then
+        while GetVehiclePedIsIn(ped) ~= veh do
+            Wait(0)
+            TaskWarpPedIntoVehicle(ped, veh, -1)
+        end
+    end
     while NetworkGetEntityOwner(veh) ~= source do Wait(0) end
     return veh
 end
 
 ---@deprecated use SpawnVehicle from imports/utils.lua
-functions.CreateVehicle = functions.SpawnVehicle
+function QBCore.Functions.CreateVehicle(source, model, _, coords, warp)
+    local netId = SpawnVehicle(source, model, coords, warp)
+    return NetworkGetEntityFromNetworkId(netId)
+end
 
 ---@deprecated No replacement. See https://overextended.dev/ox_inventory/Functions/Client#useitem
 ---@param source Source

--- a/bridge/qb/server/functions.lua
+++ b/bridge/qb/server/functions.lua
@@ -65,7 +65,7 @@ function functions.SpawnVehicle(source, model, coords, warp)
 end
 
 ---@deprecated use SpawnVehicle from imports/utils.lua
-function QBCore.Functions.CreateVehicle(source, model, _, coords, warp)
+function functions.CreateVehicle(source, model, _, coords, warp)
     local netId = SpawnVehicle(source, model, coords, warp)
     return NetworkGetEntityFromNetworkId(netId)
 end

--- a/modules/utils.lua
+++ b/modules/utils.lua
@@ -183,7 +183,7 @@ if isServer then
     ---@param model string | integer
     ---@param coords? vector4 defaults to player's position
     ---@param warp? boolean
-    ---@param props table vehicle properties to set https://github.com/overextended/ox_lib/blob/master/resource/vehicleProperties/client.lua#L3
+    ---@param props? table vehicle properties to set https://github.com/overextended/ox_lib/blob/master/resource/vehicleProperties/client.lua#L3
     ---@return integer? netId
     function SpawnVehicle(source, model, coords, warp, props) -- luacheck: ignore
         model = type(model) == 'string' and joaat(model) or model


### PR DESCRIPTION
- needed to avoid incompatibilities with server side vehicle spawning and QB
- changed inputs and return of CreateVehicle to match QB
- made props an optional field when spawning vehicle in utils (forgot to do so last PR)