### PR TITLE
feat: toggle bridge on/off via convar

### DIFF
--- a/bridge/qb/client/drawtext.lua
+++ b/bridge/qb/client/drawtext.lua
@@ -59,13 +59,13 @@ RegisterNetEvent('qb-core:client:KeyPressed', function()
     keyPressed()
 end)
 
-require 'bridge.qb.client.main'
+local createQbExport = require 'bridge.qb.shared.export-function'
 
 ---@deprecated use ox_lib showTextUI calls directly
-CreateQbExport('DrawText', drawText)
+createQbExport('DrawText', drawText)
 ---@deprecated use ox_lib showTextUI calls directly
-CreateQbExport('ChangeText', changeText)
+createQbExport('ChangeText', changeText)
 ---@deprecated use ox_lib showTextUI calls directly
-CreateQbExport('HideText', hideText)
+createQbExport('HideText', hideText)
 ---@deprecated use ox_lib showTextUI calls directly
-CreateQbExport('KeyPressed', keyPressed)
+createQbExport('KeyPressed', keyPressed)

--- a/bridge/qb/client/main.lua
+++ b/bridge/qb/client/main.lua
@@ -1,3 +1,8 @@
+if GetConvar('qbx:enablebridge', 'true') == 'false' then return end
+
+require 'bridge.qb.client.drawtext'
+require 'bridge.qb.client.events'
+
 local qbCoreCompat = {}
 qbCoreCompat.PlayerData = QBX.PlayerData
 qbCoreCompat.Config = lib.table.merge(require 'config.client', require 'config.shared')
@@ -56,12 +61,8 @@ function qbCoreCompat.Debug(_, obj)
     lib.print.debug(obj)
 end
 
-function CreateQbExport(name, cb)
-    AddEventHandler(string.format('__cfx_export_qb-core_%s', name), function(setCB)
-        setCB(cb)
-    end)
-end
+local createQbExport = require 'bridge.qb.shared.export-function'
 
-CreateQbExport('GetCoreObject', function()
+createQbExport('GetCoreObject', function()
     return qbCoreCompat
 end)

--- a/bridge/qb/server/functions.lua
+++ b/bridge/qb/server/functions.lua
@@ -1,7 +1,9 @@
 require 'server.functions'
 local functions = {}
 
-function CreateQbExport(name, cb)
+local createQbExport = require 'bridge.qb.shared.export-function'
+
+function createQbExport(name, cb)
     AddEventHandler(string.format('__cfx_export_qb-core_%s', name), function(setCB)
         setCB(cb)
     end)
@@ -112,7 +114,7 @@ local function AddItem(itemName, item)
 end
 
 functions.AddItem = AddItem
-CreateQbExport('AddItem', AddItem)
+createQbExport('AddItem', AddItem)
 
 -- Single update item
 ---@deprecated incompatible with ox_inventory. Update ox_inventory item config instead.
@@ -131,7 +133,7 @@ local function UpdateItem(itemName, item)
 end
 
 functions.UpdateItem = UpdateItem
-CreateQbExport('UpdateItem', UpdateItem)
+createQbExport('UpdateItem', UpdateItem)
 
 -- Multiple Add Items
 ---@deprecated incompatible with ox_inventory. Update ox_inventory item config instead.
@@ -166,7 +168,7 @@ local function AddItems(items)
 end
 
 functions.AddItems = AddItems
-CreateQbExport('AddItems', AddItems)
+createQbExport('AddItems', AddItems)
 
 -- Single Remove Item
 ---@deprecated incompatible with ox_inventory. Update ox_inventory item config instead.
@@ -188,7 +190,7 @@ local function RemoveItem(itemName)
 end
 
 functions.RemoveItem = RemoveItem
-CreateQbExport('RemoveItem', RemoveItem)
+createQbExport('RemoveItem', RemoveItem)
 
 -- Single add job function which should only be used if you planning on adding a single job
 ---@deprecated use export CreateJobs
@@ -213,7 +215,7 @@ local function AddJob(jobName, job)
 end
 
 functions.AddJob = AddJob
-CreateQbExport('AddJob', AddJob)
+createQbExport('AddJob', AddJob)
 
 -- Multiple Add Jobs
 ---@deprecated call export CreateJobs
@@ -241,7 +243,7 @@ local function AddJobs(jobs)
 end
 
 functions.AddJobs = AddJobs
-CreateQbExport('AddJobs', AddJobs)
+createQbExport('AddJobs', AddJobs)
 
 -- Single Update Job
 ---@deprecated call CreateJobs
@@ -266,7 +268,7 @@ local function UpdateJob(jobName, job)
 end
 
 functions.UpdateJob = UpdateJob
-CreateQbExport('UpdateJob', UpdateJob)
+createQbExport('UpdateJob', UpdateJob)
 
 -- Single Add Gang
 ---@deprecated call export CreateGangs
@@ -291,7 +293,7 @@ local function AddGang(gangName, gang)
 end
 
 functions.AddGang = AddGang
-CreateQbExport('AddGang', AddGang)
+createQbExport('AddGang', AddGang)
 
 -- Single Update Gang
 ---@deprecated call export CreateGangs
@@ -316,7 +318,7 @@ local function UpdateGang(gangName, gang)
 end
 
 functions.UpdateGang = UpdateGang
-CreateQbExport('UpdateGang', UpdateGang)
+createQbExport('UpdateGang', UpdateGang)
 
 -- Multiple Add Gangs
 ---@deprecated call export CreateGangs
@@ -343,13 +345,13 @@ local function AddGangs(gangs)
 end
 
 functions.AddGangs = AddGangs
-CreateQbExport('AddGangs', AddGangs)
+createQbExport('AddGangs', AddGangs)
 
 functions.RemoveJob = RemoveJob
-CreateQbExport('RemoveJob', RemoveJob)
+createQbExport('RemoveJob', RemoveJob)
 
 functions.RemoveGang = RemoveGang
-CreateQbExport('RemoveGang', RemoveGang)
+createQbExport('RemoveGang', RemoveGang)
 
 ---Add a new function to the Functions table of the player class
 ---Use-case:
@@ -432,7 +434,7 @@ local function SetMethod(methodName, handler)
 end
 
 functions.SetMethod = SetMethod
-CreateQbExport("SetMethod", SetMethod)
+createQbExport("SetMethod", SetMethod)
 
 -- Add or change (a) field(s) in the QBCore table
 ---@deprecated

--- a/bridge/qb/server/functions.lua
+++ b/bridge/qb/server/functions.lua
@@ -3,12 +3,6 @@ local functions = {}
 
 local createQbExport = require 'bridge.qb.shared.export-function'
 
-function createQbExport(name, cb)
-    AddEventHandler(string.format('__cfx_export_qb-core_%s', name), function(setCB)
-        setCB(cb)
-    end)
-end
-
 function AddDeprecatedFunctions(player)
     if not player then return end
 

--- a/bridge/qb/server/main.lua
+++ b/bridge/qb/server/main.lua
@@ -1,3 +1,8 @@
+if GetConvar('qbx:enablebridge', 'true') == 'false' then return end
+
+require 'bridge.qb.server.debug'
+require 'bridge.qb.server.events'
+
 local qbCoreCompat = {}
 
 qbCoreCompat.Config = lib.table.merge(require 'config.server', require 'config.shared')
@@ -93,6 +98,8 @@ qbCoreCompat.Functions.CreateCallback('QBCore:Server:CreateVehicle', function(so
     if netId then cb(netId) end
 end)
 
-CreateQbExport('GetCoreObject', function()
+local createQbExport = require 'bridge.qb.shared.export-function'
+
+createQbExport('GetCoreObject', function()
     return qbCoreCompat
 end)

--- a/bridge/qb/shared/export-function.lua
+++ b/bridge/qb/shared/export-function.lua
@@ -1,0 +1,5 @@
+return function (name, cb)
+    AddEventHandler(string.format('__cfx_export_qb-core_%s', name), function(setCB)
+        setCB(cb)
+    end)
+end

--- a/fxmanifest.lua
+++ b/fxmanifest.lua
@@ -20,8 +20,7 @@ client_scripts {
     'client/events.lua',
     'client/character.lua',
     'client/discord.lua',
-    'bridge/qb/client/drawtext.lua',
-    'bridge/qb/client/events.lua',
+    'bridge/qb/client/main.lua',
 }
 
 server_scripts {
@@ -34,10 +33,7 @@ server_scripts {
     'server/loops.lua',
     'server/storage.lua',
     'server/character.lua',
-    'bridge/qb/server/commands.lua',
-    'bridge/qb/server/debug.lua',
     'bridge/qb/server/main.lua',
-    'bridge/qb/server/events.lua',
 }
 
 modules {
@@ -53,12 +49,16 @@ files {
     'shared/main.lua',
     'shared/vehicles.lua',
     'shared/weapons.lua',
-    'bridge/qb/client/main.lua',
     'bridge/qb/client/functions.lua',
+    'bridge/qb/client/drawtext.lua',
+    'bridge/qb/client/events.lua',
     'bridge/qb/shared/main.lua',
+    'bridge/qb/shared/export-function.lua',
     'bridge/qb/server/functions.lua',
-    'bridge/qb/server/main.lua',
     'bridge/qb/server/player.lua',
+    'bridge/qb/server/commands.lua',
+    'bridge/qb/server/debug.lua',
+    'bridge/qb/server/events.lua',
     'config/client.lua',
     'config/shared.lua'
 }


### PR DESCRIPTION
Can put` setr "qbx:enablebridge"` false into server.cfg to disable the bridge entirely. Useful if you aren't using the bridge to avoid extra overhead.

To accomplish this, modularized all the bridge files, so that the only loaded file via fxmanfiest is main.lua on client and server

