### PR TITLE
feat(manifest): remove client readability

### DIFF
--- a/fxmanifest.lua
+++ b/fxmanifest.lua
@@ -54,11 +54,6 @@ files {
     'bridge/qb/client/events.lua',
     'bridge/qb/shared/main.lua',
     'bridge/qb/shared/export-function.lua',
-    'bridge/qb/server/functions.lua',
-    'bridge/qb/server/player.lua',
-    'bridge/qb/server/commands.lua',
-    'bridge/qb/server/debug.lua',
-    'bridge/qb/server/events.lua',
     'config/client.lua',
     'config/shared.lua'
 }


### PR DESCRIPTION
## Description

Files inside of the manifest means that clients can read these files through dumping files etc.

WE DO NOT WANT THAT, the reason it was most likely put here was when we swapped to modular loading, but server files do not need to be loaded this way.

## Checklist

- [ ] I have personally loaded this code into an updated Qbox project and checked all of its functionality.
- [x] My code fits the style guidelines.
- [x] My PR fits the contribution guidelines.
