### PR TITLE
fix(statebags): wait for entity ID to exsist in network

### DIFF
--- a/modules/utils.lua
+++ b/modules/utils.lua
@@ -375,7 +375,7 @@ else
             if netIdExsist then return netIdExsist end
         end, ('statebag timed out while awaiting entity creation! (%s)'):format(bagName), 10000)
 
-        local entity = idExsist and NetworkGetEntityFromNetworkId(netId) or 0
+        local entity = idExist and NetworkGetEntityFromNetworkId(netId) or 0
 
         if entity == 0 then
             lib.print.error(('statebag received invalid entity! (%s)'):format(bagName))

--- a/modules/utils.lua
+++ b/modules/utils.lua
@@ -369,10 +369,10 @@ else
     function GetEntityAndNetIdFromBagName(bagName) -- luacheck: ignore
         local netId = tonumber(bagName:gsub('entity:', ''), 10)
 
-        local idExsist = lib.waitFor(function()
+        local idExist = lib.waitFor(function()
             local netIdExist = NetworkDoesEntityExistWithNetworkId(netId)
 
-            if netIdExsist then return netIdExsist end
+            if netIdExist then return netIdExist end
         end, ('statebag timed out while awaiting entity creation! (%s)'):format(bagName), 10000)
 
         local entity = idExist and NetworkGetEntityFromNetworkId(netId) or 0

--- a/modules/utils.lua
+++ b/modules/utils.lua
@@ -370,7 +370,7 @@ else
         local netId = tonumber(bagName:gsub('entity:', ''), 10)
 
         local idExsist = lib.waitFor(function()
-            local netIdExsist = NetworkDoesEntityExistWithNetworkId(netId)
+            local netIdExist = NetworkDoesEntityExistWithNetworkId(netId)
 
             if netIdExsist then return netIdExsist end
         end, ('statebag timed out while awaiting entity creation! (%s)'):format(bagName), 10000)

--- a/modules/utils.lua
+++ b/modules/utils.lua
@@ -369,11 +369,13 @@ else
     function GetEntityAndNetIdFromBagName(bagName) -- luacheck: ignore
         local netId = tonumber(bagName:gsub('entity:', ''), 10)
 
-        lib.waitFor(function()
-            return NetworkDoesEntityExistWithNetworkId(netId)
+        local idExsist = lib.waitFor(function()
+            local netIdExsist = NetworkDoesEntityExistWithNetworkId(netId)
+
+            if netIdExsist then return netIdExsist end
         end, ('statebag timed out while awaiting entity creation! (%s)'):format(bagName), 10000)
 
-        local entity = NetworkDoesEntityExistWithNetworkId(netId) and NetworkGetEntityFromNetworkId(netId) or 0
+        local entity = idExsist and NetworkGetEntityFromNetworkId(netId) or 0
 
         if entity == 0 then
             lib.print.error(('statebag received invalid entity! (%s)'):format(bagName))


### PR DESCRIPTION
Beforehand it was returning lib.waitFor without even checking if the networkId exsist (which was the entire reason for lib.waitFor). Due to this we had multiple errors when statebags was still used, meaning theoritically we could swap back.

## Checklist

- [ ] I have personally loaded this code into an updated Qbox project and checked all of its functionality.
- [x] My code fits the style guidelines.
- [x] My PR fits the contribution guidelines.
