### PR TITLE
fix: new character spawning

### DIFF
--- a/client/character.lua
+++ b/client/character.lua
@@ -166,7 +166,12 @@ local function spawnDefault() -- We use a callback to make the server wait on th
 
     destroyPreviewCam()
 
-    pcall(function() exports.spawnmanager:spawnPlayer() end)
+    pcall(function() exports.spawnmanager:spawnPlayer({
+        x = defaultSpawn.x,
+        y = defaultSpawn.y,
+        z = defaultSpawn.z,
+        heading = defaultSpawn.w
+    }) end)
 
     TriggerServerEvent('QBCore:Server:OnPlayerLoaded')
     TriggerEvent('QBCore:Client:OnPlayerLoaded')

--- a/config/client.lua
+++ b/config/client.lua
@@ -7,7 +7,7 @@ return {
     characters = {
         useExternalCharacters = false, -- Whether you have an external character management resource. (If true, disables the character management inside the core)
         enableDeleteButton = true, -- Whether players should be able to delete characters themselves.
-        startingApartment = false, -- If set to false, skips apartment choice in the beginning (requires qbx_spawn if true)
+        startingApartment = true, -- If set to false, skips apartment choice in the beginning (requires qbx_spawn if true)
 
         profanityWords = {
             ['bad word'] = true


### PR DESCRIPTION
## Description

Fix new character spawning when not using qbx_spawn and renable starting apartments after it was mistakenly disabled.

## Checklist

- [x] I have personally loaded this code into an updated Qbox project and checked all of its functionality.
- [x] My code fits the style guidelines.
- [x] My PR fits the contribution guidelines.
