### PR TITLE
fix(character): typo

### DIFF
--- a/client/character.lua
+++ b/client/character.lua
@@ -322,7 +322,7 @@ local function chooseCharacter()
                         onSelect = function()
                             DoScreenFadeOut(10)
                             lib.callback.await('qbx_core:server:loadCharacter', false, character.citizenid)
-                            if GetResourceState('qbx-apartments'):find('start') then
+                            if GetResourceState('qbx_apartments'):find('start') then
                                 TriggerEvent('apartments:client:setupSpawnUI', { citizenid = character.citizenid })
                             elseif GetResourceState('qbx_spawn'):find('start') then
                                 TriggerEvent('qb-spawn:client:setupSpawns', { citizenid = character.citizenid })


### PR DESCRIPTION
## Description
Fixes a typo in "qbx-apartments" it should be "qbx_apartments" ;)

## Checklist

- [x] I have personally loaded this code into an updated Qbox project and checked all of its functionality.
- [x] My code fits the style guidelines.
- [x] My PR fits the contribution guidelines.
