### PR TITLE
fix: typo for haskeys export

### DIFF
--- a/config/client.lua
+++ b/config/client.lua
@@ -68,6 +68,6 @@ return {
 
     --- Only used by QB bridge
     hasKeys = function()
-        return exports['qb-vehiclekeys']:HasKeys()
+        return exports['qbx_vehiclekeys']:HasKeys()
     end,
 }

--- a/config/client.lua
+++ b/config/client.lua
@@ -68,6 +68,6 @@ return {
 
     --- Only used by QB bridge
     hasKeys = function()
-        return exports['qbx_vehiclekeys']:HasKeys()
+        return exports.qbx_vehiclekeys:HasKeys()
     end,
 }


### PR DESCRIPTION
## Description

On a fresh install, you get "No such export HasKeys in resource qb-vehiclekeys" whenever you sit in the vehicle. I guess this was a typo in the last commit, so this fixes that problem.

## Checklist

<!-- Put an x inside the [ ] to check an item, like so: [x] -->

- [x] I have personally loaded this code into an updated Qbox project and checked all of its functionality.
- [x] My code fits the style guidelines.
- [x] My PR fits the contribution guidelines.
