### PR TITLE
fix: missing bankAuth for society banking

### DIFF
--- a/shared/gangs.lua
+++ b/shared/gangs.lua
@@ -1,6 +1,6 @@
 ---@class Gang
 ---@field label string
----@field grades table<integer, {name: string, isboss: boolean}>
+---@field grades table<integer, {name: string, isboss: boolean, bankAuth: boolean}>
 
 ---@type table<string, Gang>
 return {

--- a/shared/gangs.lua
+++ b/shared/gangs.lua
@@ -26,7 +26,8 @@ return {
             },
 			[3] = {
                 name = 'Boss',
-				isboss = true
+                isboss = true,
+                bankAuth = true
             },
         },
 	},
@@ -44,7 +45,8 @@ return {
             },
 			[3] = {
                 name = 'Boss',
-				isboss = true
+                isboss = true,
+                bankAuth = true
             },
         },
 	},
@@ -62,7 +64,8 @@ return {
             },
 			[3] = {
                 name = 'Boss',
-				isboss = true
+                isboss = true,
+                bankAuth = true
             },
         },
 	},
@@ -80,7 +83,8 @@ return {
             },
 			[3] = {
                 name = 'Boss',
-				isboss = true
+                isboss = true,
+                bankAuth = true
             },
         },
 	},
@@ -98,7 +102,8 @@ return {
             },
 			[3] = {
                 name = 'Boss',
-				isboss = true
+                isboss = true,
+                bankAuth = true
             },
         },
 	},
@@ -116,7 +121,8 @@ return {
             },
 			[3] = {
                 name = 'Boss',
-				isboss = true
+                isboss = true,
+                bankAuth = true
             },
         },
 	}

--- a/shared/jobs.lua
+++ b/shared/jobs.lua
@@ -42,7 +42,8 @@ return {
             },
 			[4] = {
                 name = 'Chief',
-				isboss = true,
+                isboss = true,
+                bankAuth = true,
                 payment = 150
             },
         },
@@ -71,7 +72,8 @@ return {
             },
 			[4] = {
                 name = 'Chief',
-				isboss = true,
+                isboss = true,
+                bankAuth = true,
                 payment = 150
             },
         },
@@ -100,7 +102,8 @@ return {
             },
 			[4] = {
                 name = 'Chief',
-				isboss = true,
+                isboss = true,
+                bankAuth = true,
                 payment = 150
             },
         },
@@ -129,7 +132,8 @@ return {
             },
 			[4] = {
                 name = 'Chief',
-				isboss = true,
+                isboss = true,
+                bankAuth = true,
                 payment = 150
             },
         },
@@ -157,7 +161,8 @@ return {
             },
 			[4] = {
                 name = 'Manager',
-				isboss = true,
+                isboss = true,
+                bankAuth = true,
                 payment = 150
             },
         },
@@ -185,7 +190,8 @@ return {
             },
 			[4] = {
                 name = 'Manager',
-				isboss = true,
+                isboss = true,
+                bankAuth = true,
                 payment = 150
             },
         },
@@ -224,7 +230,8 @@ return {
             },
 			[4] = {
                 name = 'Manager',
-				isboss = true,
+                isboss = true,
+                bankAuth = true,
                 payment = 150
             },
         },
@@ -253,7 +260,8 @@ return {
             },
 			[4] = {
                 name = 'Manager',
-				isboss = true,
+                isboss = true,
+                bankAuth = true,
                 payment = 150
             },
         },

--- a/shared/jobs.lua
+++ b/shared/jobs.lua
@@ -3,7 +3,7 @@
 ---@field type? string
 ---@field defaultDuty boolean
 ---@field offDutyPay boolean
----@field grades table<integer, {name: string, payment: number, isboss: boolean}>
+---@field grades table<integer, {name: string, payment: number, isboss: boolean, bankAuth: boolean}>
 
 ---@type table<string, Job>
 return {


### PR DESCRIPTION
## Description

Fixes not being able to see society funds for jobs or gangs when using Renewed-Banking

## Checklist

- [x] I have personally loaded this code into an updated Qbox project and checked all of its functionality.
- [x] My code fits the style guidelines.
- [x] My PR fits the contribution guidelines.
