### PR TITLE
feat: add logging avatar

### DIFF
--- a/modules/logger.lua
+++ b/modules/logger.lua
@@ -47,7 +47,7 @@ local allowedErr = {
 local function logPayload(payload)
     local tags
     local username = 'QBX Logs',
-    local avatarUrl = '',
+    local avatarUrl = 'https://qbox-project.github.io/qbox-duck.png',
     
     if payload.tags then
         for i = 1, #payload.tags do

--- a/modules/logger.lua
+++ b/modules/logger.lua
@@ -46,8 +46,8 @@ local allowedErr = {
 ---@param payload Log Queue
 local function logPayload(payload)
     local tags
-    local username = 'QBX Logs',
-    local avatarUrl = 'https://qbox-project.github.io/qbox-duck.png',
+    local username = 'QBX Logs'
+    local avatarUrl = 'https://qbox-project.github.io/qbox-duck.png'
     
     if payload.tags then
         for i = 1, #payload.tags do

--- a/modules/logger.lua
+++ b/modules/logger.lua
@@ -46,7 +46,9 @@ local allowedErr = {
 ---@param payload Log Queue
 local function logPayload(payload)
     local tags
-
+    local username = 'QBX Logs',
+    local avatarUrl = '',
+    
     if payload.tags then
         for i = 1, #payload.tags do
             if not tags then tags = '' end
@@ -71,7 +73,7 @@ local function logPayload(payload)
                 requestDelay = resetDelay * 1000 / 10
             end
         end
-    end, 'POST', json.encode({content = tags, embeds = payload.embed}), { ['Content-Type'] = 'application/json' })
+    end, 'POST', json.encode({username = username, avatar_url = avatarUrl, content = tags, embeds = payload.embed}), { ['Content-Type'] = 'application/json' })
 end
 
 ---Log Queue
@@ -115,7 +117,7 @@ local function discordLog(log)
             },
             description = log.message,
             author = {
-                name = 'QBX Logs',
+                name = log.source,
             },
         }
     }


### PR DESCRIPTION
## Description

Discord webhooks support changing the hook username and avatar_url. This adds the variables to change the name of the webhook . This replaces the Captain Hook and default avatar with the configured variables. 

![image](https://github.com/Qbox-project/qbx_core/assets/769465/c1820502-408d-4bec-81fa-878238b3d592)


## Checklist

<!-- Put an x inside the [ ] to check an item, like so: [x] -->

- [x] I have personally loaded this code into an updated Qbox project and checked all of its functionality.
- [x] My code fits the style guidelines.
- [x] My PR fits the contribution guidelines.
