### PR TITLE
fix: spawn vehicles in player routing bucket

### DIFF
--- a/fxmanifest.lua
+++ b/fxmanifest.lua
@@ -56,6 +56,7 @@ files {
 }
 
 dependencies {
+    '/server:7186',
     'ox_lib',
     'oxmysql',
 }

--- a/fxmanifest.lua
+++ b/fxmanifest.lua
@@ -57,6 +57,7 @@ files {
 
 dependencies {
     '/server:7186',
+    '/onesync',
     'ox_lib',
     'oxmysql',
 }

--- a/modules/utils.lua
+++ b/modules/utils.lua
@@ -200,6 +200,8 @@ if isServer then
         local vehicleType = GetVehicleType(tempVehicle)
         DeleteEntity(tempVehicle)
 
+        local bucket = GetPlayerRoutingBucket(source)
+
         local ped = GetPlayerPed(source)
         if not coords then
             coords = GetCoordsFromEntity(ped)
@@ -214,6 +216,8 @@ if isServer then
         while GetVehicleNumberPlateText(veh) == "" do
             Wait(0)
         end
+
+        SetEntityRoutingBucket(veh, bucket)
 
         if warp then SetPedIntoVehicle(ped, veh, -1) end
 


### PR DESCRIPTION
## Description

Spawns the vehicle in the routing bucket the player is in instead of 0

## Checklist

- [ ] I have personally loaded this code into an updated Qbox project and checked all of its functionality.
- [ ] My code fits the style guidelines.
- [ ] My PR fits the contribution guidelines.
