### PR TITLE
fix(server/events): fix license sometimes being used instead of license2

### DIFF
--- a/server/events.lua
+++ b/server/events.lua
@@ -59,8 +59,7 @@ end)
 ---@param deferrals Deferrals
 local function onPlayerConnecting(name, _, deferrals)
     local src = source --[[@as string]]
-    local license
-    local identifiers = GetPlayerIdentifiers(src)
+    local license = GetPlayerIdentifierByType(src, 'license2') or GetPlayerIdentifierByType(src, 'license')
     deferrals.defer()
 
     -- Mandatory wait
@@ -69,13 +68,6 @@ local function onPlayerConnecting(name, _, deferrals)
     if serverConfig.closed then
         if not IsPlayerAceAllowed(src, 'qbadmin.join') then
             deferrals.done(serverConfig.closedReason)
-        end
-    end
-
-    for _, v in pairs(identifiers) do
-        if string.find(v, 'license2') or string.find(v, 'license') then
-            license = v
-            break
         end
     end
 


### PR DESCRIPTION
## Description

In the `playerConnecting` event, use `GetPlayerIdentifierByType` instead of looping over `GetPlayerIdentifiers` to guarantee using `license2` over `license` when available.

## Checklist

<!-- Put an x inside the [ ] to check an item, like so: [x] -->

- [x] I have personally loaded this code into an updated Qbox project and checked all of its functionality.
- [x] My code fits the style guidelines.
- [x] My PR fits the contribution guidelines.
