### PR TITLE
fix(bridge/qb/main): QBCore:CallCommand event

### DIFF
--- a/bridge/qb/server/main.lua
+++ b/bridge/qb/server/main.lua
@@ -53,7 +53,6 @@ end)
 --- @deprecated
 RegisterNetEvent('QBCore:CallCommand', function(command, args)
     local src = source --[[@as Source]]
-    if not qbCoreCompat.Commands.List[command] then return end
     local player = GetPlayer(src)
     if not player then return end
     if IsPlayerAceAllowed(src, string.format('command.%s', command)) then


### PR DESCRIPTION
There is no list field of the commands table. I believe if you attempt to Execute a command that doesn't exist you will get an error or a no-op anyway, so the gate condition doesn't seem needed.