### PR TITLE
feat(discord): add toggle for rich presence

### DIFF
--- a/client/discord.lua
+++ b/client/discord.lua
@@ -1,7 +1,9 @@
 local maxPlayers = GlobalState.MaxPlayers
 local discord = require 'config.client'.discord
 
-AddStateBagChangeHandler('PlayerCount', nil, function(bagName, _, value)
+if not discord.enabled then return end
+
+AddStateBagChangeHandler('PlayerCount', '', function(bagName, _, value)
     if bagName == 'global' and value then
         local players = 'Players %s/' .. maxPlayers
         SetRichPresence((players):format(value))

--- a/config/client.lua
+++ b/config/client.lua
@@ -43,6 +43,8 @@ return {
     },
 
     discord = {
+        enabled = true, -- This will enable or disable the built in discord rich presence.
+
         appId = '', -- This is the Application ID (Replace this with you own)
 
         largeIcon = { -- To set this up, visit https://forum.cfx.re/t/how-to-updated-discord-rich-presence-custom-image/157686


### PR DESCRIPTION
## Description

Basically just adding a config toggle (enabled by default to simulate previous implementation) to the discord rich presence.

## Checklist

<!-- Put an x inside the [ ] to check an item, like so: [x] -->

- [x] I have personally loaded this code into an updated Qbox project and checked all of its functionality.
- [x] My pull request fits the contribution guidelines & code conventions.
