### PR TITLE
fix(bridge/qb/functions): drawtext parameters

### DIFF
--- a/bridge/qb/client/functions.lua
+++ b/bridge/qb/client/functions.lua
@@ -20,10 +20,14 @@ functions.HasItem = HasItem
 -- Utility
 
 ---@deprecated use DrawText2D from imports/utils.lua
-functions.DrawText = DrawText2D
+functions.DrawText = function(x, y, width, height, scale, r, g, b, a, text)
+    DrawText2D(text, vec2(x, y), width, height, scale, 4, r, g, b, a)
+end
 
 ---@deprecated use DrawText3D from imports/utils.lua
-functions.DrawText3D = DrawText3D
+functions.DrawText3D = function(x, y, z, text)
+    DrawText3D(text, vec3(x, y, z), 0.35, 4, 255, 255, 255, 215)
+end
 
 ---@deprecated use lib.requestAnimDict from ox_lib
 functions.RequestAnimDict = lib.requestAnimDict


### PR DESCRIPTION
## Description

<!-- What does your pull request change? Why should it be merged? Does it fix an issue? -->

Fixes the parameters for `QBCore.Functions.DrawText` and `QBCore.Functions.DrawText3D`.

See `qb-core/client/functions.lua` [line 21](https://github.com/qbcore-framework/qb-core/blob/b132f2963ee01252eb08b1ed384ad797a7008ff1/client/functions.lua#L21) and [line 31](https://github.com/qbcore-framework/qb-core/blob/b132f2963ee01252eb08b1ed384ad797a7008ff1/client/functions.lua#L31)

## Checklist

<!-- Put an x inside the [ ] to check an item, like so: [x] -->

- [ ] I have personally loaded this code into an updated Qbox project and checked all of its functionality.
- [x] My pull request fits the contribution guidelines & code conventions.
