### PR TITLE
feat: jobs sql table

### DIFF
--- a/qbx_core.sql
+++ b/qbx_core.sql
@@ -62,3 +62,19 @@ CREATE TABLE IF NOT EXISTS `job_grades` (
     CONSTRAINT `job_name_grade` PRIMARY KEY (`job_name`, `grade`),
     FOREIGN KEY (`job_name`) REFERENCES jobs(`name`)
 ) ENGINE=InnoDB;
+
+CREATE TABLE IF NOT EXISTS `gangs` (
+    `name` varchar(50) NOT NULL,
+    `label` varchar(50) NOT NULL,
+    PRIMARY KEY (`name`)
+) ENGINE=InnoDB;
+
+CREATE TABLE IF NOT EXISTS `gang_grades` (
+    `gang_name` varchar(50) NOT NULL,
+    `grade` int(11) NOT NULL,
+    `name` varchar(50) NOT NULL,
+    `isboss` boolean DEFAULT FALSE,
+    `bankAuth` boolean DEFAULT FALSE,
+    CONSTRAINT `gang_name_grade` PRIMARY KEY (`gang_name`, `grade`),
+    FOREIGN KEY (`gang_name`) REFERENCES gangs(`name`)
+) ENGINE=InnoDB;

--- a/qbx_core.sql
+++ b/qbx_core.sql
@@ -42,3 +42,23 @@ CREATE TABLE IF NOT EXISTS `player_contacts` (
   PRIMARY KEY (`id`),
   KEY `citizenid` (`citizenid`)
 ) ENGINE=InnoDB AUTO_INCREMENT=1;
+
+CREATE TABLE IF NOT EXISTS `jobs` (
+    `name` varchar(50) NOT NULL,
+    `label` varchar(50) NOT NULL,
+    `type` varchar(50) DEFAULT NULL,
+    `defaultDuty` boolean DEFAULT FALSE,
+    `offDutyPay` boolean DEFAULT FALSE,
+    PRIMARY KEY (`name`)
+) ENGINE=InnoDB;
+
+CREATE TABLE IF NOT EXISTS `job_grades` (
+    `job_name` varchar(50) NOT NULL,
+    `grade` int(11) NOT NULL,
+    `name` varchar(50) NOT NULL,
+    `payment` int(11) NOT NULL,
+    `isboss` boolean DEFAULT FALSE,
+    `bankAuth` boolean DEFAULT FALSE,
+    CONSTRAINT `job_name_grade` PRIMARY KEY (`job_name`, `grade`),
+    FOREIGN KEY (`job_name`) REFERENCES jobs(`name`)
+) ENGINE=InnoDB;


### PR DESCRIPTION
## Description

Creates two tables to store job information such as pay, grades, and job names. This is the first step to enable dynamic pay configuration via core exports. Currently jobs are stored in a table of tables in shared/jobs.lua. The goal is to eventually rely on that only for initial load and instead store jobs information in the database.

## Checklist

<!-- Put an x inside the [ ] to check an item, like so: [x] -->

- [ ] I have personally loaded this code into an updated Qbox project and checked all of its functionality.
- [ ] My pull request fits the contribution guidelines & code conventions.
