### PR TITLE
Set to third person

### DIFF
--- a/client/character.lua
+++ b/client/character.lua
@@ -256,6 +256,7 @@ end
 
 local function chooseCharacter()
     randomLocation = config.characters.locations[math.random(1, #config.characters.locations)]
+    SetFollowPedCamViewMode(2)
 
     DoScreenFadeOut(500)
 


### PR DESCRIPTION
## Description

Sets to third person view on server join/logout,
Prevents a weird behavior where the ped is facing the same way you're looking.
Like that:
![image](https://github.com/Qbox-project/qbx_core/assets/97451137/6b3a040f-d2d8-477b-ae84-218d64e9b484)

(I think your view is persistent across servers too? so if you left in first you'll join in first?)

## Checklist

<!-- Put an x inside the [ ] to check an item, like so: [x] -->

- [x] I have personally loaded this code into an updated Qbox project and checked all of its functionality.
- [x] My pull request fits the contribution guidelines & code conventions.
