### PR TITLE
modify: allow for basic character creation without ox_inventory

### DIFF
--- a/server/character.lua
+++ b/server/character.lua
@@ -10,6 +10,9 @@ end
 ---@param source Source
 local function giveStarterItems(source)
     if GetResourceState('ox_inventory') == 'missing' then return end
+    while not exports.ox_inventory:GetInventory(source) do
+        Wait(100)
+    end
     for i = 1, #config.starterItems do
         local item = config.starterItems[i]
         if item.metadata and type(item.metadata) == 'function' then

--- a/server/character.lua
+++ b/server/character.lua
@@ -9,10 +9,7 @@ end
 
 ---@param source Source
 local function giveStarterItems(source)
-    while not exports.ox_inventory:GetInventory(source) do
-        Wait(100)
-    end
-
+    if GetResourceState('ox_inventory') == 'missing' then return end
     for i = 1, #config.starterItems do
         local item = config.starterItems[i]
         if item.metadata and type(item.metadata) == 'function' then


### PR DESCRIPTION
## Description

This will allow for basic character creation to proceed even if ox_inventory is missing from the server.

## Checklist

<!-- Put an x inside the [ ] to check an item, like so: [x] -->

- [ ] I have personally loaded this code into an updated Qbox project and checked all of its functionality.
- [X] My pull request fits the contribution guidelines & code conventions.
