### PR TITLE
fix(server/events): possibly fix deferral hangs

### DIFF
--- a/server/events.lua
+++ b/server/events.lua
@@ -90,6 +90,7 @@ local function onPlayerConnecting(name, _, deferrals)
         local success, err = pcall(function()
             local isBanned, Reason = IsPlayerBanned(src --[[@as Source]])
             if isBanned then
+                Wait(0) -- Mandatory wait
                 deferrals.done(Reason)
             end
         end)
@@ -98,6 +99,7 @@ local function onPlayerConnecting(name, _, deferrals)
             deferrals.update(string.format(Lang:t('info.checking_whitelisted'), name))
             success, err = pcall(function()
                 if not IsWhitelisted(src --[[@as Source]]) then
+                    Wait(0) -- Mandatory wait
                     deferrals.done(Lang:t('error.not_whitelisted'))
                 end
             end)
@@ -112,6 +114,10 @@ local function onPlayerConnecting(name, _, deferrals)
     -- wait for database to finish
     databasePromise:next(function()
         deferrals.update(string.format(Lang:t('info.join_server'), name))
+
+        -- Mandatory wait
+        Wait(0)
+
         if queue then
             queue.awaitPlayerQueue(src --[[@as Source]], license, deferrals)
         else

--- a/server/queue.lua
+++ b/server/queue.lua
@@ -263,9 +263,6 @@ local function awaitPlayerQueue(source, license, deferrals)
         Wait(1000)
     end
 
-    -- Mandatory wait
-    Wait(0)
-
     -- if the player disconnected while waiting in queue
     if not DoesPlayerExist(source --[[@as string]]) then
         if awaitPlayerTimeout(license) then

--- a/server/queue.lua
+++ b/server/queue.lua
@@ -263,6 +263,9 @@ local function awaitPlayerQueue(source, license, deferrals)
         Wait(1000)
     end
 
+    -- Mandatory wait
+    Wait(0)
+
     -- if the player disconnected while waiting in queue
     if not DoesPlayerExist(source --[[@as string]]) then
         if awaitPlayerTimeout(license) then


### PR DESCRIPTION
## Description

<!-- What does your pull request change? Why should it be merged? Does it fix an issue? -->

Possibly fixes deferral hangs.

The [FiveM docs](https://docs.fivem.net/docs/scripting-reference/events/list/playerConnecting/) state that before using `deferrals.done` you must wait at least a tick before calling it after calling a prior deferral method, which we weren't doing. So I assume that may have caused the deferrals to just not go anywhere.

I have no way of reliably checking this but let's assume that it works ;)

## Checklist

<!-- Put an x inside the [ ] to check an item, like so: [x] -->

- [ ] I have personally loaded this code into an updated Qbox project and checked all of its functionality.
- [x] My pull request fits the contribution guidelines & code conventions.
