### PR TITLE
refactor: use callbacks instead of netevents for setting vehicle props

### DIFF
--- a/client/events.lua
+++ b/client/events.lua
@@ -129,8 +129,7 @@ RegisterNetEvent('QBCore:Command:GoToMarker', function()
 end)
 
 -- Vehicle Commands
-
-RegisterNetEvent('qbx_core:client:vehicleSpawned', function(netId, props)
+lib.callback.register('qbx_core:client:vehicleSpawned', function(netId, props)
     local veh = NetworkGetEntityFromNetworkId(netId)
 
     for i = -1, 0 do

--- a/modules/lib.lua
+++ b/modules/lib.lua
@@ -170,7 +170,7 @@ if isServer then
         end, 5000)
 
         local netId = NetworkGetNetworkIdFromEntity(veh)
-        TriggerClientEvent('qbx_core:client:vehicleSpawned', owner, netId, props)
+        lib.callback.await('qbx_core:client:vehicleSpawned', owner, netId, props)
         return netId
     end
 else

--- a/modules/utils.lua
+++ b/modules/utils.lua
@@ -223,7 +223,7 @@ if isServer then
         end, 5000)
 
         local netId = NetworkGetNetworkIdFromEntity(veh)
-        TriggerClientEvent('qbx_core:client:vehicleSpawned', owner, netId, props)
+        lib.callback.await('qbx_core:client:vehicleSpawned', owner, netId, props)
         return netId
     end
 


### PR DESCRIPTION
## Description

Fixes #316. The current code flow for spawning a vehicle server side relies on the entity owner (client) to set the vehicle props. Due to various sync issues triggering this via NetEvent is not recommended as it causes an early return to the SpawnVehicle function in the Utils and Lib modules. Depending on the code following the SpawnVehicle call another entity owner may be set before the first entity owner can make the changes to the vehicle props. This fix yields until the original vehicle prop set request is completed before returning the netId to the caller of SpawnVehicle

## Checklist

<!-- Put an x inside the [ ] to check an item, like so: [x] -->

- [ ] I have personally loaded this code into an updated Qbox project and checked all of its functionality.
- [x] My pull request fits the contribution guidelines & code conventions.
