### PR TITLE
fix(server/queue): fix edge case when awaiting player joining

### DIFF
--- a/server/queue.lua
+++ b/server/queue.lua
@@ -128,6 +128,7 @@ local function awaitPlayerJoinsOrDisconnects(license)
     local joiningData
     while true do
         joiningData = joiningPlayers[license]
+        if not joiningData then return end
 
         -- wait until the player finally joins or disconnects while installing server content
         -- this may result in waiting ~2 additional minutes if the player disconnects as FXServer will think that the player exists


### PR DESCRIPTION
## Description

<!-- What does your pull request change? Why should it be merged? Does it fix an issue? -->

Fixes an edge case that causes an `attempt to index a nil value` error.
The error itself causes no harm except for being misleading.

## Checklist

<!-- Put an x inside the [ ] to check an item, like so: [x] -->

- [x] I have personally loaded this code into an updated Qbox project and checked all of its functionality.
- [x] My pull request fits the contribution guidelines & code conventions.
