### PR TITLE
feat(server/events): use shared config string for server name

### DIFF
--- a/config/shared.lua
+++ b/config/shared.lua
@@ -1,5 +1,5 @@
 return {
-    serverName = 'Qbox',
+    serverName = 'Server',
     defaultSpawn = vec4(-540.58, -212.02, 37.65, 208.88),
     notifyPosition = 'top-right' -- 'top' | 'top-right' | 'top-left' | 'bottom' | 'bottom-right' | 'bottom-left'
 }

--- a/config/shared.lua
+++ b/config/shared.lua
@@ -1,4 +1,5 @@
 return {
+    serverName = 'Qbox',
     defaultSpawn = vec4(-540.58, -212.02, 37.65, 208.88),
     notifyPosition = 'top-right' -- 'top' | 'top-right' | 'top-left' | 'bottom' | 'bottom-right' | 'bottom-left'
 }

--- a/server/events.lua
+++ b/server/events.lua
@@ -1,5 +1,6 @@
 local serverConfig = require 'config.server'.server
 local loggingConfig = require 'config.server'.logging
+local serverName = require 'config.shared'.serverName
 local logger = require 'modules.logger'
 local queue = require 'server.queue'
 
@@ -118,7 +119,6 @@ local function onPlayerConnecting(name, _, deferrals)
 
     -- wait for database to finish
     databasePromise:next(function()
-        local serverName = GetConvar('sv_projectName', GetConvar('sv_hostname', 'Server'))
         deferrals.update(locale('info.join_server', name, serverName))
 
         -- Mandatory wait


### PR DESCRIPTION
## Description

Adds a shared config for server name to avoid using any special color coded values in the deferrals section (unsure if deferrals will honor those). My suspicion says it will look like `Welcome to ^3SUPER ^1LIT ^2RP`. Originally this was a fix for the issue corrected by #323 but David's had error handling so I held off until it was merged.

## Checklist

<!-- Put an x inside the [ ] to check an item, like so: [x] -->

- [x] I have personally loaded this code into an updated Qbox project and checked all of its functionality.
- [x] My pull request fits the contribution guidelines & code conventions.
