### PR TITLE
refactor(config/queue): use shared config string for server name

### DIFF
--- a/config/queue.lua
+++ b/config/queue.lua
@@ -1,3 +1,5 @@
+local serverName = require 'config.shared'.serverName
+
 return {
     ---Amount of seconds to wait before removing a player from the queue after disconnecting while waiting.
     timeoutSeconds = 30,
@@ -54,10 +56,9 @@ return {
         local size = params.totalQueueSize
         local displayTime = params.displayTime
 
-        local serverName = GetConvar('sv_projectName', GetConvar('sv_hostname', 'Server'))
         local progressAmount = 7 -- amount of progress shown between the queue & server
-
         local playerColumn = pos == 1 and progressAmount or (progressAmount - math.ceil(pos / (size / progressAmount)) + 1)
+
         local progressTextReplacements = {
             [1] = {
                 text = 'Queue',


### PR DESCRIPTION
## Description

<!-- What does your pull request change? Why should it be merged? Does it fix an issue? -->

Refactors the queue config to get the server name from the config string added by #325 instead of the convars.

## Checklist

<!-- Put an x inside the [ ] to check an item, like so: [x] -->

- [x] I have personally loaded this code into an updated Qbox project and checked all of its functionality.
- [x] My pull request fits the contribution guidelines & code conventions.
