### PR TITLE
refactor: nil check for GetVehicleNumberPlateText

### DIFF
--- a/modules/lib.lua
+++ b/modules/lib.lua
@@ -138,9 +138,11 @@ end
 
 ---Returns the number plate of the given vehicle.
 ---@param vehicle integer
----@return string
+---@return string?
 function qbx.getVehiclePlate(vehicle)
-    return qbx.string.trim(GetVehicleNumberPlateText(vehicle))
+    local plate = GetVehicleNumberPlateText(vehicle)
+    if not plate then return end
+    return qbx.string.trim(plate)
 end
 
 ---Generates and returns a random number plate with the given pattern.


### PR DESCRIPTION
## Description

GetVehicleNumberPlateText has to be trimmed and you can't trim a nil. This fixes that

## Checklist

<!-- Put an x inside the [ ] to check an item, like so: [x] -->

- [ ] I have personally loaded this code into an updated Qbox project and checked all of its functionality.
- [x] My pull request fits the contribution guidelines & code conventions.
