### PR TITLE
Fix(bucket): Set player instance state whenever you change bucket

### DIFF
--- a/server/functions.lua
+++ b/server/functions.lua
@@ -129,6 +129,7 @@ exports('GetBucketObjects', GetBucketObjects)
 function SetPlayerBucket(source, bucket)
     if not (source or bucket) then return false end
 
+    Player(source).state:set('instance', bucket, true)
     SetPlayerRoutingBucket(source --[[@as string]], bucket)
     QBX.Player_Buckets[source] = bucket
     return true


### PR DESCRIPTION
Adds support for inventory instances.

Check: https://github.com/overextended/ox_inventory/blob/8f565f8ca9cb55ea78eb9666c409363928f2f2ee/client.lua#L1088

Whenever you change routing bucket all drops should dissapear and this PR does exactly that.

another benefit that other scripts can now use this same information which is great 👍 