### PR TITLE
fix(queue): subqueue card options not being optional

### DIFF
--- a/config/queue.lua
+++ b/config/queue.lua
@@ -56,6 +56,8 @@ return {
         local size = params.totalQueueSize
         local displayTime = params.displayTime
 
+        local cardOptions = subQueue.cardOptions or {}
+
         local progressAmount = 7 -- amount of progress shown between the queue & server
         local playerColumn = pos == 1 and progressAmount or (progressAmount - math.ceil(pos / (size / progressAmount)) + 1)
 
@@ -139,11 +141,11 @@ return {
                                 {
                                     type = 'TextBlock',
                                     text = subQueue.name,
-                                    style = subQueue.cardOptions.style,
-                                    fontType = subQueue.cardOptions.fontType,
-                                    size = subQueue.cardOptions.size or 'medium',
-                                    color = subQueue.cardOptions.color,
-                                    isSubtle = subQueue.cardOptions.isSubtle,
+                                    style = cardOptions.style,
+                                    fontType = cardOptions.fontType,
+                                    size = cardOptions.size or 'medium',
+                                    color = cardOptions.color,
+                                    isSubtle = cardOptions.isSubtle,
                                 }
                             },
                         },


### PR DESCRIPTION
## Description

<!-- What does your pull request change? Why should it be merged? Does it fix an issue? -->

Fixes a nil error by actually making the sub-queue `cardOptions` optional. (this was supposed to be the expected functionality, whoops...)

## Checklist

<!-- Put an x inside the [ ] to check an item, like so: [x] -->

- [x] I have personally loaded this code into an updated Qbox project and checked all of its functionality.
- [x] My pull request fits the contribution guidelines & code conventions.
