### PR TITLE
fix: players are not vehicles

### DIFF
--- a/bridge/qb/client/functions.lua
+++ b/bridge/qb/client/functions.lua
@@ -166,7 +166,7 @@ functions.IsWearingGloves = qbx.isWearingGloves
 
 ---@deprecated use lib.getClosestPlayer from ox_lib
 functions.GetClosestPlayer = function(coords)
-    local playerId, _, playerCoords = lib.getClosestVehicle(coords)
+    local playerId, _, playerCoords = lib.getClosestPlayer(coords)
     local playerDistance = #(coords - playerCoords)
     return playerId, playerDistance
 end


### PR DESCRIPTION
## Description

Players are not vehicles... This corrects that issue.

## Checklist

<!-- Put an x inside the [ ] to check an item, like so: [x] -->

- [x] I have personally loaded this code into an updated Qbox project and checked all of its functionality.
- [x] My pull request fits the contribution guidelines & code conventions.
