### PR TITLE
fix(bridge/qb/client): make functions strictly backwards compatible

### DIFF
--- a/bridge/qb/client/functions.lua
+++ b/bridge/qb/client/functions.lua
@@ -153,9 +153,7 @@ functions.GetObjects = function()
 end
 
 ---@deprecated use the GetActivePlayers native directly
-functions.GetPlayers = function()
-    return GetActivePlayers()
-end
+functions.GetPlayers = GetActivePlayers
 
 ---@deprecated use the GetGamePool('CPed') native directly
 functions.GetPeds = function(ignoreList)

--- a/bridge/qb/client/functions.lua
+++ b/bridge/qb/client/functions.lua
@@ -143,32 +143,18 @@ local function getEntities(pool, ignoreList) -- luacheck: ignore
 end
 
 ---@deprecated use the GetGamePool('CVehicle') native directly
-functions.GetVehicles = function(ignoreList)
-    return getEntities('CVehicle', ignoreList)
+functions.GetVehicles = function()
+    return GetGamePool('CVehicle')
 end
 
 ---@deprecated use the GetGamePool('CObject') native directly
-functions.GetObjects = function(ignoreList)
-    return getEntities('CObject', ignoreList)
+functions.GetObjects = function()
+    return GetGamePool('CObject')
 end
 
 ---@deprecated use the GetActivePlayers native directly
-functions.GetPlayers = function(ignoreList)
-    ignoreList = ignoreList or {}
-    local plys = GetActivePlayers()
-    local players = {}
-    local ignoreMap = {}
-    for i = 1, #ignoreList do
-        ignoreMap[ignoreList[i]] = true
-    end
-
-    for i = 1, #plys do
-        local player = plys[i]
-        if not ignoreMap[player] then
-            players[#players + 1] = player
-        end
-    end
-    return players
+functions.GetPlayers = function()
+    return GetActivePlayers()
 end
 
 ---@deprecated use the GetGamePool('CPed') native directly
@@ -205,11 +191,22 @@ end
 ---@deprecated use qbx.isWearingGloves from modules/lib.lua
 functions.IsWearingGloves = qbx.isWearingGloves
 
-functions.GetClosestPlayer = function(coords, maxDistance) -- luacheck: ignore
+---@deprecated use lib.getClosestPlayer from ox_lib
+functions.GetClosestPlayer = function(coords) -- luacheck: ignore
     coords = type(coords) == 'table' and vec3(coords.x, coords.y, coords.z) or coords or GetEntityCoords(cache.ped)
-    local playerId, _, playerCoords = lib.getClosestPlayer(coords, maxDistance or 50, false)
-    local closestDistance = playerCoords and #(playerCoords - coords) or nil
-    return playerId, closestDistance
+    local players = GetActivePlayers()
+    local closestDistance = -1
+    local closestPlayer = -1
+    for i = 1, #players do
+        local player = players[i]
+        local playerCoords = GetEntityCoords(GetPlayerPed(player))
+        local distance = #(playerCoords - coords)
+        if closestDistance == -1 or closestDistance > distance then
+            closestPlayer = player
+            closestDistance = distance
+        end
+    end
+    return closestPlayer, closestDistance
 end
 
 ---@deprecated use lib.getNearbyPlayers from ox_lib
@@ -226,13 +223,13 @@ functions.GetPlayersFromCoords = function(coords, radius)
 end
 
 ---@deprecated use lib.getClosestVehicle from ox_lib
-functions.GetClosestVehicle = function(coords, ignoreList)
-    return getClosestEntity(getEntities('CVehicle', ignoreList), coords)
+functions.GetClosestVehicle = function(coords)
+    return getClosestEntity(GetGamePool('CVehicle'), coords)
 end
 
 ---@deprecated use lib.getClosestObject from ox_lib
-functions.GetClosestObject = function(coords, ignoreList)
-    return getClosestEntity(getEntities('CObject', ignoreList), coords)
+functions.GetClosestObject = function(coords)
+    return getClosestEntity(GetGamePool('CObject'), coords)
 end
 
 ---@deprecated use the GetWorldPositionOfEntityBone native and calculate distance directly


### PR DESCRIPTION
## Description

<!-- What does your pull request change? Why should it be merged? Does it fix an issue? -->

Make the QB bridge functions more strict with backwards compatibility after the changes in #337.

In QBCore these functions do not accept an `ignoreList` param but currently we do: `GetVehicles`, `GetObjects`, `GetPlayers`, `GetClosestVehicle`, `GetClosestObject`

In QBCore this function does not accept a `maxDistance` param: `GetClosestPlayer`

In addition the `GetClosestPlayer` function was edited to not use ox_lib because it requires using a max radius.

## Checklist

<!-- Put an x inside the [ ] to check an item, like so: [x] -->

- [ ] I have personally loaded this code into an updated Qbox project and checked all of its functionality.
- [x] My pull request fits the contribution guidelines & code conventions.
