### PR TITLE
feat: onSetMetaData event

### DIFF
--- a/server/player.lua
+++ b/server/player.lua
@@ -317,7 +317,7 @@ function CreatePlayer(playerData, Offline)
             val = val > 100 and 100 or val
         end
         TriggerClientEvent('qbx_core:client:onSetMetaData', self.PlayerData.source, meta, self.PlayerData.metadata[meta], val)
-        TriggerClientEvent('qbx_core:server:onSetMetaData', meta, self.PlayerData.metadata[meta], val)
+        TriggerEvent('qbx_core:server:onSetMetaData', meta, self.PlayerData.metadata[meta], val)
         self.PlayerData.metadata[meta] = val
         self.Functions.UpdatePlayerData()
         if meta == 'inlaststand' or meta == 'isdead' then

--- a/server/player.lua
+++ b/server/player.lua
@@ -317,6 +317,7 @@ function CreatePlayer(playerData, Offline)
             val = val > 100 and 100 or val
         end
         TriggerClientEvent('qbx_core:client:onSetMetaData', self.PlayerData.source, meta, self.PlayerData.metadata[meta], val)
+        TriggerClientEvent('qbx_core:server:onSetMetaData', meta, self.PlayerData.metadata[meta], val)
         self.PlayerData.metadata[meta] = val
         self.Functions.UpdatePlayerData()
         if meta == 'inlaststand' or meta == 'isdead' then

--- a/server/player.lua
+++ b/server/player.lua
@@ -316,6 +316,7 @@ function CreatePlayer(playerData, Offline)
         if meta == 'hunger' or meta == 'thirst' then
             val = val > 100 and 100 or val
         end
+        TriggerClientEvent('qbx_core:client:onSetMetaData', self.PlayerData.source, meta, self.PlayerData.metadata[meta], val)
         self.PlayerData.metadata[meta] = val
         self.Functions.UpdatePlayerData()
         if meta == 'inlaststand' or meta == 'isdead' then

--- a/server/player.lua
+++ b/server/player.lua
@@ -316,13 +316,15 @@ function CreatePlayer(playerData, Offline)
         if meta == 'hunger' or meta == 'thirst' then
             val = val > 100 and 100 or val
         end
-        TriggerClientEvent('qbx_core:client:onSetMetaData', self.PlayerData.source, meta, self.PlayerData.metadata[meta], val)
-        TriggerEvent('qbx_core:server:onSetMetaData', meta, self.PlayerData.metadata[meta], val)
+
+        local oldVal = self.PlayerData.metadata[meta]
         self.PlayerData.metadata[meta] = val
         self.Functions.UpdatePlayerData()
         if meta == 'inlaststand' or meta == 'isdead' then
             self.Functions.Save()
         end
+        TriggerClientEvent('qbx_core:client:onSetMetaData', self.PlayerData.source, meta, oldVal, val)
+        TriggerEvent('qbx_core:server:onSetMetaData', meta,  oldVal, val)
     end
 
     ---@param meta string


### PR DESCRIPTION
## Description

SetMetaData now triggers a clientside event that can be listened to,

`AddEventHandler('qbx_core:client:onSetMetaData', key, oldValue, newValue)`
`AddEventHandler('qbx_core:server:onSetMetaData', key, oldValue, newValue)`

## Checklist

- [ ] I have personally loaded this code into an updated Qbox project and checked all of its functionality.
- [x] My pull request fits the contribution guidelines & code conventions.
