### PR TITLE
fix(bridge/qb/client): GetClosestPlayer not ignoring local player

### DIFF
--- a/bridge/qb/client/functions.lua
+++ b/bridge/qb/client/functions.lua
@@ -192,11 +192,11 @@ functions.IsWearingGloves = qbx.isWearingGloves
 ---@deprecated use lib.getClosestPlayer from ox_lib
 functions.GetClosestPlayer = function(coords) -- luacheck: ignore
     coords = type(coords) == 'table' and vec3(coords.x, coords.y, coords.z) or coords or GetEntityCoords(cache.ped)
-    local players = GetActivePlayers()
+    local players = lib.getNearbyPlayers(coords, 5, false)
     local closestDistance = -1
     local closestPlayer = -1
     for i = 1, #players do
-        local player = players[i]
+        local player = players[i].id
         local playerCoords = GetEntityCoords(GetPlayerPed(player))
         local distance = #(playerCoords - coords)
         if closestDistance == -1 or closestDistance > distance then

--- a/bridge/qb/client/functions.lua
+++ b/bridge/qb/client/functions.lua
@@ -192,19 +192,9 @@ functions.IsWearingGloves = qbx.isWearingGloves
 ---@deprecated use lib.getClosestPlayer from ox_lib
 functions.GetClosestPlayer = function(coords) -- luacheck: ignore
     coords = type(coords) == 'table' and vec3(coords.x, coords.y, coords.z) or coords or GetEntityCoords(cache.ped)
-    local players = lib.getNearbyPlayers(coords, 5, false)
-    local closestDistance = -1
-    local closestPlayer = -1
-    for i = 1, #players do
-        local player = players[i].id
-        local playerCoords = GetEntityCoords(GetPlayerPed(player))
-        local distance = #(playerCoords - coords)
-        if closestDistance == -1 or closestDistance > distance then
-            closestPlayer = player
-            closestDistance = distance
-        end
-    end
-    return closestPlayer, closestDistance
+    local playerId, _, playerCoords = lib.getClosestPlayer(coords, 5, false)
+    local closestDistance = playerCoords and #(playerCoords - coords) or nil
+    return (playerId or -1), (closestDistance or -1)
 end
 
 ---@deprecated use lib.getNearbyPlayers from ox_lib

--- a/bridge/qb/client/functions.lua
+++ b/bridge/qb/client/functions.lua
@@ -194,7 +194,7 @@ functions.GetClosestPlayer = function(coords) -- luacheck: ignore
     coords = type(coords) == 'table' and vec3(coords.x, coords.y, coords.z) or coords or GetEntityCoords(cache.ped)
     local playerId, _, playerCoords = lib.getClosestPlayer(coords, 5, false)
     local closestDistance = playerCoords and #(playerCoords - coords) or nil
-    return (playerId or -1), (closestDistance or -1)
+    return playerId or -1, closestDistance or -1
 end
 
 ---@deprecated use lib.getNearbyPlayers from ox_lib


### PR DESCRIPTION
## Description

<!-- What does your pull request change? Why should it be merged? Does it fix an issue? -->

Fixes an issue introduced by #338 where `GetClosestPlayer` wouldn't ignore the local player. In addition the original QBCore function only returns players in a 5-radius distance from the local player, this is now fixed too.

## Checklist

<!-- Put an x inside the [ ] to check an item, like so: [x] -->

- [ ] I have personally loaded this code into an updated Qbox project and checked all of its functionality.
- [x] My pull request fits the contribution guidelines & code conventions.
