### PR TITLE
feat(dynamic groups): sql schema

### DIFF
--- a/qbx_core.sql
+++ b/qbx_core.sql
@@ -42,3 +42,17 @@ CREATE TABLE IF NOT EXISTS `player_contacts` (
   PRIMARY KEY (`id`),
   KEY `citizenid` (`citizenid`)
 ) ENGINE=InnoDB AUTO_INCREMENT=1;
+
+CREATE TABLE IF NOT EXISTS `jobs` (
+	`name` VARCHAR(50) NOT NULL,
+	`data` LONGTEXT NOT NULL,
+	PRIMARY KEY (`name`)
+) ENGINE=InnoDB;
+
+CREATE TABLE IF NOT EXISTS `job_grades` (
+	`job` VARCHAR(50) NOT NULL
+	`grade` TINYINT(3) UNSIGNED NOT NULL,
+	`data` LONGTEXT NOT NULL,
+	PRIMARY KEY (`job`, `grade`),
+	CONSTRAINT `jobs` FOREIGN KEY (`job`) REFERENCES `jobs` (`name`) ON UPDATE CASCADE ON DELETE CASCADE
+) ENGINE=InnoDB;

--- a/qbx_core.sql
+++ b/qbx_core.sql
@@ -43,16 +43,18 @@ CREATE TABLE IF NOT EXISTS `player_contacts` (
   KEY `citizenid` (`citizenid`)
 ) ENGINE=InnoDB AUTO_INCREMENT=1;
 
-CREATE TABLE IF NOT EXISTS `jobs` (
+CREATE TABLE IF NOT EXISTS `groups` (
 	`name` VARCHAR(50) NOT NULL,
+  `type` ENUM('job','gang') NOT NULL,
 	`data` LONGTEXT NOT NULL,
-	PRIMARY KEY (`name`)
+	PRIMARY KEY (`name`, `type`)
 ) ENGINE=InnoDB;
 
-CREATE TABLE IF NOT EXISTS `job_grades` (
-	`job` VARCHAR(50) NOT NULL
+CREATE TABLE IF NOT EXISTS `group_grades` (
+	`group` VARCHAR(50) NOT NULL
+  `type` ENUM('job', 'gang') NOT NULL,
 	`grade` TINYINT(3) UNSIGNED NOT NULL,
 	`data` LONGTEXT NOT NULL,
-	PRIMARY KEY (`job`, `grade`),
-	CONSTRAINT `jobs` FOREIGN KEY (`job`) REFERENCES `jobs` (`name`) ON UPDATE CASCADE ON DELETE CASCADE
+	PRIMARY KEY (`group`, `grade`, `type`),
+	CONSTRAINT `groups` FOREIGN KEY (`group`) REFERENCES `groups` (`name`) ON UPDATE CASCADE ON DELETE CASCADE
 ) ENGINE=InnoDB;

--- a/qbx_core.sql
+++ b/qbx_core.sql
@@ -44,17 +44,17 @@ CREATE TABLE IF NOT EXISTS `player_contacts` (
 ) ENGINE=InnoDB AUTO_INCREMENT=1;
 
 CREATE TABLE IF NOT EXISTS `groups` (
-	`name` VARCHAR(50) NOT NULL,
+  `name` VARCHAR(50) NOT NULL,
   `type` ENUM('job','gang') NOT NULL,
-	`data` LONGTEXT NOT NULL,
-	PRIMARY KEY (`name`, `type`)
+  `data` LONGTEXT NOT NULL,
+  PRIMARY KEY (`name`, `type`)
 ) ENGINE=InnoDB;
 
 CREATE TABLE IF NOT EXISTS `group_grades` (
-	`group` VARCHAR(50) NOT NULL,
+  `group` VARCHAR(50) NOT NULL,
   `type` ENUM('job', 'gang') NOT NULL,
-	`grade` TINYINT(3) UNSIGNED NOT NULL,
-	`data` LONGTEXT NOT NULL,
-	PRIMARY KEY (`group`, `grade`, `type`),
-	CONSTRAINT `groups` FOREIGN KEY (`group`) REFERENCES `groups` (`name`) ON UPDATE CASCADE ON DELETE CASCADE
+  `grade` TINYINT(3) UNSIGNED NOT NULL,
+  `data` LONGTEXT NOT NULL,
+  PRIMARY KEY (`group`, `grade`, `type`),
+  CONSTRAINT `groups` FOREIGN KEY (`group`) REFERENCES `groups` (`name`) ON UPDATE CASCADE ON DELETE CASCADE
 ) ENGINE=InnoDB;

--- a/qbx_core.sql
+++ b/qbx_core.sql
@@ -51,7 +51,7 @@ CREATE TABLE IF NOT EXISTS `groups` (
 ) ENGINE=InnoDB;
 
 CREATE TABLE IF NOT EXISTS `group_grades` (
-	`group` VARCHAR(50) NOT NULL
+	`group` VARCHAR(50) NOT NULL,
   `type` ENUM('job', 'gang') NOT NULL,
 	`grade` TINYINT(3) UNSIGNED NOT NULL,
 	`data` LONGTEXT NOT NULL,


### PR DESCRIPTION
Moves groups from config into database. Config would be the default values and the database would override.
This allows for jobs/gangs to be modified at runtime supporting features such as players changing names.
Opted for a more flexible structure since normal use cases would be reading/writing to an individual group/grade. Querying a selection of grades/groups doesn't seem to be a likely use case.