### PR TITLE
feat: jobs/gangs stored in database instead of config

### DIFF
--- a/fxmanifest.lua
+++ b/fxmanifest.lua
@@ -26,6 +26,8 @@ client_scripts {
 
 server_scripts {
     '@oxmysql/lib/MySQL.lua',
+    'server/storage/players.lua',
+    'server/storage/groups.lua',
     'server/main.lua',
     'server/groups.lua',
     'server/functions.lua',
@@ -33,8 +35,6 @@ server_scripts {
     'server/events.lua',
     'server/commands.lua',
     'server/loops.lua',
-    'server/storage/players.lua',
-    'server/storage/groups.lua',
     'server/character.lua',
     'bridge/qb/server/main.lua',
 }


### PR DESCRIPTION
- On initial load, gangs/jobs are fetched from the database. Any groups in the config, but not in the database are added to the database. It's intended that server operators edit the database directly and stop using the job/gang config. Future PRs will make this easier by adding menus and commands to edit groups with.

