### PR TITLE
fix(server/storage/groups): escape `group` in queries

### DIFF
--- a/server/storage/groups.lua
+++ b/server/storage/groups.lua
@@ -46,7 +46,7 @@ end
 ---@param grade integer
 ---@param data GradeData
 local function upsertGradeEntity(group, groupType, grade, data)
-    MySQL.insert.await('INSERT INTO group_grades (group, type, grade, data) VALUES (:group, :type, :grade, :data) ON DUPLICATE KEY UPDATE group = :group, type = :type, grade = :grade, data = :data', {
+    MySQL.insert.await('INSERT INTO group_grades (`group`, type, grade, data) VALUES (:group, :type, :grade, :data) ON DUPLICATE KEY UPDATE `group` = :group, type = :type, grade = :grade, data = :data', {
         group = group,
         type = groupType,
         grade = grade,
@@ -87,7 +87,7 @@ function FetchGroups()
         end
     end
 
-    local grades = MySQL.query.await('SELECT group, type, grade, data FROM group_grades')
+    local grades = MySQL.query.await('SELECT `group`, type, grade, data FROM group_grades')
     if grades then
         for i = 1, #grades do
             local grade = grades[i]
@@ -153,7 +153,7 @@ function UpsertJob(name, job)
 
     for grade, gradeData in pairs(job.grades) do
         queries[#queries+1] = {
-            query = 'INSERT INTO group_grades (group, type, grade, data) VALUES (@name, @type, @grade, @data) ON DUPLICATE KEY UPDATE group = @name, type = @type, grade = @grade, data = @data',
+            query = 'INSERT INTO group_grades (`group`, type, grade, data) VALUES (@name, @type, @grade, @data) ON DUPLICATE KEY UPDATE `group` = @name, type = @type, grade = @grade, data = @data',
             values = {
                 name = name,
                 type = GroupType.JOB,
@@ -214,7 +214,7 @@ function UpsertGang(name, gang)
 
     for grade, gradeData in pairs(gang.grades) do
         queries[#queries+1] = {
-            query = 'INSERT INTO group_grades (group, type, grade, data) VALUES (@name, @type, @grade, @data) ON DUPLICATE KEY UPDATE group = @name, type = @type, grade = @grade, data = @data',
+            query = 'INSERT INTO group_grades (`group`, type, grade, data) VALUES (@name, @type, @grade, @data) ON DUPLICATE KEY UPDATE `group` = @name, type = @type, grade = @grade, data = @data',
             values = {
                 name = name,
                 type = GroupType.GANG,


### PR DESCRIPTION
## Description

<!-- What does your pull request change? Why should it be merged? Does it fix an issue? -->

`GROUP` is a reserved keyword, so it has to be escaped.

## Checklist

<!-- Put an x inside the [ ] to check an item, like so: [x] -->

- [x] I have personally loaded this code into an updated Qbox project and checked all of its functionality.
- [x] My pull request fits the contribution guidelines & code conventions.
