### PR TITLE
fix(server/storage/groups): wrong variable used in group instantiation

### DIFF
--- a/server/storage/groups.lua
+++ b/server/storage/groups.lua
@@ -80,9 +80,9 @@ function FetchGroups()
             local data = json.decode(group.data)
             data.grades = {}
             if group.type == GroupType.JOB then
-                jobs[group.name] = group.data
+                jobs[group.name] = data
             else
-                gangs[group.name] = group.data
+                gangs[group.name] = data
             end
         end
     end


### PR DESCRIPTION
## Description

<!-- What does your pull request change? Why should it be merged? Does it fix an issue? -->

The wrong variable was used to instantiate groups when fetching them.

## Checklist

<!-- Put an x inside the [ ] to check an item, like so: [x] -->

- [x] I have personally loaded this code into an updated Qbox project and checked all of its functionality.
- [x] My pull request fits the contribution guidelines & code conventions.
