### PR TITLE
feat(sql): new table player_groups for multi-job

### DIFF
--- a/qbx_core.sql
+++ b/qbx_core.sql
@@ -44,17 +44,27 @@ CREATE TABLE IF NOT EXISTS `player_contacts` (
 ) ENGINE=InnoDB AUTO_INCREMENT=1;
 
 CREATE TABLE IF NOT EXISTS `groups` (
-  `name` VARCHAR(50) NOT NULL,
-  `type` ENUM('job','gang') NOT NULL,
-  `data` LONGTEXT NOT NULL,
-  PRIMARY KEY (`name`, `type`)
+	`name` VARCHAR(50) NOT NULL,
+	`type` VARCHAR(50) NOT NULL,
+	`data` LONGTEXT NOT NULL,
+	PRIMARY KEY (`name`, `type`)
 ) ENGINE=InnoDB;
 
 CREATE TABLE IF NOT EXISTS `group_grades` (
-  `group` VARCHAR(50) NOT NULL,
-  `type` ENUM('job', 'gang') NOT NULL,
-  `grade` TINYINT(3) UNSIGNED NOT NULL,
-  `data` LONGTEXT NOT NULL,
-  PRIMARY KEY (`group`, `grade`, `type`),
-  CONSTRAINT `groups` FOREIGN KEY (`group`) REFERENCES `groups` (`name`) ON UPDATE CASCADE ON DELETE CASCADE
+	`group` VARCHAR(50) NOT NULL,
+	`type` VARCHAR(50) NOT NULL,
+	`grade` TINYINT(3) UNSIGNED NOT NULL,
+	`data` LONGTEXT NOT NULL,
+	PRIMARY KEY (`group`, `grade`, `type`),
+	CONSTRAINT `fk_groups` FOREIGN KEY (`group`, `type`) REFERENCES `groups` (`name`, `type`) ON UPDATE CASCADE ON DELETE CASCADE
+) ENGINE=InnoDB;
+
+CREATE TABLE IF NOT EXISTS `player_groups` (
+	`citizenid` VARCHAR(50) NOT NULL,
+	`group` VARCHAR(50) NOT NULL,
+	`type` VARCHAR(50) NOT NULL,
+	`grade` TINYINT(3) UNSIGNED NOT NULL,
+	PRIMARY KEY (`citizenid`, `type`, `group`),
+	CONSTRAINT `fk_citizenid` FOREIGN KEY (`citizenid`) REFERENCES `players` (`citizenid`) ON UPDATE CASCADE ON DELETE CASCADE,
+	CONSTRAINT `fk_grade` FOREIGN KEY (`group`, `type`, `grade`) REFERENCES `group_grades` (`group`, `type`, `grade`) ON UPDATE CASCADE ON DELETE CASCADE
 ) ENGINE=InnoDB;


### PR DESCRIPTION
- Changed group tables to use varchar instead of enum. Would rather this be more flexible in case we want to add new enum values, don't need to modify the schema.
- Add new table player_groups to map characters to group_grades. Foreign key constraints enforce that a grade must exist for a player to hold it