### PR TITLE
refactor(server): organize storage functions into a module instead of global functions

### DIFF
--- a/fxmanifest.lua
+++ b/fxmanifest.lua
@@ -26,8 +26,6 @@ client_scripts {
 
 server_scripts {
     '@oxmysql/lib/MySQL.lua',
-    'server/storage/players.lua',
-    'server/storage/groups.lua',
     'server/main.lua',
     'server/groups.lua',
     'server/functions.lua',

--- a/server/character.lua
+++ b/server/character.lua
@@ -1,5 +1,6 @@
 local config = require 'config.server'
 local logger = require 'modules.logger'
+local storage = require 'server.storage.main'
 
 ---@param license2 string
 ---@param license? string
@@ -25,7 +26,7 @@ end
 
 lib.callback.register('qbx_core:server:getCharacters', function(source)
     local license2, license = GetPlayerIdentifierByType(source, 'license2'), GetPlayerIdentifierByType(source, 'license')
-    local chars = FetchAllPlayerEntities(license2, license)
+    local chars = storage.fetchAllPlayerEntities(license2, license)
     local allowedAmount = getAllowedAmountOfCharacters(license2, license)
     local sortedChars = {}
     for i = 1, #chars do
@@ -36,7 +37,7 @@ lib.callback.register('qbx_core:server:getCharacters', function(source)
 end)
 
 lib.callback.register('qbx_core:server:getPreviewPedData', function(_, citizenId)
-    local ped = FetchPlayerSkin(citizenId)
+    local ped = storage.fetchPlayerSkin(citizenId)
     if not ped then return end
 
     return ped.skin, ped.model and joaat(ped.model)

--- a/server/functions.lua
+++ b/server/functions.lua
@@ -392,7 +392,7 @@ exports('GetCoreVersion', GetCoreVersion)
 local function ExploitBan(playerId, origin)
     local name = GetPlayerName(playerId)
     CreateThread(function()
-        storage.insertBanEntity({
+        storage.insertBan({
             name = name,
             license = GetPlayerIdentifierByType(playerId --[[@as string]], 'license2') or GetPlayerIdentifierByType(playerId --[[@as string]], 'license'),
             discordId = GetPlayerIdentifierByType(playerId --[[@as string]], 'discord'),

--- a/server/functions.lua
+++ b/server/functions.lua
@@ -2,6 +2,7 @@ local serverConfig = require 'config.server'.server
 local positionConfig = require 'config.shared'.notifyPosition
 local logger = require 'modules.logger'
 local loggingConfig = require 'config.server'.logging
+local storage = require 'server.storage.main'
 
 -- Getters
 -- Get your player first and then trigger a function on them
@@ -325,7 +326,7 @@ exports('ToggleOptin', ToggleOptin)
 ---@return string? playerMessage
 function IsPlayerBanned(source)
     local plicense = GetPlayerIdentifierByType(source --[[@as string]], 'license2') or GetPlayerIdentifierByType(source --[[@as string]], 'license')
-    local result = FetchBanEntity({
+    local result = storage.fetchBan({
         license = plicense
     })
     if not result then return false end
@@ -334,7 +335,7 @@ function IsPlayerBanned(source)
         return true, 'You have been banned from the server:\n' .. result.reason .. '\nYour ban expires ' .. timeTable.day .. '/' .. timeTable.month .. '/' .. timeTable.year .. ' ' .. timeTable.hour .. ':' .. timeTable.min .. '\n'
     else
         CreateThread(function()
-            DeleteBanEntity({
+            storage.deleteBan({
                 license = plicense
             })
         end)
@@ -391,7 +392,7 @@ exports('GetCoreVersion', GetCoreVersion)
 local function ExploitBan(playerId, origin)
     local name = GetPlayerName(playerId)
     CreateThread(function()
-        InsertBanEntity({
+        storage.insertBanEntity({
             name = name,
             license = GetPlayerIdentifierByType(playerId --[[@as string]], 'license2') or GetPlayerIdentifierByType(playerId --[[@as string]], 'license'),
             discordId = GetPlayerIdentifierByType(playerId --[[@as string]], 'discord'),

--- a/server/groups.lua
+++ b/server/groups.lua
@@ -1,3 +1,5 @@
+local storage = require 'server.storage.main'
+
 ---@type table<string, Job>
 local jobs = {}
 ---@type table<string, Gang>
@@ -7,7 +9,7 @@ local gangs = {}
 ---@param newJobs table<string, Job>
 function CreateJobs(newJobs)
     for jobName, job in pairs(newJobs) do
-        UpsertJob(jobName, job)
+        storage.upsertJob(jobName, job)
         jobs[jobName] = job
         TriggerEvent('qbx_core:server:onJobUpdate', jobName, job)
         TriggerClientEvent('qbx_core:client:onJobUpdate', -1, jobName, job)
@@ -29,7 +31,7 @@ function RemoveJob(jobName)
         return false, "job_not_exists"
     end
 
-    DeleteJobEntity(jobName)
+    storage.deleteJobEntity(jobName)
     jobs[jobName] = nil
     TriggerEvent('qbx_core:server:onJobUpdate', jobName, nil)
     TriggerClientEvent('qbx_core:client:onJobUpdate', -1, jobName, nil)
@@ -42,7 +44,7 @@ exports('RemoveJob', RemoveJob)
 ---@param newGangs table<string, Gang>
 function CreateGangs(newGangs)
     for gangName, gang in pairs(newGangs) do
-        UpsertGang(gangName, gang)
+        storage.upsertGang(gangName, gang)
         gangs[gangName] = gang
         TriggerEvent('qbx_core:server:onGangUpdate', gangName, gang)
         TriggerClientEvent('qbx_core:client:onGangUpdate', -1, gangName, gang)
@@ -64,7 +66,7 @@ function RemoveGang(gangName)
         return false, "gang_not_exists"
     end
 
-    DeleteGangEntity(gangName)
+    storage.deleteGangEntity(gangName)
     gangs[gangName] = nil
 
     TriggerEvent('qbx_core:server:onGangUpdate', gangName, nil)
@@ -115,7 +117,7 @@ end)
 ---@param name string
 ---@param data JobData
 local function upsertJobData(name, data)
-    UpsertJobEntity(name, data)
+    storage.upsertJobEntity(name, data)
     if jobs[name] then
         jobs[name].defaultDuty = data.defaultDuty
         jobs[name].label = data.label
@@ -139,7 +141,7 @@ exports('UpsertJobData', upsertJobData)
 ---@param name string
 ---@param data GangData
 local function upsertGangData(name, data)
-    UpsertGangEntity(name, data)
+    storage.upsertGangEntity(name, data)
     if gangs[name] then
         gangs[name].label = data.label
     else
@@ -162,7 +164,7 @@ local function upsertJobGrade(name, grade, data)
         lib.print.error("Job must exist to edit grades. Not found:", name)
         return
     end
-    UpsertJobGradeEntity(name, grade, data)
+    storage.upsertJobGradeEntity(name, grade, data)
     jobs[name].grades[grade] = data
     TriggerEvent('qbx_core:server:onJobUpdate', name, jobs[name])
     TriggerClientEvent('qbx_core:client:onJobUpdate', -1, name, jobs[name])
@@ -178,7 +180,7 @@ local function upsertGangGrade(name, grade, data)
         lib.print.error("Gang must exist to edit grades. Not found:", name)
         return
     end
-    UpsertGangGradeEntity(name, grade, data)
+    storage.upsertGangGradeEntity(name, grade, data)
     gangs[name].grades[grade] = data
     TriggerEvent('qbx_core:server:onGangUpdate', name, gangs[name])
     TriggerClientEvent('qbx_core:client:onGangUpdate', -1, name, gangs[name])
@@ -193,7 +195,7 @@ local function removeJobGrade(name, grade)
         lib.print.error("Job must exist to edit grades. Not found:", name)
         return
     end
-    DeleteJobGradeEntity(name, grade)
+    storage.deleteJobGradeEntity(name, grade)
     jobs[name].grades[grade] = nil
     TriggerEvent('qbx_core:server:onJobUpdate', name, jobs[name])
     TriggerClientEvent('qbx_core:client:onJobUpdate', -1, name, jobs[name])
@@ -208,7 +210,7 @@ local function removeGangGrade(name, grade)
         lib.print.error("Gang must exist to edit grades. Not found:", name)
         return
     end
-    DeleteGangGradeEntity(name, grade)
+    storage.deleteGangGradeEntity(name, grade)
     gangs[name].grades[grade] = nil
     TriggerEvent('qbx_core:server:onGangUpdate', name, gangs[name])
     TriggerClientEvent('qbx_core:client:onGangUpdate', -1, name, gangs[name])
@@ -217,21 +219,21 @@ end
 exports('RemoveGangGrade', removeGangGrade)
 
 local function loadGroups()
-    local fetchedJobs, fetchedGangs = FetchGroups()
+    local fetchedJobs, fetchedGangs = storage.fetchGroups()
     local configJobs = require 'shared.jobs'
     local configGangs = require 'shared.gangs'
 
     for name, job in pairs(configJobs) do
         if not fetchedJobs[name] then
             jobs[name] = job
-            UpsertJob(name, job)
+            storage.upsertJob(name, job)
         end
     end
 
     for name, gang in pairs(configGangs) do
         if not fetchedGangs[name] then
             gangs[name] = gang
-            UpsertGang(name, gang)
+            storage.upsertGang(name, gang)
         end
     end
 

--- a/server/player.lua
+++ b/server/player.lua
@@ -602,7 +602,7 @@ function DeleteCharacter(source, citizenid)
     local result = storage.fetchPlayerEntity(citizenid).license
     if license == result or license2 == result then
         CreateThread(function()
-            local success = deletePlayerEntity(citizenid)
+            local success = storage.deletePlayer(citizenid)
             if success then
                 logger.log({
                     source = 'qbx_core',
@@ -636,7 +636,7 @@ function ForceDeleteCharacter(citizenid)
         end
 
         CreateThread(function()
-            local success = deletePlayerEntity(citizenid)
+            local success = storage.deletePlayer(citizenid)
             if success then
                 logger.log({
                     source = 'qbx_core',

--- a/server/storage/groups.lua
+++ b/server/storage/groups.lua
@@ -69,7 +69,7 @@ end
 
 ---@return table<string, Job>
 ---@return table<string, Gang>
-function FetchGroups()
+local function fetchGroups()
     local jobs = {}
     local gangs = {}
 
@@ -108,31 +108,31 @@ end
 
 ---@param name string
 ---@param data JobData
-function UpsertJobEntity(name, data)
+local function upsertJobEntity(name, data)
     upsertGroupEntity(name, GroupType.JOB, data)
 end
 
 ---@param job string
 ---@param grade integer
 ---@param data JobGradeData
-function UpsertJobGradeEntity(job, grade, data)
+local function upsertJobGradeEntity(job, grade, data)
     upsertGradeEntity(job, GroupType.JOB, grade, data)
 end
 
 ---@param name string
-function DeleteJobEntity(name)
+local function deleteJobEntity(name)
     deleteGroupEntity(name, GroupType.JOB)
 end
 
 ---@param name string
 ---@param grade integer
-function DeleteJobGradeEntity(name, grade)
+local function deleteJobGradeEntity(name, grade)
     deleteGradeEntity(name, GroupType.JOB, grade)
 end
 
 ---@param name string
 ---@param job Job
-function UpsertJob(name, job)
+local function upsertJob(name, job)
     local jobEntityData = {
         defaultDuty = job.defaultDuty,
         label = job.label,
@@ -172,31 +172,31 @@ end
 
 ---@param name string
 ---@param data GangData
-function UpsertGangEntity(name, data)
+local function upsertGangEntity(name, data)
     upsertGroupEntity(name, GroupType.GANG, data)
 end
 
 ---@param gang string
 ---@param grade integer
 ---@param data GangGradeData
-function UpsertGangGradeEntity(gang, grade, data)
+local function upsertGangGradeEntity(gang, grade, data)
     upsertGradeEntity(gang, GroupType.GANG, grade, data)
 end
 
 ---@param name string
-function DeleteGangEntity(name)
+local function deleteGangEntity(name)
     deleteGroupEntity(name, GroupType.GANG)
 end
 
 ---@param name string
 ---@param grade integer
-function DeleteGangGradeEntity(name, grade)
+local function deleteGangGradeEntity(name, grade)
     deleteGradeEntity(name, GroupType.GANG, grade)
 end
 
 ---@param name string
 ---@param gang Gang
-function UpsertGang(name, gang)
+local function upsertGang(name, gang)
     local gangEntityData = {
         label = gang.label
     }
@@ -226,3 +226,17 @@ function UpsertGang(name, gang)
 
     MySQL.transaction.await(queries)
 end
+
+return {
+    fetchGroups = fetchGroups,
+    upsertJobEntity = upsertJobEntity,
+    upsertJobGradeEntity = upsertJobGradeEntity,
+    deleteJobEntity = deleteJobEntity,
+    deleteJobGradeEntity = deleteJobGradeEntity,
+    upsertJob = upsertJob,
+    upsertGangEntity = upsertGangEntity,
+    upsertGangGradeEntity = upsertGangGradeEntity,
+    deleteGangEntity = deleteGangEntity,
+    deleteGangGradeEntity = deleteGangGradeEntity,
+    upsertGang = upsertGang,
+}

--- a/server/storage/main.lua
+++ b/server/storage/main.lua
@@ -29,4 +29,5 @@ local groups = require 'server.storage.groups'
 ---@field removePlayerFromGang fun(citizenid: string, group: string)
 
 ---@type StorageFunctions
-return lib.table.merge(players, groups)
+local storage = lib.table.merge(players, groups)
+return storage

--- a/server/storage/main.lua
+++ b/server/storage/main.lua
@@ -1,0 +1,32 @@
+local players = require 'server.storage.players'
+local groups = require 'server.storage.groups'
+
+---@class StorageFunctions
+---@field fetchGroups fun(): table<string, Job>, table<string, Gang>
+---@field upsertJobEntity fun(name: string, data: JobData)
+---@field upsertJobGradeEntity fun(job: string, grade: integer, data: JobGradeData)
+---@field deleteJobEntity fun(name: string)
+---@field deleteJobGradeEntity fun(name: string, grade: integer)
+---@field upsertJob fun(name: string, job: Job)
+---@field upsertGangEntity fun(name: string, data: GangData)
+---@field upsertGangGradeEntity fun(gang: string, grade: integer, data: GangGradeData)
+---@field deleteGangEntity fun(name: string)
+---@field deleteGangGradeEntity fun(name: string, grade: integer)
+---@field upsertGang fun(name: string, gang: Gang)
+---@field insertBan fun(request: InsertBanRequest)
+---@field fetchBan fun(request: GetBanRequest): BanEntity?
+---@field deleteBan fun(request: GetBanRequest)
+---@field upsertPlayerEntity fun(request: UpsertPlayerRequest)
+---@field fetchPlayerSkin fun(citizenId: string): PlayerSkin?
+---@field fetchPlayerEntity fun(citizenId: string): PlayerEntity?
+---@field fetchAllPlayerEntities fun(license2: string, license?: string): PlayerEntity[]
+---@field deletePlayer fun(citizenId: string): boolean success
+---@field fetchIsUnique fun(type: UniqueIdType, value: string|number): boolean
+---@field addPlayerToJob fun(citizenid: string, group: string, grade: integer)
+---@field addPlayerToGang fun(citizenid: string, group: string, grade: integer)
+---@field fetchPlayerGroups fun(citizenid: string): table<string, Job>, table<string, Gang>
+---@field removePlayerFromJob fun(citizenid: string, group: string)
+---@field removePlayerFromGang fun(citizenid: string, group: string)
+
+---@type StorageFunctions
+return lib.table.merge(players, groups)

--- a/server/storage/players.lua
+++ b/server/storage/players.lua
@@ -226,7 +226,7 @@ end
 ---deletes character data using the characterDataTables object in the config file
 ---@param citizenId string
 ---@return boolean success if operation is successful.
-local function deletePlayerEntity(citizenId)
+local function deletePlayer(citizenId)
     local query = "DELETE FROM %s WHERE %s = ?"
     local queries = {}
 
@@ -333,7 +333,7 @@ return {
     fetchPlayerSkin = fetchPlayerSkin,
     fetchPlayerEntity = fetchPlayerEntity,
     fetchAllPlayerEntities = fetchAllPlayerEntities,
-    deletePlayer = deletePlayerEntity,
+    deletePlayer = deletePlayer,
     fetchIsUnique = fetchIsUnique,
     addPlayerToJob = addPlayerToJob,
     addPlayerToGang = addPlayerToGang,

--- a/server/storage/players.lua
+++ b/server/storage/players.lua
@@ -11,7 +11,7 @@ local characterDataTables = require 'config.server'.characterDataTables
 ---@field expiration integer epoch second that the ban will expire
 
 ---@param request InsertBanRequest
-function InsertBanEntity(request)
+local function insertBanEntity(request)
     if not request.discordId and not request.ip and not request.license then
         error("no identifier provided")
     end
@@ -53,7 +53,7 @@ end
 
 ---@param request GetBanRequest
 ---@return BanEntity?
-function FetchBanEntity(request)
+local function fetchBan(request)
     local column, value = getBanId(request)
     local result = MySQL.single.await('SELECT * FROM bans WHERE ' ..column.. ' = ?', { value })
     return result and {
@@ -63,7 +63,7 @@ function FetchBanEntity(request)
 end
 
 ---@param request GetBanRequest
-function DeleteBanEntity(request)
+local function deleteBan(request)
     local column, value = getBanId(request)
     MySQL.query.await('DELETE FROM bans WHERE ' ..column.. ' = ?', { value })
 end
@@ -73,7 +73,7 @@ end
 ---@field position vector3
 
 ---@param request UpsertPlayerRequest
-function UpsertPlayerEntity(request)
+local function upsertPlayerEntity(request)
     MySQL.insert.await('INSERT INTO players (citizenid, cid, license, name, money, charinfo, job, gang, position, metadata) VALUES (:citizenid, :cid, :license, :name, :money, :charinfo, :job, :gang, :position, :metadata) ON DUPLICATE KEY UPDATE name = :name, money = :money, charinfo = :charinfo, job = :job, gang = :gang, position = :position, metadata = :metadata', {
         citizenid = request.playerEntity.citizenid,
         cid = request.playerEntity.charinfo.cid,
@@ -172,7 +172,7 @@ end
 
 ---@param citizenId string
 ---@return PlayerSkin?
-function FetchPlayerSkin(citizenId)
+local function fetchPlayerSkin(citizenId)
     return MySQL.single.await('SELECT * FROM playerskins WHERE citizenid = ? AND active = 1', {citizenId})
 end
 
@@ -185,7 +185,7 @@ end
 ---@param license2 string
 ---@param license? string
 ---@return PlayerEntity[]
-function FetchAllPlayerEntities(license2, license)
+local function fetchAllPlayerEntities(license2, license)
     ---@type PlayerEntity[]
     local chars = {}
     ---@type PlayerEntityDatabase[]
@@ -205,7 +205,7 @@ end
 
 ---@param citizenId string
 ---@return PlayerEntity?
-function FetchPlayerEntity(citizenId)
+local function fetchPlayerEntity(citizenId)
     ---@type PlayerEntityDatabase
     local player = MySQL.prepare.await('SELECT * FROM players where citizenid = ?', { citizenId })
     local charinfo = json.decode(player.charinfo)
@@ -226,7 +226,7 @@ end
 ---deletes character data using the characterDataTables object in the config file
 ---@param citizenId string
 ---@return boolean success if operation is successful.
-function DeletePlayerEntity(citizenId)
+local function deletePlayerEntity(citizenId)
     local query = "DELETE FROM %s WHERE %s = ?"
     local queries = {}
 
@@ -247,7 +247,7 @@ end
 ---@param type UniqueIdType
 ---@param value string|number
 ---@return boolean isUnique if the value does not already exist in storage for the given type
-function FetchIsUnique(type, value)
+local function fetchIsUnique(type, value)
     local typeToColumn = {
         citizenid = "citizenid",
         AccountNumber = "JSON_VALUE(charinfo, '$.account')",
@@ -277,21 +277,21 @@ end
 ---@param citizenid string
 ---@param group string
 ---@param grade integer
-function AddPlayerToJob(citizenid, group, grade)
+local function addPlayerToJob(citizenid, group, grade)
     addToGroup(citizenid, GroupType.JOB, group, grade)
 end
 
 ---@param citizenid string
 ---@param group string
 ---@param grade integer
-function AddPlayerToGang(citizenid, group, grade)
+local function addPlayerToGang(citizenid, group, grade)
     addToGroup(citizenid, GroupType.GANG, group, grade)
 end
 
 ---@param citizenid string
 ---@return table<string, integer> jobs
 ---@return table<string, integer> gangs
-function FetchPlayerGroups(citizenid)
+local function fetchPlayerGroups(citizenid)
     local groups = MySQL.query.await('SELECT `group`, type, grade FROM player_groups WHERE citizenid = ?', {citizenid})
     local jobs = {}
     local gangs = {}
@@ -315,12 +315,29 @@ end
 
 ---@param citizenid string
 ---@param group string
-function RemovePlayerFromJob(citizenid, group)
+local function removePlayerFromJob(citizenid, group)
     removeFromGroup(citizenid, GroupType.JOB, group)
 end
 
 ---@param citizenid string
 ---@param group string
-function RemovePlayerFromGang(citizenid, group)
+local function removePlayerFromGang(citizenid, group)
     removeFromGroup(citizenid, GroupType.GANG, group)
 end
+
+return {
+    insertBan = insertBanEntity,
+    fetchBan = fetchBan,
+    deleteBan = deleteBan,
+    upsertPlayerEntity = upsertPlayerEntity,
+    fetchPlayerSkin = fetchPlayerSkin,
+    fetchPlayerEntity = fetchPlayerEntity,
+    fetchAllPlayerEntities = fetchAllPlayerEntities,
+    deletePlayer = deletePlayerEntity,
+    fetchIsUnique = fetchIsUnique,
+    addPlayerToJob = addPlayerToJob,
+    addPlayerToGang = addPlayerToGang,
+    fetchPlayerGroups = fetchPlayerGroups,
+    removePlayerFromJob = removePlayerFromJob,
+    removePlayerFromGang = removePlayerFromGang,
+}

--- a/server/storage/players.lua
+++ b/server/storage/players.lua
@@ -11,7 +11,7 @@ local characterDataTables = require 'config.server'.characterDataTables
 ---@field expiration integer epoch second that the ban will expire
 
 ---@param request InsertBanRequest
-local function insertBanEntity(request)
+local function insertBan(request)
     if not request.discordId and not request.ip and not request.license then
         error("no identifier provided")
     end
@@ -326,7 +326,7 @@ local function removePlayerFromGang(citizenid, group)
 end
 
 return {
-    insertBan = insertBanEntity,
+    insertBan = insertBan,
     fetchBan = fetchBan,
     deleteBan = deleteBan,
     upsertPlayerEntity = upsertPlayerEntity,


### PR DESCRIPTION
Mainly doing this to more easily distinguish storage functions from other functions.
- renamed a few functions where it made sense. Naming can be more broad since we now have a storage prefix to know that it's in the context of storage.