### PR TITLE
feat: multi job/group implementation

### DIFF
--- a/config/server.lua
+++ b/config/server.lua
@@ -137,7 +137,4 @@ return {
     removeSocietyMoney = function(accountName, payment)
         return exports['Renewed-Banking']:removeAccountMoney(accountName, payment)
     end,
-
-    maxJobsPerPlayer = 1,
-    maxGangsPerPlayer = 1,
 }

--- a/config/server.lua
+++ b/config/server.lua
@@ -136,5 +136,8 @@ return {
 
     removeSocietyMoney = function(accountName, payment)
         return exports['Renewed-Banking']:removeAccountMoney(accountName, payment)
-    end
+    end,
+
+    maxJobsPerPlayer = 1,
+    maxGangsPerPlayer = 1,
 }

--- a/server/player.lua
+++ b/server/player.lua
@@ -4,6 +4,8 @@ local logger = require 'modules.logger'
 local storage = require 'server.storage.main'
 
 ---@class PlayerData : PlayerEntity
+---@field jobs table<string, integer>
+---@field groups table<string, integer>
 ---@field source? Source present if player is online
 ---@field optin? boolean present if player is online
 
@@ -60,6 +62,250 @@ function GetOfflinePlayer(citizenid)
 end
 
 exports('GetOfflinePlayer', GetOfflinePlayer)
+
+---Sets a player's job to be primary only if they already have it.
+---@param citizenid string
+---@param jobName string
+local function setPlayerPrimaryJob(citizenid, jobName)
+    local player = GetPlayerByCitizenId(citizenid) or GetOfflinePlayer(citizenid)
+    if not player then
+        error(("player not found with citizenid %s"):format(citizenid))
+    end
+    local grade = player.PlayerData.jobs[jobName]
+    if not grade then
+        error(("player %s does not have job %s"):format(citizenid, jobName))
+    end
+    local job = GetJob(jobName)
+    if not job then
+        error("job not found: " .. jobName)
+    end
+
+    if not job.grades[grade] then
+        error(("job %s does not have grade %s"):format(jobName, grade))
+    end
+
+    player.PlayerData.job = {
+        name = jobName,
+        label = job.label,
+        isboss = job.grades[grade].isboss,
+        onduty = job.defaultDuty,
+        payment = job.grades[grade].payment,
+        type = job.type,
+        grade = {
+            name = job.grades[grade].name,
+            level = grade
+        }
+    }
+
+    player.Functions.Save()
+
+    if not player.Offline then
+        player.Functions.UpdatePlayerData()
+        TriggerEvent('QBCore:Server:OnJobUpdate', player.PlayerData.source, player.PlayerData.job)
+        TriggerClientEvent('QBCore:Client:OnJobUpdate', player.PlayerData.source, player.PlayerData.job)
+    end
+end
+
+exports('SetPlayerPrimaryJob', setPlayerPrimaryJob)
+
+---Adds a player to the job or overwrites their grade for a job already held
+---@param citizenid string
+---@param jobName string
+---@param grade integer
+local function addPlayerToJob(citizenid, jobName, grade)
+    local job = GetJob(jobName)
+
+    if not job then
+        error("job not found: " .. jobName)
+    end
+
+    if not job.grades[grade] then
+        error(("job %s does not have grade %s"):format(jobName, grade))
+    end
+
+    local player = GetPlayerByCitizenId(citizenid) or GetOfflinePlayer(citizenid)
+    if not player then
+        error(("player not found with citizenid %s"):format(citizenid))
+    end
+
+    if player.PlayerData.jobs[jobName] == grade then return end
+
+
+    if #player.PlayerData.jobs >= config.maxJobsPerPlayer and not player.PlayerData.jobs[jobName] then
+        error("player already has maximum amount of jobs allowed")
+    end
+
+    storage.addPlayerToJob(citizenid, jobName, grade)
+    if not player.Offline then
+        player.PlayerData.jobs[jobName] = grade
+        player.Functions.SetPlayerData('jobs', player.PlayerData.jobs)
+    end
+    if player.PlayerData.job.name == jobName then
+        setPlayerPrimaryJob(citizenid, jobName)
+    end
+end
+
+exports('AddPlayerToJob', addPlayerToJob)
+
+---If the job removed from is primary, sets the primary job to unemployed.
+---@param citizenid string
+---@param jobName string
+local function removePlayerFromJob(citizenid, jobName)
+    local player = GetPlayerByCitizenId(citizenid) or GetOfflinePlayer(citizenid)
+    if not player then
+        error(("player not found with citizenid %s"):format(citizenid))
+    end
+
+    if not player.PlayerData.jobs[jobName] then
+        error(("player %s does not have job %s"):format(citizenid, jobName))
+    end
+
+    storage.removePlayerFromJob(citizenid, jobName)
+    player.PlayerData.jobs[jobName] = nil
+    if player.PlayerData.job.name == jobName then
+        local job = GetJob('unemployed')
+        if not job then
+            error("cannot find unemployed job. Check database/config")
+        end
+        player.PlayerData.job = {
+            name = jobName,
+            label = job.label,
+            isboss = false,
+            onduty = job.defaultDuty,
+            payment = job.grades[0].payment,
+            grade = {
+                name = job.grades[0].name,
+                level = 0
+            }
+        }
+        player.Functions.Save()
+    end
+
+    if not player.Offline then
+        player.Functions.SetPlayerData('jobs', player.PlayerData.jobs)
+    end
+end
+
+exports('RemovePlayerFromJob', removePlayerFromJob)
+
+---Sets a player's gang to be primary only if they already have it.
+---@param citizenid string
+---@param gangName string
+local function setPlayerPrimaryGang(citizenid, gangName)
+    local player = GetPlayerByCitizenId(citizenid) or GetOfflinePlayer(citizenid)
+    if not player then
+        error(("player not found with citizenid %s"):format(citizenid))
+    end
+    local grade = player.PlayerData.gangs[gangName]
+    if not grade then
+        error(("player %s does not have gang %s"):format(citizenid, gangName))
+    end
+    local gang = GetGang(gangName)
+    if not gang then
+        error("gang not found: " .. gangName)
+    end
+
+    if not gang.grades[grade] then
+        error(("gang %s does not have grade %s"):format(gangName, grade))
+    end
+
+    player.PlayerData.gang = {
+        name = gangName,
+        label = gang.label,
+        isboss = gang.grades[grade].isboss,
+        grade = {
+            name = gang.grades[grade].name,
+            level = grade
+        }
+    }
+
+    player.Functions.Save()
+
+    if not player.Offline then
+        player.Functions.UpdatePlayerData()
+        TriggerEvent('QBCore:Server:OnGangUpdate', player.PlayerData.source, player.PlayerData.gang)
+        TriggerClientEvent('QBCore:Client:OnGangUpdate', player.PlayerData.source, player.PlayerData.gang)
+    end
+end
+
+exports('SetPlayerPrimaryGang', setPlayerPrimaryGang)
+
+---Adds a player to the gang or overwrites their grade if already in the gang
+---@param citizenid string
+---@param gangName string
+---@param grade integer
+local function addPlayerToGang(citizenid, gangName, grade)
+    local gang = GetGang(gangName)
+
+    if not gang then
+        error("gang not found: " .. gangName)
+    end
+
+    if not gang.grades[grade] then
+        error(("gang %s does not have grade %s"):format(gangName, grade))
+    end
+
+    local player = GetPlayerByCitizenId(citizenid) or GetOfflinePlayer(citizenid)
+    if not player then
+        error(("player not found with citizenid %s"):format(citizenid))
+    end
+
+    if player.PlayerData.gangs[gangName] == grade then return end
+
+    if #player.PlayerData.gangs >= config.maxGangsPerPlayer and not player.PlayerData.gangs[gangName] then
+        error("player already has maximum amount of gangs allowed")
+    end
+
+    storage.addPlayerToGang(citizenid, gangName, grade)
+    if not player.Offline then
+        player.PlayerData.gangs[gangName] = grade
+        player.Functions.SetPlayerData('gangs', player.PlayerData.gangs)
+    end
+    if player.PlayerData.gang.name == gangName then
+        setPlayerPrimaryGang(citizenid, gangName)
+    end
+end
+
+exports('AddPlayerToGang', addPlayerToGang)
+
+---Remove a player from a gang, setting them to the default no gang.
+---@param citizenid string
+---@param gangName string
+local function removePlayerFromGang(citizenid, gangName)
+    local player = GetPlayerByCitizenId(citizenid) or GetOfflinePlayer(citizenid)
+    if not player then
+        error(("player not found with citizenid %s"):format(citizenid))
+    end
+
+    if not player.PlayerData.gangs[gangName] then
+        error(("player %s does not have gang %s"):format(citizenid, gangName))
+    end
+
+    storage.removePlayerFromGang(citizenid, gangName)
+    player.PlayerData.gangs[gangName] = nil
+    if player.PlayerData.gang.name == gangName then
+        local gang = GetGang('none')
+        if not gang then
+            error("cannot find none gang. Check database/config")
+        end
+        player.PlayerData.gang = {
+            name = gangName,
+            label = gang.label,
+            isboss = false,
+            grade = {
+                name = gang.grades[0].name,
+                level = 0
+            }
+        }
+        player.Functions.Save()
+    end
+
+    if not player.Offline then
+        player.Functions.SetPlayerData('gangs', player.PlayerData.gangs)
+    end
+end
+
+exports('RemovePlayerFromGang', removePlayerFromGang)
 
 ---@param source? integer if player is online
 ---@param playerData? PlayerEntity|PlayerData
@@ -141,6 +387,7 @@ function CheckPlayerData(source, playerData)
         SerialNumber = GenerateUniqueIdentifier('SerialNumber'),
         InstalledApps = {},
     }
+    local jobs, gangs = storage.fetchPlayerGroups(playerData.citizenid)
     -- Job
     if playerData.job and playerData.job.name and not GetJob(playerData.job.name) then playerData.job = nil end
     playerData.job = playerData.job or {}
@@ -155,6 +402,7 @@ function CheckPlayerData(source, playerData)
     playerData.job.grade = playerData.job.grade or {}
     playerData.job.grade.name = playerData.job.grade.name or 'Freelancer'
     playerData.job.grade.level = playerData.job.grade.level or 0
+    playerData.jobs = jobs or {}
     -- Gang
     if playerData.gang and playerData.gang.name and not GetGang(playerData.gang.name) then playerData.gang = nil end
     playerData.gang = playerData.gang or {}
@@ -164,6 +412,7 @@ function CheckPlayerData(source, playerData)
     playerData.gang.grade = playerData.gang.grade or {}
     playerData.gang.grade.name = playerData.gang.grade.name or 'none'
     playerData.gang.grade.level = playerData.gang.grade.level or 0
+    playerData.gangs = gangs or {}
     -- Other
     playerData.position = playerData.position or defaultSpawn
     playerData.items = GetResourceState('qb-inventory') ~= 'missing' and exports['qb-inventory']:LoadInventory(playerData.source, playerData.citizenid) or {}
@@ -228,6 +477,7 @@ function CreatePlayer(playerData, Offline)
         TriggerClientEvent('QBCore:Player:SetPlayerData', self.PlayerData.source, self.PlayerData)
     end
 
+    ---Overwrites current primary job with a new job. Removing the player from their current primary job
     ---@param job string name
     ---@param grade integer
     ---@return boolean success if job was set
@@ -240,6 +490,8 @@ function CreatePlayer(playerData, Offline)
         self.PlayerData.job.onduty = GetJob(job).defaultDuty
         self.PlayerData.job.type = GetJob(job).type or 'none'
         if GetJob(job).grades[grade] then
+            removePlayerFromJob(self.PlayerData.citizenid, job)
+            addPlayerToJob(self.PlayerData.citizenid, job, grade)
             local jobgrade = GetJob(job).grades[grade]
             self.PlayerData.job.grade = {}
             self.PlayerData.job.grade.name = jobgrade.name
@@ -263,6 +515,7 @@ function CreatePlayer(playerData, Offline)
         return true
     end
 
+    ---Removes the player from their current primary gang and adds the player to the new gang
     ---@param gang string name
     ---@param grade integer
     ---@return boolean success if gang was set
@@ -273,6 +526,8 @@ function CreatePlayer(playerData, Offline)
         self.PlayerData.gang.name = gang
         self.PlayerData.gang.label = GetGang(gang).label
         if GetGang(gang).grades[grade] then
+            removePlayerFromGang(self.PlayerData.citizenid, gang)
+            addPlayerToGang(self.PlayerData.citizenid, gang, grade)
             local ganggrade = GetGang(gang).grades[grade]
             self.PlayerData.gang.grade = {}
             self.PlayerData.gang.grade.name = ganggrade.name

--- a/server/player.lua
+++ b/server/player.lua
@@ -2,6 +2,8 @@ local config = require 'config.server'
 local defaultSpawn = require 'config.shared'.defaultSpawn
 local logger = require 'modules.logger'
 local storage = require 'server.storage.main'
+local maxJobsPerPlayer = GetConvarInt('qbx:maxjobsperplayer', 1)
+local maxGangsPerPlayer = GetConvarInt('qbx:maxgangsperplayer', 1)
 
 ---@class PlayerData : PlayerEntity
 ---@field jobs table<string, integer>
@@ -131,7 +133,7 @@ local function addPlayerToJob(citizenid, jobName, grade)
     if player.PlayerData.jobs[jobName] == grade then return end
 
 
-    if #player.PlayerData.jobs >= config.maxJobsPerPlayer and not player.PlayerData.jobs[jobName] then
+    if #player.PlayerData.jobs >= maxJobsPerPlayer and not player.PlayerData.jobs[jobName] then
         error("player already has maximum amount of jobs allowed")
     end
 
@@ -252,7 +254,7 @@ local function addPlayerToGang(citizenid, gangName, grade)
 
     if player.PlayerData.gangs[gangName] == grade then return end
 
-    if #player.PlayerData.gangs >= config.maxGangsPerPlayer and not player.PlayerData.gangs[gangName] then
+    if #player.PlayerData.gangs >= maxGangsPerPlayer and not player.PlayerData.gangs[gangName] then
         error("player already has maximum amount of gangs allowed")
     end
 

--- a/server/storage/players.lua
+++ b/server/storage/players.lua
@@ -153,7 +153,7 @@ end
 ---@field name string
 ---@field label string
 ---@field payment number
----@field type string
+---@field type? string
 ---@field onduty boolean
 ---@field isboss boolean
 ---@field grade {name: string, level: number}

--- a/shared/gangs.lua
+++ b/shared/gangs.lua
@@ -1,3 +1,5 @@
+--- This config is only used for initially populating the database. Once a gang is in the database, modifying or removing the gang will have no effect. Instead, either use core exports or modify the data in the database directly (only when the server is offline!)
+
 ---@type table<string, Gang>
 return {
 	['none'] = {

--- a/shared/jobs.lua
+++ b/shared/jobs.lua
@@ -1,3 +1,5 @@
+--- This config is only used for initially populating the database. Once a job is in the database, modifying or removing the job will have no effect. Instead, either use core exports or modify the data in the database directly (only when the server is offline!)
+
 ---@type table<string, Job>
 return {
 	['unemployed'] = {


### PR DESCRIPTION
- Introduces new playerdata jobs & gangs tables to hold key value data of all the player's groups (name & grade), including the primary. The only exception is the unemployed/none groups so that these don't contribute to the player limit.
- The existing playerdata.job/gang is the primary group, and is populated with all the data about that group and grade.
- New exports added for managing player jobs/gangs (add, remove, set primary)
- To maintain backwards compatibility, SetJob & SetGang will replace the primary job rather than act as an alias for Add.
- New config options to limit the total number of jobs/gangs a single player may hold at a time

The multi-group system is not optional and cannot be disabled. While using external multigroup systems is still possible, unless they use the exports to propagate the data to the qbox multi-group, it may break other scripts that rely on that data being accurate. I considered a way to make it optional, but doing so would have the opposite effect of making it so that other scripts couldn't rely on the built-in multi-group functionality.