### PR TITLE
fix(bridge): core not loading

### DIFF
--- a/bridge/qb/client/main.lua
+++ b/bridge/qb/client/main.lua
@@ -6,7 +6,11 @@ require 'bridge.qb.client.events'
 local qbCoreCompat = {}
 qbCoreCompat.PlayerData = QBX.PlayerData
 qbCoreCompat.Config = lib.table.merge(require 'config.client', require 'config.shared')
+
 qbCoreCompat.Shared = require 'bridge.qb.shared.main'
+qbCoreCompat.Shared.Jobs = {}
+qbCoreCompat.Shared.Gangs = {}
+
 qbCoreCompat.Functions = require 'bridge.qb.client.functions'
 
 ---@deprecated use https://overextended.github.io/docs/ox_lib/Callback/Lua/Client/ instead
@@ -73,4 +77,15 @@ end)
 
 RegisterNetEvent('qbx_core:client:onGangUpdate', function(gangName, gang)
     qbCoreCompat.Shared.Gangs[gangName] = gang
+end)
+
+lib.callback('qbx_core:server:getJobs', false, function(jobs)
+    for jobName, job in pairs(jobs) do
+        TriggerEvent('qbx_core:client:onJobUpdate', jobName, job)
+    end
+end)
+lib.callback('qbx_core:server:getGangs', false, function(gangs)
+    for gangName, gang in pairs(gangs) do
+        TriggerEvent('qbx_core:client:onGangUpdate', gangName, gang)
+    end
 end)

--- a/bridge/qb/server/main.lua
+++ b/bridge/qb/server/main.lua
@@ -7,6 +7,8 @@ local qbCoreCompat = {}
 
 qbCoreCompat.Config = lib.table.merge(require 'config.server', require 'config.shared')
 qbCoreCompat.Shared = require 'bridge.qb.shared.main'
+qbCoreCompat.Shared.Jobs = GetJobs()
+qbCoreCompat.Shared.Gangs = GetGangs()
 qbCoreCompat.Players = QBX.Players
 qbCoreCompat.Player = require 'bridge.qb.server.player'
 qbCoreCompat.Player_Buckets = QBX.Player_Buckets

--- a/bridge/qb/shared/main.lua
+++ b/bridge/qb/shared/main.lua
@@ -50,7 +50,4 @@ qbShared.MaleNoGloves = qbx.armsWithoutGloves.male
 ---@deprecated use qbx.armsWithoutGloves.female from modules/lib.lua
 qbShared.FemaleNoGloves = qbx.armsWithoutGloves.female
 
-qbShared.Jobs = IsDuplicityVersion() and GetJobs() or lib.callback.await('qbx_core:server:getJobs')
-qbShared.Gangs = IsDuplicityVersion() and GetGangs() or lib.callback.await('qbx_core:server:getGangs')
-
 return qbShared


### PR DESCRIPTION
Fixes an issue where the core didn't finish loading before other resources loaded. Doing a lib.callback.await doesn't block other resources from loading, but does block core. To get around this, the jobs/gangs tables of bridge are initialized to empty tables and then will be populated asynchronously once the lib callback returns. The event is then triggered to simulate as if these groups were added via export. 