### PR TITLE
fix(server): error when disabling queue

### DIFF
--- a/server/main.lua
+++ b/server/main.lua
@@ -1,5 +1,5 @@
 lib.versionCheck('Qbox-project/qbx_core')
-if not lib.checkDependency('ox_lib', '3.10.0', true) then error() return end
+if not lib.checkDependency('ox_lib', '3.16.3', true) then error() return end
 
 ---@type 'strict'|'relaxed'|'inactive'
 local bucketLockDownMode = GetConvar('qbx:bucketlockdownmode', 'inactive')

--- a/server/queue.lua
+++ b/server/queue.lua
@@ -1,4 +1,4 @@
-if GetConvar('qbx:enablequeue', 'true') == 'false' then return end
+if GetConvar('qbx:enablequeue', 'true') == 'false' then return false end
 
 -- Disable hardcap because it kicks the player when the server is full
 


### PR DESCRIPTION
## Description

<!-- What does your pull request change? Why should it be merged? Does it fix an issue? -->

Fixes the issue described in https://github.com/Qbox-project/qbx_core/issues/367#issuecomment-1946603716.

Bump ox_lib to a version that includes a fix for returning `false` from required modules (overextended/ox_lib#502), and return `false` from `queue.lua` when it's disabled (`events.lua` already detects when it returns a falsy value).

## Checklist

<!-- Put an x inside the [ ] to check an item, like so: [x] -->

- [x] I have personally loaded this code into an updated Qbox project and checked all of its functionality.
- [x] My pull request fits the contribution guidelines & code conventions.
