### PR TITLE
fix(server/player): use job/gang data as source of truth instead of playerdata

### DIFF
--- a/server/player.lua
+++ b/server/player.lua
@@ -390,32 +390,40 @@ function CheckPlayerData(source, playerData)
         InstalledApps = {},
     }
     local jobs, gangs = storage.fetchPlayerGroups(playerData.citizenid)
-    -- Job
-    if playerData.job and playerData.job.name and not GetJob(playerData.job.name) then playerData.job = nil end
-    playerData.job = playerData.job or {}
-    playerData.job.name = playerData.job.name or 'unemployed'
-    playerData.job.label = playerData.job.label or 'Civilian'
-    playerData.job.payment = playerData.job.payment or 10
-    playerData.job.type = playerData.job.type or 'none'
-    if QBX.Shared.ForceJobDefaultDutyAtLogin or playerData.job.onduty == nil then
-        playerData.job.onduty = GetJob(playerData.job.name).defaultDuty
+
+    local job = GetJob(playerData.job?.name) or GetJob('unemployed')
+    if not job then
+        error("unemployed job not found. Is it in your config and/or database?")
     end
-    playerData.job.isboss = playerData.job.isboss or false
-    playerData.job.grade = playerData.job.grade or {}
-    playerData.job.grade.name = playerData.job.grade.name or 'Freelancer'
-    playerData.job.grade.level = playerData.job.grade.level or 0
+    local jobGrade = GetJob(playerData.job?.name) and playerData.job.grade.level or 0
+    playerData.job = {
+        name = playerData.job.name or 'unemployed',
+        label = job.label,
+        payment = job.grades[jobGrade].payment or 0,
+        type = job.type,
+        onduty = QBX.Shared.ForceJobDefaultDutyAtLogin and job.defaultDuty or playerData.job.onduty,
+        isboss = job.grades[jobGrade].isboss or false,
+        grade = {
+            name = job.grades[jobGrade].name,
+            level = jobGrade,
+        }
+    }
     playerData.jobs = jobs or {}
-    -- Gang
-    if playerData.gang and playerData.gang.name and not GetGang(playerData.gang.name) then playerData.gang = nil end
-    playerData.gang = playerData.gang or {}
-    playerData.gang.name = playerData.gang.name or 'none'
-    playerData.gang.label = playerData.gang.label or 'No Gang Affiliation'
-    playerData.gang.isboss = playerData.gang.isboss or false
-    playerData.gang.grade = playerData.gang.grade or {}
-    playerData.gang.grade.name = playerData.gang.grade.name or 'none'
-    playerData.gang.grade.level = playerData.gang.grade.level or 0
+    local gang = GetGang(playerData.gang?.name) or GetGang('none')
+    if not gang then
+        error("none gang not found. Is it in your config and/or database?")
+    end
+    local gangGrade = GetGang(playerData.gang?.name) and playerData.gang.grade.level or 0
+    playerData.gang = {
+        name = playerData.gang.name or 'none',
+        label = gang.label,
+        isboss = gang.grades[gangGrade].isboss or false,
+        grade = {
+            name = gang.grades[gangGrade].name,
+            level = gangGrade
+        }
+    }
     playerData.gangs = gangs or {}
-    -- Other
     playerData.position = playerData.position or defaultSpawn
     playerData.items = GetResourceState('qb-inventory') ~= 'missing' and exports['qb-inventory']:LoadInventory(playerData.source, playerData.citizenid) or {}
     return CreatePlayer(playerData --[[@as PlayerData]], Offline)

--- a/server/storage/main.lua
+++ b/server/storage/main.lua
@@ -24,7 +24,7 @@ local groups = require 'server.storage.groups'
 ---@field fetchIsUnique fun(type: UniqueIdType, value: string|number): boolean
 ---@field addPlayerToJob fun(citizenid: string, group: string, grade: integer)
 ---@field addPlayerToGang fun(citizenid: string, group: string, grade: integer)
----@field fetchPlayerGroups fun(citizenid: string): table<string, Job>, table<string, Gang>
+---@field fetchPlayerGroups fun(citizenid: string): table<string, integer>, table<string, integer> jobs, gangs
 ---@field removePlayerFromJob fun(citizenid: string, group: string)
 ---@field removePlayerFromGang fun(citizenid: string, group: string)
 


### PR DESCRIPTION
The only thing the stored playerdata.job and .gang will be used for now is the name, grade, and last onduty value. Other fields of job/gang will be derived from the job/gang data. This fixes the potential for stale cached data on the player object. This doesn't change what data is written to the database.