### PR TITLE
fix(server/player): setgang and setjob error handling

### DIFF
--- a/server/player.lua
+++ b/server/player.lua
@@ -158,9 +158,7 @@ local function removePlayerFromJob(citizenid, jobName)
         error(("player not found with citizenid %s"):format(citizenid))
     end
 
-    if not player.PlayerData.jobs[jobName] then
-        error(("player %s does not have job %s"):format(citizenid, jobName))
-    end
+    if not player.PlayerData.jobs[jobName] then return end
 
     storage.removePlayerFromJob(citizenid, jobName)
     player.PlayerData.jobs[jobName] = nil
@@ -480,74 +478,42 @@ function CreatePlayer(playerData, Offline)
     end
 
     ---Overwrites current primary job with a new job. Removing the player from their current primary job
-    ---@param job string name
+    ---@param jobName string name
     ---@param grade integer
     ---@return boolean success if job was set
-    function self.Functions.SetJob(job, grade)
-        job = job or ''
-        grade = tonumber(grade) or 0
-        if not GetJob(job) then return false end
-        self.PlayerData.job.name = job
-        self.PlayerData.job.label = GetJob(job).label
-        self.PlayerData.job.onduty = GetJob(job).defaultDuty
-        self.PlayerData.job.type = GetJob(job).type or 'none'
-        if GetJob(job).grades[grade] then
-            removePlayerFromJob(self.PlayerData.citizenid, job)
-            addPlayerToJob(self.PlayerData.citizenid, job, grade)
-            local jobgrade = GetJob(job).grades[grade]
-            self.PlayerData.job.grade = {}
-            self.PlayerData.job.grade.name = jobgrade.name
-            self.PlayerData.job.grade.level = grade
-            self.PlayerData.job.payment = jobgrade.payment or 30
-            self.PlayerData.job.isboss = jobgrade.isboss or false
-        else
-            self.PlayerData.job.grade = {}
-            self.PlayerData.job.grade.name = 'No Grades'
-            self.PlayerData.job.grade.level = 0
-            self.PlayerData.job.payment = 30
-            self.PlayerData.job.isboss = false
+    function self.Functions.SetJob(jobName, grade)
+        local job = GetJob(jobName)
+        if not job then
+            lib.print.error(("cannot set job. Job %s does not exist"):format(jobName))
+            return false
         end
-
-        if not self.Offline then
-            self.Functions.UpdatePlayerData()
-            TriggerEvent('QBCore:Server:OnJobUpdate', self.PlayerData.source, self.PlayerData.job)
-            TriggerClientEvent('QBCore:Client:OnJobUpdate', self.PlayerData.source, self.PlayerData.job)
+        if not job.grades[grade] then
+            lib.print.error(("cannot set job. Job %s does not have grade %s"):format(jobName, grade))
+            return false
         end
-
+        removePlayerFromJob(self.PlayerData.citizenid, self.PlayerData.job.name)
+        addPlayerToJob(self.PlayerData.citizenid, jobName, grade)
+        setPlayerPrimaryJob(self.PlayerData.citizenid, jobName)
         return true
     end
 
     ---Removes the player from their current primary gang and adds the player to the new gang
-    ---@param gang string name
+    ---@param gangName string name
     ---@param grade integer
     ---@return boolean success if gang was set
-    function self.Functions.SetGang(gang, grade)
-        gang = gang or ''
-        grade = tonumber(grade) or 0
-        if not GetGang(gang) then return false end
-        self.PlayerData.gang.name = gang
-        self.PlayerData.gang.label = GetGang(gang).label
-        if GetGang(gang).grades[grade] then
-            removePlayerFromGang(self.PlayerData.citizenid, gang)
-            addPlayerToGang(self.PlayerData.citizenid, gang, grade)
-            local ganggrade = GetGang(gang).grades[grade]
-            self.PlayerData.gang.grade = {}
-            self.PlayerData.gang.grade.name = ganggrade.name
-            self.PlayerData.gang.grade.level = grade
-            self.PlayerData.gang.isboss = ganggrade.isboss or false
-        else
-            self.PlayerData.gang.grade = {}
-            self.PlayerData.gang.grade.name = 'No Grades'
-            self.PlayerData.gang.grade.level = 0
-            self.PlayerData.gang.isboss = false
+    function self.Functions.SetGang(gangName, grade)
+        local gang = GetGang(gangName)
+        if not gang then
+            lib.print.error(("cannot set gang. Gang %s does not exist"):format(gangName))
+            return false
         end
-
-        if not self.Offline then
-            self.Functions.UpdatePlayerData()
-            TriggerEvent('QBCore:Server:OnGangUpdate', self.PlayerData.source, self.PlayerData.gang)
-            TriggerClientEvent('QBCore:Client:OnGangUpdate', self.PlayerData.source, self.PlayerData.gang)
+        if not gang.grades[grade] then
+            lib.print.error(("cannot set gang. Gang %s does not have grade %s"):format(gangName, grade))
+            return false
         end
-
+        removePlayerFromGang(self.PlayerData.citizenid, self.PlayerData.gang.name)
+        addPlayerToGang(self.PlayerData.citizenid, gangName, grade)
+        setPlayerPrimaryGang(self.PlayerData.citizenid, gangName)
         return true
     end
 

--- a/server/player.lua
+++ b/server/player.lua
@@ -277,9 +277,7 @@ local function removePlayerFromGang(citizenid, gangName)
         error(("player not found with citizenid %s"):format(citizenid))
     end
 
-    if not player.PlayerData.gangs[gangName] then
-        error(("player %s does not have gang %s"):format(citizenid, gangName))
-    end
+    if not player.PlayerData.gangs[gangName] then return end
 
     storage.removePlayerFromGang(citizenid, gangName)
     player.PlayerData.gangs[gangName] = nil

--- a/server/player.lua
+++ b/server/player.lua
@@ -115,6 +115,8 @@ exports('SetPlayerPrimaryJob', setPlayerPrimaryJob)
 ---@param jobName string
 ---@param grade integer
 local function addPlayerToJob(citizenid, jobName, grade)
+    -- unemployed job is the default, so players cannot be added to it
+    if jobName == 'unemployed' then return end
     local job = GetJob(jobName)
 
     if not job then
@@ -153,6 +155,8 @@ exports('AddPlayerToJob', addPlayerToJob)
 ---@param citizenid string
 ---@param jobName string
 local function removePlayerFromJob(citizenid, jobName)
+    -- Unemployed is the default job, so players cannot be removed from it.
+    if jobName == 'unemployed' then return end
     local player = GetPlayerByCitizenId(citizenid) or GetOfflinePlayer(citizenid)
     if not player then
         error(("player not found with citizenid %s"):format(citizenid))
@@ -235,6 +239,8 @@ exports('SetPlayerPrimaryGang', setPlayerPrimaryGang)
 ---@param gangName string
 ---@param grade integer
 local function addPlayerToGang(citizenid, gangName, grade)
+    -- None is the default gang, so players cannot be added to it.
+    if gangName == 'none' then return end
     local gang = GetGang(gangName)
 
     if not gang then
@@ -272,6 +278,8 @@ exports('AddPlayerToGang', addPlayerToGang)
 ---@param citizenid string
 ---@param gangName string
 local function removePlayerFromGang(citizenid, gangName)
+    -- None is the default gang. So players cannot be removed from it.
+    if gangName == 'none' then return end
     local player = GetPlayerByCitizenId(citizenid) or GetOfflinePlayer(citizenid)
     if not player then
         error(("player not found with citizenid %s"):format(citizenid))


### PR DESCRIPTION
- General refactor to make the code more succinct.
- Removed unnecessary default param values
- Changed behavior of the functions to be no-op in the case of the group or grade not existing. Previously it would pick defaults instead, which seems like an undesirable behavior.
- Added error prints
- Changed removeFromJob/removeFromGang behavior when the user doesn't already have the job/gang to be no-op rather than an error scenario to make the function Idempotent. This is also useful because we don't treat the player as having the unemployed job or the none gang.
- Fixes an issue where instead of removing the old job/gang, it was attempting to remove the current one
- Prevent removing/adding to the default groups as the default groups are not tracked in the database.