### PR TITLE
feat: console command convertjobs

### DIFF
--- a/server/player.lua
+++ b/server/player.lua
@@ -114,7 +114,7 @@ exports('SetPlayerPrimaryJob', setPlayerPrimaryJob)
 ---@param citizenid string
 ---@param jobName string
 ---@param grade integer
-local function addPlayerToJob(citizenid, jobName, grade)
+function AddPlayerToJob(citizenid, jobName, grade)
     -- unemployed job is the default, so players cannot be added to it
     if jobName == 'unemployed' then return end
     local job = GetJob(jobName)
@@ -143,7 +143,7 @@ local function addPlayerToJob(citizenid, jobName, grade)
     end
 end
 
-exports('AddPlayerToJob', addPlayerToJob)
+exports('AddPlayerToJob', AddPlayerToJob)
 
 ---If the job removed from is primary, sets the primary job to unemployed.
 ---@param citizenid string
@@ -222,7 +222,7 @@ exports('SetPlayerPrimaryGang', setPlayerPrimaryGang)
 ---@param citizenid string
 ---@param gangName string
 ---@param grade integer
-local function addPlayerToGang(citizenid, gangName, grade)
+function AddPlayerToGang(citizenid, gangName, grade)
     -- None is the default gang, so players cannot be added to it.
     if gangName == 'none' then return end
     local gang = GetGang(gangName)
@@ -256,7 +256,7 @@ local function addPlayerToGang(citizenid, gangName, grade)
     end
 end
 
-exports('AddPlayerToGang', addPlayerToGang)
+exports('AddPlayerToGang', AddPlayerToGang)
 
 ---Remove a player from a gang, setting them to the default no gang.
 ---@param citizenid string
@@ -492,7 +492,7 @@ function CreatePlayer(playerData, Offline)
             return false
         end
         removePlayerFromJob(self.PlayerData.citizenid, self.PlayerData.job.name)
-        addPlayerToJob(self.PlayerData.citizenid, jobName, grade)
+        AddPlayerToJob(self.PlayerData.citizenid, jobName, grade)
         setPlayerPrimaryJob(self.PlayerData.citizenid, jobName)
         return true
     end
@@ -514,7 +514,7 @@ function CreatePlayer(playerData, Offline)
             return false
         end
         removePlayerFromGang(self.PlayerData.citizenid, self.PlayerData.gang.name)
-        addPlayerToGang(self.PlayerData.citizenid, gangName, grade)
+        AddPlayerToGang(self.PlayerData.citizenid, gangName, grade)
         setPlayerPrimaryGang(self.PlayerData.citizenid, gangName)
         return true
     end

--- a/server/storage/players.lua
+++ b/server/storage/players.lua
@@ -335,7 +335,7 @@ RegisterCommand('convertjobs', function(source)
         AddPlayerToJob(player.citizenid, player.jobName, player.jobGrade)
         AddPlayerToGang(player.citizenid, player.gangName, player.gangGrade)
     end
-    TriggerServerEvent('qbx_core:server:jobsconverted')
+    TriggerEvent('qbx_core:server:jobsconverted')
 end, true)
 
 return {

--- a/server/storage/players.lua
+++ b/server/storage/players.lua
@@ -325,6 +325,18 @@ local function removePlayerFromGang(citizenid, group)
     removeFromGroup(citizenid, GroupType.GANG, group)
 end
 
+---Copies player's primary job/gang to the player_groups table. Works for online/offline players.
+---Idempotent
+RegisterCommand('convertjobs', function(source)
+	if source ~= 0 then return warn('This command can only be executed using the server console.') end
+    local players = MySQL.query.await("SELECT citizenid, JSON_VALUE(job, '$.name') AS jobName, JSON_VALUE(job, '$.grade.level') AS jobGrade, JSON_VALUE(gang, '$.name') AS gangName, JSON_VALUE(gang, '$.grade.level') AS gangGrade FROM players")
+    for i = 1, #players do
+        local player = players[i]
+        AddPlayerToJob(player.citizenid, player.jobName, player.jobGrade)
+        AddPlayerToGang(player.citizenid, player.gangName, player.gangGrade)
+    end
+end, true)
+
 return {
     insertBan = insertBan,
     fetchBan = fetchBan,

--- a/server/storage/players.lua
+++ b/server/storage/players.lua
@@ -335,6 +335,7 @@ RegisterCommand('convertjobs', function(source)
         AddPlayerToJob(player.citizenid, player.jobName, player.jobGrade)
         AddPlayerToGang(player.citizenid, player.gangName, player.gangGrade)
     end
+    TriggerServerEvent('qbx_core:server:jobsconverted')
 end, true)
 
 return {

--- a/server/storage/players.lua
+++ b/server/storage/players.lua
@@ -332,8 +332,10 @@ RegisterCommand('convertjobs', function(source)
     local players = MySQL.query.await("SELECT citizenid, JSON_VALUE(job, '$.name') AS jobName, JSON_VALUE(job, '$.grade.level') AS jobGrade, JSON_VALUE(gang, '$.name') AS gangName, JSON_VALUE(gang, '$.grade.level') AS gangGrade FROM players")
     for i = 1, #players do
         local player = players[i]
-        AddPlayerToJob(player.citizenid, player.jobName, player.jobGrade)
-        AddPlayerToGang(player.citizenid, player.gangName, player.gangGrade)
+        local success, err = pcall(function() AddPlayerToJob(player.citizenid, player.jobName, tonumber(player.jobGrade)) end)
+        if not success then lib.print.error(err) end
+        success, err = pcall(function() AddPlayerToGang(player.citizenid, player.gangName, tonumber(player.gangGrade)) end)
+        if not success then lib.print.error(err) end
     end
     TriggerEvent('qbx_core:server:jobsconverted')
 end, true)


### PR DESCRIPTION
Adds a console command 'convertjobs': An idempotent function which copies all player's primary job & gang into the player_groups table. This works for both online & offline players, so isn't required to be ran when the server is empty.

We want the player_groups table to accurately reflect the groups the player is in. Without doing this step, it is likely that the data will eventually make its way into the player_groups table, but that would lessen the accuracy of exports that return data about which jobs the player holds. I also considered doing a check on player login instead, but that would preclude offline players from having their data corrected. The best solution I feel, is to convert all at once to guarantee the data is present immediately.

I didn't include conversions for existing multi job resources out there. Given that there is no built-in UI for qbox's multi job system, external multi job resources will need to be made qbox compatible anyway and providing a conversion function is one more step to doing that. For this reason, a server event is triggered at the end of the conversion that can be consumed by multi job resources to do additional conversion.

Tested.