### PR TITLE
feat: add vehicle shops back

### DIFF
--- a/shared/vehicles.lua
+++ b/shared/vehicles.lua
@@ -5,6 +5,7 @@
 ---@field price number
 ---@field category string
 ---@field hash string | integer actually just an integer but string is required for types to align when using `asbo` for example
+---@field shop string
 
 ---@type table<string, Vehicle>
 return {
@@ -15,6 +16,7 @@ return {
         price = 86065,
         category = 'super',
         hash = `adder`,
+        shop = 'luxury'
     },
     airbus = {
         name = 'Airport Bus',
@@ -22,7 +24,7 @@ return {
         model = 'airbus',
         price = 42321,
         category = 'service',
-        hash = `airbus`,
+        hash = `airbus`
     },
     airtug = {
         name = 'Airtug',
@@ -30,7 +32,7 @@ return {
         model = 'airtug',
         price = 18786,
         category = 'utility',
-        hash = `airtug`,
+        hash = `airtug`
     },
     akula = {
         name = 'Akula',
@@ -38,7 +40,7 @@ return {
         model = 'akula',
         price = 6879704,
         category = 'helicopters',
-        hash = `akula`,
+        hash = `akula`
     },
     akuma = {
         name = 'Akuma',
@@ -47,6 +49,7 @@ return {
         price = 25356,
         category = 'motorcycles',
         hash = `akuma`,
+        shop = 'pdm'
     },
     aleutian = {
         name = 'Aleutian',
@@ -54,7 +57,7 @@ return {
         model = 'aleutian',
         price = 66169,
         category = 'suvs',
-        hash = `aleutian`,
+        hash = `aleutian`
     },
     alkonost = {
         name = 'RO-86 Alkonost',
@@ -62,7 +65,7 @@ return {
         model = 'alkonost',
         price = 1933450,
         category = 'planes',
-        hash = `alkonost`,
+        hash = `alkonost`
     },
     alpha = {
         name = 'Alpha',
@@ -71,6 +74,7 @@ return {
         price = 82526,
         category = 'sports',
         hash = `alpha`,
+        shop = 'luxury'
     },
     alphaz1 = {
         name = 'Alpha-Z1',
@@ -79,6 +83,7 @@ return {
         price = 2587839,
         category = 'planes',
         hash = `alphaz1`,
+        shop = 'air'
     },
     ambulance = {
         name = 'Ambulance',
@@ -86,7 +91,7 @@ return {
         model = 'ambulance',
         price = 66002,
         category = 'emergency',
-        hash = `ambulance`,
+        hash = `ambulance`
     },
     annihilator = {
         name = 'Annihilator',
@@ -94,7 +99,7 @@ return {
         model = 'annihilator',
         price = 5278061,
         category = 'helicopters',
-        hash = `annihilator`,
+        hash = `annihilator`
     },
     annihilator2 = {
         name = 'Annihilator Stealth',
@@ -102,7 +107,7 @@ return {
         model = 'annihilator2',
         price = 5947464,
         category = 'helicopters',
-        hash = `annihilator2`,
+        hash = `annihilator2`
     },
     apc = {
         name = 'APC',
@@ -110,7 +115,7 @@ return {
         model = 'apc',
         price = 38410,
         category = 'military',
-        hash = `apc`,
+        hash = `apc`
     },
     ardent = {
         name = 'Ardent',
@@ -119,6 +124,7 @@ return {
         price = 79425,
         category = 'sportsclassics',
         hash = `ardent`,
+        shop = 'pdm'
     },
     armytanker = {
         name = 'Army Trailer (Tanker)',
@@ -126,7 +132,7 @@ return {
         model = 'armytanker',
         price = 5748,
         category = 'utility',
-        hash = `armytanker`,
+        hash = `armytanker`
     },
     armytrailer = {
         name = 'Army Trailer',
@@ -134,15 +140,15 @@ return {
         model = 'armytrailer',
         price = 5668,
         category = 'utility',
-        hash = `armytrailer`,
+        hash = `armytrailer`
     },
     armytrailer2 = {
+        name = 'Army Trailer (Civilian)',
         brand = '',
-        category = 'utility',
         model = 'armytrailer2',
         price = 5668,
-        name = 'Army Trailer (Civilian)',
-        hash = `armytrailer2`,
+        category = 'utility',
+        hash = `armytrailer2`
     },
     asbo = {
         name = 'Asbo',
@@ -151,6 +157,7 @@ return {
         price = 63020,
         category = 'compacts',
         hash = `asbo`,
+        shop = 'pdm'
     },
     asea = {
         name = 'Asea',
@@ -159,6 +166,7 @@ return {
         price = 63374,
         category = 'sedans',
         hash = `asea`,
+        shop = 'pdm'
     },
     asea2 = {
         name = 'Asea (Snow)',
@@ -166,7 +174,7 @@ return {
         model = 'asea2',
         price = 63374,
         category = 'sedans',
-        hash = `asea2`,
+        hash = `asea2`
     },
     asterope = {
         name = 'Asterope',
@@ -175,6 +183,7 @@ return {
         price = 64174,
         category = 'sedans',
         hash = `asterope`,
+        shop = 'pdm'
     },
     asterope2 = {
         name = 'Asterope GZ',
@@ -182,7 +191,7 @@ return {
         model = 'asterope2',
         price = 71306,
         category = 'sedans',
-        hash = `asterope2`,
+        hash = `asterope2`
     },
     astron = {
         name = 'Astron',
@@ -191,6 +200,7 @@ return {
         price = 81719,
         category = 'suvs',
         hash = `astron`,
+        shop = 'pdm'
     },
     autarch = {
         name = 'Autarch',
@@ -199,6 +209,7 @@ return {
         price = 85798,
         category = 'super',
         hash = `autarch`,
+        shop = 'luxury'
     },
     avarus = {
         name = 'Avarus',
@@ -207,6 +218,7 @@ return {
         price = 23028,
         category = 'motorcycles',
         hash = `avarus`,
+        shop = 'pdm'
     },
     avenger = {
         name = 'Avenger',
@@ -214,7 +226,7 @@ return {
         model = 'avenger',
         price = 1953425,
         category = 'planes',
-        hash = `avenger`,
+        hash = `avenger`
     },
     avenger2 = {
         name = 'Avenger (Prop)',
@@ -222,7 +234,7 @@ return {
         model = 'avenger2',
         price = 1953425,
         category = 'planes',
-        hash = `avenger2`,
+        hash = `avenger2`
     },
     avenger3 = {
         name = 'Avenger (Upgraded)',
@@ -230,7 +242,7 @@ return {
         model = 'avenger3',
         price = 1953425,
         category = 'planes',
-        hash = `avenger3`,
+        hash = `avenger3`
     },
     avenger4 = {
         name = 'Avenger (Upgraded Prop)',
@@ -238,7 +250,7 @@ return {
         model = 'avenger4',
         price = 1953425,
         category = 'planes',
-        hash = `avenger4`,
+        hash = `avenger4`
     },
     avisa = {
         name = 'Avisa',
@@ -246,7 +258,7 @@ return {
         model = 'avisa',
         price = 804616,
         category = 'boats',
-        hash = `avisa`,
+        hash = `avisa`
     },
     bagger = {
         name = 'Bagger',
@@ -255,6 +267,7 @@ return {
         price = 19934,
         category = 'motorcycles',
         hash = `bagger`,
+        shop = 'pdm'
     },
     baletrailer = {
         name = 'Baletrailer',
@@ -262,7 +275,7 @@ return {
         model = 'baletrailer',
         price = 5668,
         category = 'utility',
-        hash = `baletrailer`,
+        hash = `baletrailer`
     },
     baller = {
         name = 'Baller',
@@ -271,6 +284,7 @@ return {
         price = 65628,
         category = 'suvs',
         hash = `baller`,
+        shop = 'pdm'
     },
     baller2 = {
         name = 'Baller',
@@ -279,6 +293,7 @@ return {
         price = 74432,
         category = 'suvs',
         hash = `baller2`,
+        shop = 'pdm'
     },
     baller3 = {
         name = 'Baller LE',
@@ -287,6 +302,7 @@ return {
         price = 74448,
         category = 'suvs',
         hash = `baller3`,
+        shop = 'pdm'
     },
     baller4 = {
         name = 'Baller LE LWB',
@@ -295,6 +311,7 @@ return {
         price = 74384,
         category = 'suvs',
         hash = `baller4`,
+        shop = 'pdm'
     },
     baller5 = {
         name = ' Baller LE (Armored)',
@@ -303,6 +320,7 @@ return {
         price = 74400,
         category = 'suvs',
         hash = `baller5`,
+        shop = 'pdm'
     },
     baller6 = {
         name = 'Baller LE LWB (Armored)',
@@ -311,6 +329,7 @@ return {
         price = 74335,
         category = 'suvs',
         hash = `baller6`,
+        shop = 'pdm'
     },
     baller7 = {
         name = 'Baller ST',
@@ -319,6 +338,7 @@ return {
         price = 77229,
         category = 'suvs',
         hash = `baller7`,
+        shop = 'pdm'
     },
     baller8 = {
         name = 'Baller ST-D',
@@ -326,7 +346,7 @@ return {
         model = 'baller8',
         price = 77694,
         category = 'suvs',
-        hash = `baller8`,
+        hash = `baller8`
     },
     banshee = {
         name = 'Banshee',
@@ -335,6 +355,7 @@ return {
         price = 79495,
         category = 'sports',
         hash = `banshee`,
+        shop = 'luxury'
     },
     banshee2 = {
         name = 'Banshee 900R',
@@ -343,6 +364,7 @@ return {
         price = 74887,
         category = 'super',
         hash = `banshee2`,
+        shop = 'luxury'
     },
     barracks = {
         name = 'Barracks',
@@ -350,7 +372,7 @@ return {
         model = 'barracks',
         price = 53283,
         category = 'military',
-        hash = `barracks`,
+        hash = `barracks`
     },
     barracks2 = {
         name = 'Barracks Semi',
@@ -358,7 +380,7 @@ return {
         model = 'barracks2',
         price = 60073,
         category = 'military',
-        hash = `barracks2`,
+        hash = `barracks2`
     },
     barracks3 = {
         name = 'Barracks',
@@ -366,7 +388,7 @@ return {
         model = 'barracks3',
         price = 53283,
         category = 'military',
-        hash = `barracks3`,
+        hash = `barracks3`
     },
     barrage = {
         name = 'Barrage',
@@ -374,7 +396,7 @@ return {
         model = 'barrage',
         price = 66580,
         category = 'military',
-        hash = `barrage`,
+        hash = `barrage`
     },
     bati = {
         name = 'Bati 801',
@@ -383,6 +405,7 @@ return {
         price = 25838,
         category = 'motorcycles',
         hash = `bati`,
+        shop = 'pdm'
     },
     bati2 = {
         name = 'Bati 801RR',
@@ -391,6 +414,7 @@ return {
         price = 25838,
         category = 'motorcycles',
         hash = `bati2`,
+        shop = 'pdm'
     },
     benson = {
         name = 'Benson',
@@ -398,7 +422,7 @@ return {
         model = 'benson',
         price = 60635,
         category = 'commercial',
-        hash = `benson`,
+        hash = `benson`
     },
     benson2 = {
         name = 'Benson (Cluckin\' Bell)',
@@ -406,7 +430,7 @@ return {
         model = 'benson2',
         price = 60635,
         category = 'commercial',
-        hash = `benson2`,
+        hash = `benson2`
     },
     besra = {
         name = 'Besra',
@@ -414,7 +438,7 @@ return {
         model = 'besra',
         price = 2373206,
         category = 'planes',
-        hash = `besra`,
+        hash = `besra`
     },
     bestiagts = {
         name = 'Bestia GTS',
@@ -423,6 +447,7 @@ return {
         price = 79703,
         category = 'sports',
         hash = `bestiagts`,
+        shop = 'luxury'
     },
     bf400 = {
         name = 'BF400',
@@ -431,6 +456,7 @@ return {
         price = 23103,
         category = 'motorcycles',
         hash = `bf400`,
+        shop = 'pdm'
     },
     bfinjection = {
         name = 'Injection',
@@ -439,6 +465,7 @@ return {
         price = 67551,
         category = 'offroad',
         hash = `bfinjection`,
+        shop = 'pdm'
     },
     biff = {
         name = 'Biff',
@@ -446,7 +473,7 @@ return {
         model = 'biff',
         price = 56668,
         category = 'commercial',
-        hash = `biff`,
+        hash = `biff`
     },
     bifta = {
         name = 'Bifta',
@@ -455,6 +482,7 @@ return {
         price = 74872,
         category = 'offroad',
         hash = `bifta`,
+        shop = 'pdm'
     },
     bison = {
         name = 'Bison',
@@ -463,6 +491,7 @@ return {
         price = 62297,
         category = 'vans',
         hash = `bison`,
+        shop = 'pdm'
     },
     bison2 = {
         name = 'Bison (McGill-Olsen)',
@@ -470,7 +499,7 @@ return {
         model = 'bison2',
         price = 62297,
         category = 'vans',
-        hash = `bison2`,
+        hash = `bison2`
     },
     bison3 = {
         name = 'Bison (The Mighty Bush)',
@@ -478,7 +507,7 @@ return {
         model = 'bison3',
         price = 62297,
         category = 'vans',
-        hash = `bison3`,
+        hash = `bison3`
     },
     bjxl = {
         name = 'BeeJay XL',
@@ -487,6 +516,7 @@ return {
         price = 60692,
         category = 'suvs',
         hash = `bjxl`,
+        shop = 'pdm'
     },
     blade = {
         name = 'Blade',
@@ -495,6 +525,7 @@ return {
         price = 70520,
         category = 'muscle',
         hash = `blade`,
+        shop = 'pdm'
     },
     blazer = {
         name = 'Blazer',
@@ -503,6 +534,7 @@ return {
         price = 21457,
         category = 'offroad',
         hash = `blazer`,
+        shop = 'pdm'
     },
     blazer2 = {
         name = 'Blazer Lifeguard',
@@ -511,6 +543,7 @@ return {
         price = 15679,
         category = 'offroad',
         hash = `blazer2`,
+        shop = 'pdm'
     },
     blazer3 = {
         name = 'Hot Rod Blazer',
@@ -519,6 +552,7 @@ return {
         price = 21457,
         category = 'offroad',
         hash = `blazer3`,
+        shop = 'pdm'
     },
     blazer4 = {
         name = 'Blazer Sport',
@@ -527,6 +561,7 @@ return {
         price = 24453,
         category = 'offroad',
         hash = `blazer4`,
+        shop = 'pdm'
     },
     blazer5 = {
         name = 'Blazer Aqua',
@@ -535,6 +570,7 @@ return {
         price = 25680,
         category = 'offroad',
         hash = `blazer5`,
+        shop = 'pdm'
     },
     blimp = {
         name = 'Atomic Blimp',
@@ -542,7 +578,7 @@ return {
         model = 'blimp',
         price = 1024161,
         category = 'planes',
-        hash = `blimp`,
+        hash = `blimp`
     },
     blimp2 = {
         name = 'Xero Blimp',
@@ -550,7 +586,7 @@ return {
         model = 'blimp2',
         price = 1036862,
         category = 'planes',
-        hash = `blimp2`,
+        hash = `blimp2`
     },
     blimp3 = {
         name = 'Blimp',
@@ -558,7 +594,7 @@ return {
         model = 'blimp3',
         price = 1024161,
         category = 'planes',
-        hash = `blimp3`,
+        hash = `blimp3`
     },
     blista = {
         name = 'Blista',
@@ -567,6 +603,7 @@ return {
         price = 69371,
         category = 'compacts',
         hash = `blista`,
+        shop = 'pdm'
     },
     blista2 = {
         name = 'Blista Compact',
@@ -575,6 +612,7 @@ return {
         price = 69291,
         category = 'sports',
         hash = `blista2`,
+        shop = 'pdm'
     },
     blista3 = {
         name = 'Blista Go Go Monkey',
@@ -583,6 +621,7 @@ return {
         price = 69291,
         category = 'sports',
         hash = `blista3`,
+        shop = 'pdm'
     },
     bmx = {
         name = 'BMX',
@@ -591,6 +630,7 @@ return {
         price = 2735,
         category = 'cycles',
         hash = `bmx`,
+        shop = 'pdm'
     },
     boattrailer = {
         name = 'Boat Trailer',
@@ -598,7 +638,7 @@ return {
         model = 'boattrailer',
         price = 5668,
         category = 'utility',
-        hash = `boattrailer`,
+        hash = `boattrailer`
     },
     boattrailer2 = {
         name = 'Boat Trailer (Dinghy)',
@@ -606,7 +646,7 @@ return {
         model = 'boattrailer2',
         price = 5668,
         category = 'utility',
-        hash = `boattrailer2`,
+        hash = `boattrailer2`
     },
     boattrailer3 = {
         name = 'Boat Trailer (Seashark)',
@@ -614,7 +654,7 @@ return {
         model = 'boattrailer3',
         price = 5668,
         category = 'utility',
-        hash = `boattrailer3`,
+        hash = `boattrailer3`
     },
     bobcatxl = {
         name = 'Bobcat XL Open',
@@ -623,6 +663,7 @@ return {
         price = 58720,
         category = 'vans',
         hash = `bobcatxl`,
+        shop = 'pdm'
     },
     bodhi2 = {
         name = 'Bodhi',
@@ -630,7 +671,7 @@ return {
         model = 'bodhi2',
         price = 59867,
         category = 'offroad',
-        hash = `bodhi2`,
+        hash = `bodhi2`
     },
     bombushka = {
         name = 'RM-10 Bombushka',
@@ -638,7 +679,7 @@ return {
         model = 'bombushka',
         price = 788207,
         category = 'planes',
-        hash = `bombushka`,
+        hash = `bombushka`
     },
     boor = {
         name = 'Boor',
@@ -646,7 +687,7 @@ return {
         model = 'boor',
         price = 67237,
         category = 'offroad',
-        hash = `boor`,
+        hash = `boor`
     },
     boxville = {
         name = 'Boxville (LSDWP)',
@@ -654,7 +695,7 @@ return {
         model = 'boxville',
         price = 47273,
         category = 'vans',
-        hash = `boxville`,
+        hash = `boxville`
     },
     boxville2 = {
         name = 'Boxville (Go Postal)',
@@ -662,7 +703,7 @@ return {
         model = 'boxville2',
         price = 47273,
         category = 'vans',
-        hash = `boxville2`,
+        hash = `boxville2`
     },
     boxville3 = {
         name = 'Boxville (Humane Labs)',
@@ -670,7 +711,7 @@ return {
         model = 'boxville3',
         price = 47273,
         category = 'vans',
-        hash = `boxville3`,
+        hash = `boxville3`
     },
     boxville4 = {
         name = 'Boxville (Post Op)',
@@ -678,7 +719,7 @@ return {
         model = 'boxville4',
         price = 47273,
         category = 'vans',
-        hash = `boxville4`,
+        hash = `boxville4`
     },
     boxville5 = {
         name = 'Armored Boxville',
@@ -686,7 +727,7 @@ return {
         model = 'boxville5',
         price = 65341,
         category = 'vans',
-        hash = `boxville5`,
+        hash = `boxville5`
     },
     boxville6 = {
         name = 'Boxville (LSDS)',
@@ -694,7 +735,7 @@ return {
         model = 'boxville6',
         price = 47273,
         category = 'vans',
-        hash = `boxville6`,
+        hash = `boxville6`
     },
     brawler = {
         name = 'Brawler',
@@ -703,6 +744,7 @@ return {
         price = 77578,
         category = 'offroad',
         hash = `brawler`,
+        shop = 'pdm'
     },
     brickade = {
         name = 'Brickade',
@@ -710,7 +752,7 @@ return {
         model = 'brickade',
         price = 54416,
         category = 'service',
-        hash = `brickade`,
+        hash = `brickade`
     },
     brickade2 = {
         name = 'Brickade 6x6',
@@ -718,7 +760,7 @@ return {
         model = 'brickade2',
         price = 54416,
         category = 'service',
-        hash = `brickade2`,
+        hash = `brickade2`
     },
     brigham = {
         name = 'Brigham',
@@ -726,7 +768,7 @@ return {
         model = 'brigham',
         price = 63825,
         category = 'muscle',
-        hash = `brigham`,
+        hash = `brigham`
     },
     brioso = {
         name = 'Brioso R/A',
@@ -735,6 +777,7 @@ return {
         price = 69113,
         category = 'compacts',
         hash = `brioso`,
+        shop = 'pdm'
     },
     brioso2 = {
         name = 'Brioso 300',
@@ -743,6 +786,7 @@ return {
         price = 54291,
         category = 'compacts',
         hash = `brioso2`,
+        shop = 'pdm'
     },
     brioso3 = {
         name = 'Brioso 300 Widebody',
@@ -751,6 +795,7 @@ return {
         price = 61333,
         category = 'compacts',
         hash = `brioso3`,
+        shop = 'pdm'
     },
     broadway = {
         name = 'Broadway',
@@ -758,7 +803,7 @@ return {
         model = 'broadway',
         price = 61702,
         category = 'muscle',
-        hash = `broadway`,
+        hash = `broadway`
     },
     bruiser = {
         name = 'Apocalypse Bruiser',
@@ -766,7 +811,7 @@ return {
         model = 'bruiser',
         price = 63687,
         category = 'offroad',
-        hash = `bruiser`,
+        hash = `bruiser`
     },
     bruiser2 = {
         name = 'Future Shock Bruiser',
@@ -774,7 +819,7 @@ return {
         model = 'bruiser2',
         price = 63687,
         category = 'offroad',
-        hash = `bruiser2`,
+        hash = `bruiser2`
     },
     bruiser3 = {
         name = 'Nightmare Bruiser',
@@ -782,7 +827,7 @@ return {
         model = 'bruiser3',
         price = 63687,
         category = 'offroad',
-        hash = `bruiser3`,
+        hash = `bruiser3`
     },
     brutus = {
         name = 'Apocalypse Brutus',
@@ -790,7 +835,7 @@ return {
         model = 'brutus',
         price = 70122,
         category = 'offroad',
-        hash = `brutus`,
+        hash = `brutus`
     },
     brutus2 = {
         name = 'Future Shock Brutus',
@@ -798,7 +843,7 @@ return {
         model = 'brutus2',
         price = 70122,
         category = 'offroad',
-        hash = `brutus2`,
+        hash = `brutus2`
     },
     brutus3 = {
         name = 'Nightmare Brutus',
@@ -806,7 +851,7 @@ return {
         model = 'brutus3',
         price = 70122,
         category = 'offroad',
-        hash = `brutus3`,
+        hash = `brutus3`
     },
     btype = {
         name = 'Roosevelt',
@@ -815,6 +860,7 @@ return {
         price = 69018,
         category = 'sportsclassics',
         hash = `btype`,
+        shop = 'pdm'
     },
     btype2 = {
         name = 'Franken Stange',
@@ -823,6 +869,7 @@ return {
         price = 74624,
         category = 'sportsclassics',
         hash = `btype2`,
+        shop = 'pdm'
     },
     btype3 = {
         name = 'Roosevelt Valor',
@@ -831,6 +878,7 @@ return {
         price = 69018,
         category = 'sportsclassics',
         hash = `btype3`,
+        shop = 'pdm'
     },
     buccaneer = {
         name = 'Buccaneer',
@@ -839,6 +887,7 @@ return {
         price = 76634,
         category = 'muscle',
         hash = `buccaneer`,
+        shop = 'pdm'
     },
     buccaneer2 = {
         name = 'Buccaneer Custom',
@@ -847,6 +896,7 @@ return {
         price = 76634,
         category = 'muscle',
         hash = `buccaneer2`,
+        shop = 'pdm'
     },
     buffalo = {
         name = 'Buffalo',
@@ -855,6 +905,7 @@ return {
         price = 75156,
         category = 'sports',
         hash = `buffalo`,
+        shop = 'luxury'
     },
     buffalo2 = {
         name = 'Buffalo S',
@@ -863,6 +914,7 @@ return {
         price = 77026,
         category = 'sports',
         hash = `buffalo2`,
+        shop = 'luxury'
     },
     buffalo3 = {
         name = 'Sprunk Buffalo',
@@ -870,7 +922,7 @@ return {
         model = 'buffalo3',
         price = 80264,
         category = 'sports',
-        hash = `buffalo3`,
+        hash = `buffalo3`
     },
     buffalo4 = {
         name = 'Buffalo STX',
@@ -879,6 +931,7 @@ return {
         price = 80516,
         category = 'muscle',
         hash = `buffalo4`,
+        shop = 'pdm'
     },
     buffalo5 = {
         name = 'Buffalo EVX',
@@ -886,7 +939,7 @@ return {
         model = 'buffalo5',
         price = 83332,
         category = 'muscle',
-        hash = `buffalo5`,
+        hash = `buffalo5`
     },
     bulldozer = {
         name = 'Dozer',
@@ -894,7 +947,7 @@ return {
         model = 'bulldozer',
         price = 9376,
         category = 'industrial',
-        hash = `bulldozer`,
+        hash = `bulldozer`
     },
     bullet = {
         name = 'Bullet',
@@ -903,6 +956,7 @@ return {
         price = 82565,
         category = 'super',
         hash = `bullet`,
+        shop = 'luxury'
     },
     burrito = {
         name = 'Burrito (LSDWP)',
@@ -910,7 +964,7 @@ return {
         model = 'burrito',
         price = 61195,
         category = 'vans',
-        hash = `burrito`,
+        hash = `burrito`
     },
     burrito2 = {
         name = 'Bugstars Burrito',
@@ -918,7 +972,7 @@ return {
         model = 'burrito2',
         price = 61195,
         category = 'vans',
-        hash = `burrito2`,
+        hash = `burrito2`
     },
     burrito3 = {
         name = 'Burrito',
@@ -927,6 +981,7 @@ return {
         price = 61195,
         category = 'vans',
         hash = `burrito3`,
+        shop = 'pdm'
     },
     burrito4 = {
         name = 'Burrito (McGill-Olsen)',
@@ -934,7 +989,7 @@ return {
         model = 'burrito4',
         price = 61195,
         category = 'vans',
-        hash = `burrito4`,
+        hash = `burrito4`
     },
     burrito5 = {
         name = 'Burrito (Snow)',
@@ -942,7 +997,7 @@ return {
         model = 'burrito5',
         price = 61195,
         category = 'vans',
-        hash = `burrito5`,
+        hash = `burrito5`
     },
     bus = {
         name = 'Bus',
@@ -950,7 +1005,7 @@ return {
         model = 'bus',
         price = 42481,
         category = 'service',
-        hash = `bus`,
+        hash = `bus`
     },
     buzzard = {
         name = 'Buzzard Attack Chopper',
@@ -958,7 +1013,7 @@ return {
         model = 'buzzard',
         price = 6462758,
         category = 'helicopters',
-        hash = `buzzard`,
+        hash = `buzzard`
     },
     buzzard2 = {
         name = 'Buzzard',
@@ -967,6 +1022,7 @@ return {
         price = 6462758,
         category = 'helicopters',
         hash = `buzzard2`,
+        shop = 'air'
     },
     cablecar = {
         name = 'Cable Car',
@@ -974,7 +1030,7 @@ return {
         model = 'cablecar',
         price = 194680,
         category = 'trains',
-        hash = `cablecar`,
+        hash = `cablecar`
     },
     caddy = {
         name = 'Caddy (Golf)',
@@ -982,7 +1038,7 @@ return {
         model = 'caddy',
         price = 36554,
         category = 'utility',
-        hash = `caddy`,
+        hash = `caddy`
     },
     caddy2 = {
         name = 'Caddy',
@@ -990,7 +1046,7 @@ return {
         model = 'caddy2',
         price = 36554,
         category = 'utility',
-        hash = `caddy2`,
+        hash = `caddy2`
     },
     caddy3 = {
         name = 'Caddy (Bunker)',
@@ -998,7 +1054,7 @@ return {
         model = 'caddy3',
         price = 36022,
         category = 'utility',
-        hash = `caddy3`,
+        hash = `caddy3`
     },
     calico = {
         name = 'Calico GTF',
@@ -1007,6 +1063,7 @@ return {
         price = 82150,
         category = 'sports',
         hash = `calico`,
+        shop = 'luxury'
     },
     camper = {
         name = 'Camper',
@@ -1014,7 +1071,7 @@ return {
         model = 'camper',
         price = 50131,
         category = 'vans',
-        hash = `camper`,
+        hash = `camper`
     },
     caracara = {
         name = 'Caracara',
@@ -1023,6 +1080,7 @@ return {
         price = 63685,
         category = 'offroad',
         hash = `caracara`,
+        shop = 'pdm'
     },
     caracara2 = {
         name = 'Caracara 4x4',
@@ -1031,6 +1089,7 @@ return {
         price = 64784,
         category = 'offroad',
         hash = `caracara2`,
+        shop = 'pdm'
     },
     carbonizzare = {
         name = 'Carbonizzare',
@@ -1039,14 +1098,16 @@ return {
         price = 80346,
         category = 'sports',
         hash = `carbonizzare`,
+        shop = 'luxury'
     },
     carbonrs = {
-        brand = 'Nagasaki',
         name = 'Carbon RS',
+        brand = 'Nagasaki',
         model = 'carbonrs',
         price = 24649,
         category = 'motorcycles',
         hash = `carbonrs`,
+        shop = 'pdm'
     },
     cargobob = {
         name = 'Cargobob',
@@ -1054,7 +1115,7 @@ return {
         model = 'cargobob',
         price = 5616986,
         category = 'helicopters',
-        hash = `cargobob`,
+        hash = `cargobob`
     },
     cargobob2 = {
         name = 'Cargobob (Jetsam)',
@@ -1062,7 +1123,7 @@ return {
         model = 'cargobob2',
         price = 5616986,
         category = 'helicopters',
-        hash = `cargobob2`,
+        hash = `cargobob2`
     },
     cargobob3 = {
         name = 'Cargobob (Trevor Philips Enterprises)',
@@ -1070,7 +1131,7 @@ return {
         model = 'cargobob3',
         price = 5616986,
         category = 'helicopters',
-        hash = `cargobob3`,
+        hash = `cargobob3`
     },
     cargobob4 = {
         name = 'Cargobob (Drop Zone)',
@@ -1078,7 +1139,7 @@ return {
         model = 'cargobob4',
         price = 5616986,
         category = 'helicopters',
-        hash = `cargobob4`,
+        hash = `cargobob4`
     },
     cargoplane = {
         name = 'Cargo Plane',
@@ -1086,7 +1147,7 @@ return {
         model = 'cargoplane',
         price = 1537948,
         category = 'planes',
-        hash = `cargoplane`,
+        hash = `cargoplane`
     },
     cargoplane2 = {
         name = 'Cargo Plane',
@@ -1094,7 +1155,7 @@ return {
         model = 'cargoplane2',
         price = 1537948,
         category = 'planes',
-        hash = `cargoplane2`,
+        hash = `cargoplane2`
     },
     casco = {
         name = 'Casco',
@@ -1103,6 +1164,7 @@ return {
         price = 83125,
         category = 'sportsclassics',
         hash = `casco`,
+        shop = 'pdm'
     },
     cavalcade = {
         name = 'Cavalcade',
@@ -1111,6 +1173,7 @@ return {
         price = 63694,
         category = 'suvs',
         hash = `cavalcade`,
+        shop = 'pdm'
     },
     cavalcade2 = {
         name = 'Cavalcade',
@@ -1119,6 +1182,7 @@ return {
         price = 63694,
         category = 'suvs',
         hash = `cavalcade2`,
+        shop = 'pdm'
     },
     cavalcade3 = {
         name = 'Cavalcade XL',
@@ -1126,7 +1190,7 @@ return {
         model = 'cavalcade3',
         price = 67959,
         category = 'suvs',
-        hash = `cavalcade3`,
+        hash = `cavalcade3`
     },
     cerberus = {
         name = 'Apocalypse Cerberus',
@@ -1134,7 +1198,7 @@ return {
         model = 'cerberus',
         price = 61154,
         category = 'commercial',
-        hash = `cerberus`,
+        hash = `cerberus`
     },
     cerberus2 = {
         name = 'Future Shock Cerberus',
@@ -1142,7 +1206,7 @@ return {
         model = 'cerberus2',
         price = 61154,
         category = 'commercial',
-        hash = `cerberus2`,
+        hash = `cerberus2`
     },
     cerberus3 = {
         name = 'Nightmare Cerberus',
@@ -1150,7 +1214,7 @@ return {
         model = 'cerberus3',
         price = 61154,
         category = 'commercial',
-        hash = `cerberus3`,
+        hash = `cerberus3`
     },
     champion = {
         name = 'Champion',
@@ -1159,6 +1223,7 @@ return {
         price = 86582,
         category = 'super',
         hash = `champion`,
+        shop = 'pdm'
     },
     cheburek = {
         name = 'Cheburek',
@@ -1167,6 +1232,7 @@ return {
         price = 74166,
         category = 'sportsclassics',
         hash = `cheburek`,
+        shop = 'pdm'
     },
     cheetah = {
         name = 'Cheetah',
@@ -1175,6 +1241,7 @@ return {
         price = 82927,
         category = 'super',
         hash = `cheetah`,
+        shop = 'luxury'
     },
     cheetah2 = {
         name = 'Cheetah Classic',
@@ -1183,6 +1250,7 @@ return {
         price = 82724,
         category = 'sportsclassics',
         hash = `cheetah2`,
+        shop = 'luxury'
     },
     chernobog = {
         name = 'Chernobog',
@@ -1190,7 +1258,7 @@ return {
         model = 'chernobog',
         price = 37291,
         category = 'military',
-        hash = `chernobog`,
+        hash = `chernobog`
     },
     chimera = {
         name = 'Chimera',
@@ -1199,6 +1267,7 @@ return {
         price = 22412,
         category = 'motorcycles',
         hash = `chimera`,
+        shop = 'pdm'
     },
     chino = {
         name = 'Chino',
@@ -1207,6 +1276,7 @@ return {
         price = 58651,
         category = 'muscle',
         hash = `chino`,
+        shop = 'pdm'
     },
     chino2 = {
         name = 'Chino Custom',
@@ -1215,6 +1285,7 @@ return {
         price = 60394,
         category = 'muscle',
         hash = `chino2`,
+        shop = 'pdm'
     },
     cinquemila = {
         name = 'Cinquemila',
@@ -1223,6 +1294,7 @@ return {
         price = 80476,
         category = 'sedans',
         hash = `cinquemila`,
+        shop = 'pdm'
     },
     cliffhanger = {
         name = 'Cliffhanger',
@@ -1231,6 +1303,7 @@ return {
         price = 25621,
         category = 'motorcycles',
         hash = `cliffhanger`,
+        shop = 'pdm'
     },
     clique = {
         name = 'Clique',
@@ -1239,6 +1312,7 @@ return {
         price = 76525,
         category = 'muscle',
         hash = `clique`,
+        shop = 'pdm'
     },
     clique2 = {
         name = 'Clique Wagon',
@@ -1246,7 +1320,7 @@ return {
         model = 'clique2',
         price = 54902,
         category = 'muscle',
-        hash = `clique2`,
+        hash = `clique2`
     },
     club = {
         name = 'Club',
@@ -1255,6 +1329,7 @@ return {
         price = 69335,
         category = 'compacts',
         hash = `club`,
+        shop = 'pdm'
     },
     coach = {
         name = 'Dashound',
@@ -1262,7 +1337,7 @@ return {
         model = 'coach',
         price = 42321,
         category = 'service',
-        hash = `coach`,
+        hash = `coach`
     },
     cog55 = {
         name = 'Cognoscenti 55',
@@ -1271,6 +1346,7 @@ return {
         price = 76441,
         category = 'sedans',
         hash = `cog55`,
+        shop = 'pdm'
     },
     cog552 = {
         name = 'Cognoscenti 55 (Armored)',
@@ -1278,7 +1354,7 @@ return {
         model = 'cog552',
         price = 75535,
         category = 'sedans',
-        hash = `cog552`,
+        hash = `cog552`
     },
     cogcabrio = {
         name = 'Cognoscenti Cabrio',
@@ -1287,6 +1363,7 @@ return {
         price = 74712,
         category = 'coupes',
         hash = `cogcabrio`,
+        shop = 'pdm'
     },
     cognoscenti = {
         name = 'Cognoscenti',
@@ -1295,6 +1372,7 @@ return {
         price = 75535,
         category = 'sedans',
         hash = `cognoscenti`,
+        shop = 'pdm'
     },
     cognoscenti2 = {
         name = 'Cognoscenti (Armored)',
@@ -1302,7 +1380,7 @@ return {
         model = 'cognoscenti2',
         price = 74605,
         category = 'sedans',
-        hash = `cognoscenti2`,
+        hash = `cognoscenti2`
     },
     comet2 = {
         name = 'Comet',
@@ -1311,6 +1389,7 @@ return {
         price = 83289,
         category = 'sports',
         hash = `comet2`,
+        shop = 'luxury'
     },
     comet3 = {
         name = 'Comet Retro Custom',
@@ -1319,6 +1398,7 @@ return {
         price = 83253,
         category = 'sports',
         hash = `comet3`,
+        shop = 'luxury'
     },
     comet4 = {
         name = 'Comet Safari',
@@ -1327,6 +1407,7 @@ return {
         price = 78289,
         category = 'sports',
         hash = `comet4`,
+        shop = 'luxury'
     },
     comet5 = {
         name = 'Comet SR',
@@ -1335,6 +1416,7 @@ return {
         price = 78583,
         category = 'sports',
         hash = `comet5`,
+        shop = 'luxury'
     },
     comet6 = {
         name = 'Comet S2',
@@ -1343,6 +1425,7 @@ return {
         price = 83378,
         category = 'sports',
         hash = `comet6`,
+        shop = 'luxury'
     },
     comet7 = {
         name = 'Comet S2 Cabrio',
@@ -1351,6 +1434,7 @@ return {
         price = 83759,
         category = 'sports',
         hash = `comet7`,
+        shop = 'pdm'
     },
     conada = {
         name = 'Conada',
@@ -1359,6 +1443,7 @@ return {
         price = 6931736,
         category = 'helicopters',
         hash = `conada`,
+        shop = 'air'
     },
     conada2 = {
         name = 'Weaponized Conada',
@@ -1366,7 +1451,7 @@ return {
         model = 'conada2',
         price = 6855740,
         category = 'helicopters',
-        hash = `conada2`,
+        hash = `conada2`
     },
     contender = {
         name = 'Contender',
@@ -1375,6 +1460,7 @@ return {
         price = 68578,
         category = 'suvs',
         hash = `contender`,
+        shop = 'pdm'
     },
     coquette = {
         name = 'Coquette',
@@ -1383,6 +1469,7 @@ return {
         price = 83674,
         category = 'sports',
         hash = `coquette`,
+        shop = 'luxury'
     },
     coquette2 = {
         name = 'Coquette Classic',
@@ -1391,6 +1478,7 @@ return {
         price = 81755,
         category = 'sportsclassics',
         hash = `coquette2`,
+        shop = 'pdm'
     },
     coquette3 = {
         name = 'Coquette BlackFin',
@@ -1399,6 +1487,7 @@ return {
         price = 74621,
         category = 'muscle',
         hash = `coquette3`,
+        shop = 'pdm'
     },
     coquette4 = {
         name = 'Coquette D10',
@@ -1407,6 +1496,7 @@ return {
         price = 80771,
         category = 'sports',
         hash = `coquette4`,
+        shop = 'luxury'
     },
     corsita = {
         name = 'Corsita',
@@ -1415,6 +1505,7 @@ return {
         price = 87616,
         category = 'sports',
         hash = `corsita`,
+        shop = 'luxury'
     },
     coureur = {
         name = 'La Coureuse',
@@ -1422,7 +1513,7 @@ return {
         model = 'coureur',
         price = 77754,
         category = 'sports',
-        hash = `coureur`,
+        hash = `coureur`
     },
     cruiser = {
         name = 'Cruiser',
@@ -1431,6 +1522,7 @@ return {
         price = 2751,
         category = 'cycles',
         hash = `cruiser`,
+        shop = 'pdm'
     },
     crusader = {
         name = 'Crusader',
@@ -1438,7 +1530,7 @@ return {
         model = 'crusader',
         price = 59206,
         category = 'military',
-        hash = `crusader`,
+        hash = `crusader`
     },
     cuban800 = {
         name = 'Cuban 800',
@@ -1446,7 +1538,7 @@ return {
         model = 'cuban800',
         price = 1489140,
         category = 'planes',
-        hash = `cuban800`,
+        hash = `cuban800`
     },
     cutter = {
         name = 'Cutter',
@@ -1454,7 +1546,7 @@ return {
         model = 'cutter',
         price = 22017,
         category = 'industrial',
-        hash = `cutter`,
+        hash = `cutter`
     },
     cyclone = {
         name = 'Cyclone',
@@ -1463,6 +1555,7 @@ return {
         price = 68875,
         category = 'super',
         hash = `cyclone`,
+        shop = 'luxury'
     },
     cypher = {
         name = 'Cypher',
@@ -1471,6 +1564,7 @@ return {
         price = 75676,
         category = 'sports',
         hash = `cypher`,
+        shop = 'luxury'
     },
     daemon = {
         name = 'Daemon',
@@ -1479,6 +1573,7 @@ return {
         price = 22321,
         category = 'motorcycles',
         hash = `daemon`,
+        shop = 'pdm'
     },
     daemon2 = {
         name = 'Daemon Custom',
@@ -1487,6 +1582,7 @@ return {
         price = 22423,
         category = 'motorcycles',
         hash = `daemon2`,
+        shop = 'pdm'
     },
     deathbike = {
         name = 'Apocalypse Deathbike',
@@ -1495,6 +1591,7 @@ return {
         price = 25195,
         category = 'motorcycles',
         hash = `deathbike`,
+        shop = 'pdm'
     },
     deathbike2 = {
         name = 'Future Shock Deathbike',
@@ -1503,6 +1600,7 @@ return {
         price = 25195,
         category = 'motorcycles',
         hash = `deathbike2`,
+        shop = 'pdm'
     },
     deathbike3 = {
         name = 'Nightmare Deathbike',
@@ -1511,6 +1609,7 @@ return {
         price = 25195,
         category = 'motorcycles',
         hash = `deathbike3`,
+        shop = 'pdm'
     },
     defiler = {
         name = 'Defiler',
@@ -1519,6 +1618,7 @@ return {
         price = 25616,
         category = 'motorcycles',
         hash = `defiler`,
+        shop = 'pdm'
     },
     deity = {
         name = 'Deity',
@@ -1527,6 +1627,7 @@ return {
         price = 73581,
         category = 'sedans',
         hash = `deity`,
+        shop = 'pdm'
     },
     deluxo = {
         name = 'Deluxo',
@@ -1535,6 +1636,7 @@ return {
         price = 70738,
         category = 'sportsclassics',
         hash = `deluxo`,
+        shop = 'pdm'
     },
     deveste = {
         name = 'Deveste',
@@ -1543,6 +1645,7 @@ return {
         price = 87916,
         category = 'super',
         hash = `deveste`,
+        shop = 'luxury'
     },
     deviant = {
         name = 'Deviant',
@@ -1551,6 +1654,7 @@ return {
         price = 70267,
         category = 'muscle',
         hash = `deviant`,
+        shop = 'pdm'
     },
     diablous = {
         name = 'Diablous',
@@ -1559,6 +1663,7 @@ return {
         price = 24745,
         category = 'motorcycles',
         hash = `diablous`,
+        shop = 'pdm'
     },
     diablous2 = {
         name = 'Diablous Custom',
@@ -1567,6 +1672,7 @@ return {
         price = 24901,
         category = 'motorcycles',
         hash = `diablous2`,
+        shop = 'pdm'
     },
     dilettante = {
         name = 'Dilettante',
@@ -1575,6 +1681,7 @@ return {
         price = 40298,
         category = 'compacts',
         hash = `dilettante`,
+        shop = 'pdm'
     },
     dilettante2 = {
         name = 'Dilettante (Security)',
@@ -1583,6 +1690,7 @@ return {
         price = 40298,
         category = 'compacts',
         hash = `dilettante2`,
+        shop = 'pdm'
     },
     dinghy = {
         name = 'Dinghy',
@@ -1591,6 +1699,7 @@ return {
         price = 446680,
         category = 'boats',
         hash = `dinghy`,
+        shop = 'boats'
     },
     dinghy2 = {
         name = 'Dinghy',
@@ -1599,6 +1708,7 @@ return {
         price = 446680,
         category = 'boats',
         hash = `dinghy2`,
+        shop = 'boats'
     },
     dinghy3 = {
         name = 'Dinghy (Heist)',
@@ -1607,6 +1717,7 @@ return {
         price = 446680,
         category = 'boats',
         hash = `dinghy3`,
+        shop = 'boats'
     },
     dinghy4 = {
         name = 'Dinghy (Yacht)',
@@ -1615,6 +1726,7 @@ return {
         price = 446680,
         category = 'boats',
         hash = `dinghy4`,
+        shop = 'boats'
     },
     dinghy5 = {
         name = 'Weaponized Dinghy',
@@ -1622,7 +1734,7 @@ return {
         model = 'dinghy5',
         price = 446680,
         category = 'boats',
-        hash = `dinghy5`,
+        hash = `dinghy5`
     },
     dloader = {
         name = 'Duneloader',
@@ -1630,7 +1742,7 @@ return {
         model = 'dloader',
         price = 55231,
         category = 'offroad',
-        hash = `dloader`,
+        hash = `dloader`
     },
     docktrailer = {
         name = 'Dock Trailer',
@@ -1638,7 +1750,7 @@ return {
         model = 'docktrailer',
         price = 5668,
         category = 'utility',
-        hash = `docktrailer`,
+        hash = `docktrailer`
     },
     docktug = {
         name = 'Docktug',
@@ -1646,7 +1758,7 @@ return {
         model = 'docktug',
         price = 41473,
         category = 'utility',
-        hash = `docktug`,
+        hash = `docktug`
     },
     dodo = {
         name = 'Dodo',
@@ -1655,6 +1767,7 @@ return {
         price = 1321065,
         category = 'planes',
         hash = `dodo`,
+        shop = 'air'
     },
     dominator = {
         name = 'Dominator',
@@ -1663,6 +1776,7 @@ return {
         price = 80149,
         category = 'muscle',
         hash = `dominator`,
+        shop = 'pdm'
     },
     dominator2 = {
         name = 'Pisswasser Dominator',
@@ -1671,6 +1785,7 @@ return {
         price = 81440,
         category = 'muscle',
         hash = `dominator2`,
+        shop = 'pdm'
     },
     dominator3 = {
         name = 'Dominator GTX',
@@ -1679,6 +1794,7 @@ return {
         price = 77862,
         category = 'muscle',
         hash = `dominator3`,
+        shop = 'pdm'
     },
     dominator4 = {
         name = 'Dominator Arena',
@@ -1687,6 +1803,7 @@ return {
         price = 80565,
         category = 'muscle',
         hash = `dominator4`,
+        shop = 'pdm'
     },
     dominator5 = {
         name = 'Future Shock Dominator',
@@ -1694,7 +1811,7 @@ return {
         model = 'dominator5',
         price = 80565,
         category = 'muscle',
-        hash = `dominator5`,
+        hash = `dominator5`
     },
     dominator6 = {
         name = 'Nightmare Dominator',
@@ -1702,7 +1819,7 @@ return {
         model = 'dominator6',
         price = 80565,
         category = 'muscle',
-        hash = `dominator6`,
+        hash = `dominator6`
     },
     dominator7 = {
         name = 'Dominator ASP',
@@ -1711,6 +1828,7 @@ return {
         price = 83320,
         category = 'muscle',
         hash = `dominator7`,
+        shop = 'pdm'
     },
     dominator8 = {
         name = 'Dominator GTT',
@@ -1719,6 +1837,7 @@ return {
         price = 76296,
         category = 'muscle',
         hash = `dominator8`,
+        shop = 'pdm'
     },
     dominator9 = {
         name = 'Dominator GT',
@@ -1726,7 +1845,7 @@ return {
         model = 'dominator9',
         price = 82702,
         category = 'muscle',
-        hash = `dominator9`,
+        hash = `dominator9`
     },
     dorado = {
         name = 'Dorado',
@@ -1734,7 +1853,7 @@ return {
         model = 'dorado',
         price = 69578,
         category = 'suvs',
-        hash = `dorado`,
+        hash = `dorado`
     },
     double = {
         name = 'Double-T',
@@ -1743,6 +1862,7 @@ return {
         price = 25173,
         category = 'motorcycles',
         hash = `double`,
+        shop = 'pdm'
     },
     drafter = {
         name = '8F Drafter',
@@ -1751,6 +1871,7 @@ return {
         price = 79907,
         category = 'sports',
         hash = `drafter`,
+        shop = 'luxury'
     },
     draugur = {
         name = 'Draugur',
@@ -1759,6 +1880,7 @@ return {
         price = 72622,
         category = 'offroad',
         hash = `draugur`,
+        shop = 'pdm'
     },
     drifteuros = {
         name = 'Euros (Drift)',
@@ -1766,7 +1888,7 @@ return {
         model = 'drifteuros',
         price = 76163,
         category = 'sports',
-        hash = `drifteuros`,
+        hash = `drifteuros`
     },
     driftfr36 = {
         name = 'FR36 (Drift)',
@@ -1774,7 +1896,7 @@ return {
         model = 'driftfr36',
         price = 75045,
         category = 'coupes',
-        hash = `driftfr36`,
+        hash = `driftfr36`
     },
     driftfuto = {
         name = 'Futo GTX (Drift)',
@@ -1782,7 +1904,7 @@ return {
         model = 'driftfuto',
         price = 75037,
         category = 'sports',
-        hash = `driftfuto`,
+        hash = `driftfuto`
     },
     driftjester = {
         name = 'Jester RR (Drift)',
@@ -1790,7 +1912,7 @@ return {
         model = 'driftjester',
         price = 74933,
         category = 'sports',
-        hash = `driftjester`,
+        hash = `driftjester`
     },
     driftremus = {
         name = 'Remus (Drift)',
@@ -1798,7 +1920,7 @@ return {
         model = 'driftremus',
         price = 78305,
         category = 'sports',
-        hash = `driftremus`,
+        hash = `driftremus`
     },
     drifttampa = {
         name = 'Drift Tampa',
@@ -1806,7 +1928,7 @@ return {
         model = 'drifttampa',
         price = 78299,
         category = 'sports',
-        hash = `drifttampa`,
+        hash = `drifttampa`
     },
     driftyosemite = {
         name = 'Drift Yosemite',
@@ -1814,7 +1936,7 @@ return {
         model = 'driftyosemite',
         price = 70884,
         category = 'muscle',
-        hash = `driftyosemite`,
+        hash = `driftyosemite`
     },
     driftzr350 = {
         name = 'ZR350 (Drift)',
@@ -1822,7 +1944,7 @@ return {
         model = 'driftzr350',
         price = 75060,
         category = 'sports',
-        hash = `driftzr350`,
+        hash = `driftzr350`
     },
     dubsta = {
         name = 'Dubsta',
@@ -1831,6 +1953,7 @@ return {
         price = 62617,
         category = 'suvs',
         hash = `dubsta`,
+        shop = 'pdm'
     },
     dubsta2 = {
         name = 'Dubsta',
@@ -1839,6 +1962,7 @@ return {
         price = 62617,
         category = 'suvs',
         hash = `dubsta2`,
+        shop = 'pdm'
     },
     dubsta3 = {
         name = 'Dubsta 6x6',
@@ -1847,6 +1971,7 @@ return {
         price = 64556,
         category = 'offroad',
         hash = `dubsta3`,
+        shop = 'pdm'
     },
     dukes = {
         name = 'Dukes',
@@ -1855,6 +1980,7 @@ return {
         price = 79383,
         category = 'muscle',
         hash = `dukes`,
+        shop = 'pdm'
     },
     dukes2 = {
         name = 'Dukes Nightrider',
@@ -1863,6 +1989,7 @@ return {
         price = 77611,
         category = 'muscle',
         hash = `dukes2`,
+        shop = 'pdm'
     },
     dukes3 = {
         name = 'Beater Dukes',
@@ -1871,6 +1998,7 @@ return {
         price = 78577,
         category = 'muscle',
         hash = `dukes3`,
+        shop = 'pdm'
     },
     dump = {
         name = 'Dump',
@@ -1878,7 +2006,7 @@ return {
         model = 'dump',
         price = 24629,
         category = 'industrial',
-        hash = `dump`,
+        hash = `dump`
     },
     dune = {
         name = 'Dune Buggy',
@@ -1887,6 +2015,7 @@ return {
         price = 64617,
         category = 'offroad',
         hash = `dune`,
+        shop = 'pdm'
     },
     dune2 = {
         name = 'Space Docker',
@@ -1894,7 +2023,7 @@ return {
         model = 'dune2',
         price = 63085,
         category = 'offroad',
-        hash = `dune2`,
+        hash = `dune2`
     },
     dune3 = {
         name = 'Dune FAV',
@@ -1902,7 +2031,7 @@ return {
         model = 'dune3',
         price = 64617,
         category = 'offroad',
-        hash = `dune3`,
+        hash = `dune3`
     },
     dune4 = {
         name = 'Ramp Buggy',
@@ -1910,7 +2039,7 @@ return {
         model = 'dune4',
         price = 82003,
         category = 'offroad',
-        hash = `dune4`,
+        hash = `dune4`
     },
     dune5 = {
         name = 'Ramp Buggy',
@@ -1918,7 +2047,7 @@ return {
         model = 'dune5',
         price = 81376,
         category = 'offroad',
-        hash = `dune5`,
+        hash = `dune5`
     },
     duster = {
         name = 'Duster',
@@ -1927,6 +2056,7 @@ return {
         price = 1321065,
         category = 'planes',
         hash = `duster`,
+        shop = 'air'
     },
     dynasty = {
         name = 'Dynasty',
@@ -1935,6 +2065,7 @@ return {
         price = 58840,
         category = 'sportsclassics',
         hash = `dynasty`,
+        shop = 'pdm'
     },
     elegy = {
         name = 'Elegy Retro Custom',
@@ -1943,6 +2074,7 @@ return {
         price = 78735,
         category = 'sports',
         hash = `elegy`,
+        shop = 'luxury'
     },
     elegy2 = {
         name = 'Elegy RH8',
@@ -1951,6 +2083,7 @@ return {
         price = 80339,
         category = 'sports',
         hash = `elegy2`,
+        shop = 'luxury'
     },
     ellie = {
         name = 'Ellie',
@@ -1959,6 +2092,7 @@ return {
         price = 75782,
         category = 'muscle',
         hash = `ellie`,
+        shop = 'pdm'
     },
     emerus = {
         name = 'Progen Emerus',
@@ -1967,6 +2101,7 @@ return {
         price = 85112,
         category = 'super',
         hash = `emerus`,
+        shop = 'luxury'
     },
     emperor = {
         name = 'Emperor',
@@ -1975,6 +2110,7 @@ return {
         price = 56110,
         category = 'sedans',
         hash = `emperor`,
+        shop = 'pdm'
     },
     emperor2 = {
         name = 'Emperor (Beater)',
@@ -1982,7 +2118,7 @@ return {
         model = 'emperor2',
         price = 56110,
         category = 'sedans',
-        hash = `emperor2`,
+        hash = `emperor2`
     },
     emperor3 = {
         name = 'Emperor (Snow)',
@@ -1990,7 +2126,7 @@ return {
         model = 'emperor3',
         price = 56110,
         category = 'sedans',
-        hash = `emperor3`,
+        hash = `emperor3`
     },
     enduro = {
         name = 'Enduro',
@@ -1999,6 +2135,7 @@ return {
         price = 20848,
         category = 'motorcycles',
         hash = `enduro`,
+        shop = 'pdm'
     },
     entity2 = {
         name = 'Entity XXR',
@@ -2007,6 +2144,7 @@ return {
         price = 89286,
         category = 'super',
         hash = `entity2`,
+        shop = 'luxury'
     },
     entity3 = {
         name = 'Entity MT',
@@ -2014,7 +2152,7 @@ return {
         model = 'entity3',
         price = 89208,
         category = 'super',
-        hash = `entity3`,
+        hash = `entity3`
     },
     entityxf = {
         name = 'Entity XF',
@@ -2023,6 +2161,7 @@ return {
         price = 84601,
         category = 'super',
         hash = `entityxf`,
+        shop = 'luxury'
     },
     esskey = {
         name = 'Esskey',
@@ -2031,6 +2170,7 @@ return {
         price = 23138,
         category = 'motorcycles',
         hash = `esskey`,
+        shop = 'pdm'
     },
     eudora = {
         name = 'Eudora',
@@ -2038,7 +2178,7 @@ return {
         model = 'eudora',
         price = 66819,
         category = 'muscle',
-        hash = `eudora`,
+        hash = `eudora`
     },
     euros = {
         name = 'Euros',
@@ -2047,6 +2187,7 @@ return {
         price = 78840,
         category = 'sports',
         hash = `euros`,
+        shop = 'luxury'
     },
     everon = {
         name = 'Everon',
@@ -2055,6 +2196,7 @@ return {
         price = 68803,
         category = 'offroad',
         hash = `everon`,
+        shop = 'pdm'
     },
     everon2 = {
         name = 'Hotring Everon',
@@ -2062,7 +2204,7 @@ return {
         model = 'everon2',
         price = 79842,
         category = 'sports',
-        hash = `everon2`,
+        hash = `everon2`
     },
     exemplar = {
         name = 'Exemplar',
@@ -2071,6 +2213,7 @@ return {
         price = 79891,
         category = 'coupes',
         hash = `exemplar`,
+        shop = 'pdm'
     },
     f620 = {
         name = 'F620',
@@ -2079,6 +2222,7 @@ return {
         price = 79607,
         category = 'coupes',
         hash = `f620`,
+        shop = 'pdm'
     },
     faction = {
         name = 'Faction',
@@ -2087,6 +2231,7 @@ return {
         price = 77450,
         category = 'muscle',
         hash = `faction`,
+        shop = 'pdm'
     },
     faction2 = {
         name = 'Faction Rider',
@@ -2095,6 +2240,7 @@ return {
         price = 77450,
         category = 'muscle',
         hash = `faction2`,
+        shop = 'pdm'
     },
     faction3 = {
         name = 'Faction Custom Donk',
@@ -2103,6 +2249,7 @@ return {
         price = 58971,
         category = 'muscle',
         hash = `faction3`,
+        shop = 'pdm'
     },
     fagaloa = {
         name = 'Fagaloa',
@@ -2111,6 +2258,7 @@ return {
         price = 57546,
         category = 'sportsclassics',
         hash = `fagaloa`,
+        shop = 'pdm'
     },
     faggio = {
         name = 'Faggio Sport',
@@ -2119,6 +2267,7 @@ return {
         price = 14728,
         category = 'motorcycles',
         hash = `faggio`,
+        shop = 'pdm'
     },
     faggio2 = {
         name = 'Faggio Sport',
@@ -2127,6 +2276,7 @@ return {
         price = 12263,
         category = 'motorcycles',
         hash = `faggio2`,
+        shop = 'pdm'
     },
     faggio3 = {
         name = 'Faggio Mod',
@@ -2135,6 +2285,7 @@ return {
         price = 14291,
         category = 'motorcycles',
         hash = `faggio3`,
+        shop = 'pdm'
     },
     fbi = {
         name = 'FIB',
@@ -2142,7 +2293,7 @@ return {
         model = 'fbi',
         price = 76794,
         category = 'emergency',
-        hash = `fbi`,
+        hash = `fbi`
     },
     fbi2 = {
         name = 'FIB',
@@ -2150,7 +2301,7 @@ return {
         model = 'fbi2',
         price = 62617,
         category = 'emergency',
-        hash = `fbi2`,
+        hash = `fbi2`
     },
     fcr = {
         name = 'FCR 1000',
@@ -2159,6 +2310,7 @@ return {
         price = 24321,
         category = 'motorcycles',
         hash = `fcr`,
+        shop = 'pdm'
     },
     fcr2 = {
         name = 'FCR 1000 Custom',
@@ -2167,6 +2319,7 @@ return {
         price = 24491,
         category = 'motorcycles',
         hash = `fcr2`,
+        shop = 'pdm'
     },
     felon = {
         name = 'Felon',
@@ -2175,6 +2328,7 @@ return {
         price = 76088,
         category = 'coupes',
         hash = `felon`,
+        shop = 'pdm'
     },
     felon2 = {
         name = 'Felon GT',
@@ -2183,6 +2337,7 @@ return {
         price = 72343,
         category = 'coupes',
         hash = `felon2`,
+        shop = 'pdm'
     },
     feltzer2 = {
         name = 'Feltzer',
@@ -2191,6 +2346,7 @@ return {
         price = 82235,
         category = 'sports',
         hash = `feltzer2`,
+        shop = 'luxury'
     },
     feltzer3 = {
         name = 'Stirling GT',
@@ -2199,6 +2355,7 @@ return {
         price = 76445,
         category = 'sportsclassics',
         hash = `feltzer3`,
+        shop = 'pdm'
     },
     firetruk = {
         name = 'Fire Truck',
@@ -2206,7 +2363,7 @@ return {
         model = 'firetruk',
         price = 64793,
         category = 'emergency',
-        hash = `firetruk`,
+        hash = `firetruk`
     },
     fixter = {
         name = 'Fixter',
@@ -2215,6 +2372,7 @@ return {
         price = 2835,
         category = 'cycles',
         hash = `fixter`,
+        shop = 'pdm'
     },
     flashgt = {
         name = 'Flash GT',
@@ -2223,6 +2381,7 @@ return {
         price = 73890,
         category = 'sports',
         hash = `flashgt`,
+        shop = 'luxury'
     },
     flatbed = {
         name = 'Flatbed',
@@ -2230,7 +2389,7 @@ return {
         model = 'flatbed',
         price = 46633,
         category = 'industrial',
-        hash = `flatbed`,
+        hash = `flatbed`
     },
     fmj = {
         name = 'FMJ',
@@ -2239,6 +2398,7 @@ return {
         price = 88017,
         category = 'super',
         hash = `fmj`,
+        shop = 'luxury'
     },
     forklift = {
         name = 'Forklift',
@@ -2246,7 +2406,7 @@ return {
         model = 'forklift',
         price = 17664,
         category = 'utility',
-        hash = `forklift`,
+        hash = `forklift`
     },
     formula = {
         name = 'PR4',
@@ -2254,7 +2414,7 @@ return {
         model = 'formula',
         price = 106933,
         category = 'openwheel',
-        hash = `formula`,
+        hash = `formula`
     },
     formula2 = {
         name = 'R88',
@@ -2262,7 +2422,7 @@ return {
         model = 'formula2',
         price = 106571,
         category = 'openwheel',
-        hash = `formula2`,
+        hash = `formula2`
     },
     fq2 = {
         name = 'FQ2',
@@ -2271,6 +2431,7 @@ return {
         price = 65442,
         category = 'suvs',
         hash = `fq2`,
+        shop = 'pdm'
     },
     fr36 = {
         name = 'FR36',
@@ -2278,7 +2439,7 @@ return {
         model = 'fr36',
         price = 78667,
         category = 'coupes',
-        hash = `fr36`,
+        hash = `fr36`
     },
     freecrawler = {
         name = 'Freecrawler',
@@ -2287,6 +2448,7 @@ return {
         price = 60453,
         category = 'offroad',
         hash = `freecrawler`,
+        shop = 'pdm'
     },
     freight = {
         name = 'Freight Train (Locomotive)',
@@ -2294,7 +2456,7 @@ return {
         model = 'freight',
         price = 194680,
         category = 'trains',
-        hash = `freight`,
+        hash = `freight`
     },
     freight2 = {
         name = 'Freight Train (Chop Shop)',
@@ -2302,7 +2464,7 @@ return {
         model = 'freight2',
         price = 194680,
         category = 'trains',
-        hash = `freight2`,
+        hash = `freight2`
     },
     freightcar = {
         name = 'Freight Train (Container)',
@@ -2310,7 +2472,7 @@ return {
         model = 'freightcar',
         price = 194680,
         category = 'trains',
-        hash = `freightcar`,
+        hash = `freightcar`
     },
     freightcar2 = {
         name = 'Freight Train (Flatbed Trailer)',
@@ -2318,7 +2480,7 @@ return {
         model = 'freightcar2',
         price = 194680,
         category = 'trains',
-        hash = `freightcar2`,
+        hash = `freightcar2`
     },
     freightcont1 = {
         name = 'Freight Train (Container)',
@@ -2326,7 +2488,7 @@ return {
         model = 'freightcont1',
         price = 194680,
         category = 'trains',
-        hash = `freightcont1`,
+        hash = `freightcont1`
     },
     freightcont2 = {
         name = 'Freight Train (Lando Container)',
@@ -2334,7 +2496,7 @@ return {
         model = 'freightcont2',
         price = 194680,
         category = 'trains',
-        hash = `freightcont2`,
+        hash = `freightcont2`
     },
     freightgrain = {
         name = 'Freight Train (Grain Trailer)',
@@ -2342,7 +2504,7 @@ return {
         model = 'freightgrain',
         price = 194680,
         category = 'trains',
-        hash = `freightgrain`,
+        hash = `freightgrain`
     },
     freighttrailer = {
         name = 'Army Trailer',
@@ -2350,7 +2512,7 @@ return {
         model = 'freighttrailer',
         price = 5668,
         category = 'utility',
-        hash = `freighttrailer`,
+        hash = `freighttrailer`
     },
     frogger = {
         name = 'Frogger',
@@ -2359,6 +2521,7 @@ return {
         price = 6367865,
         category = 'helicopters',
         hash = `frogger`,
+        shop = 'air'
     },
     frogger2 = {
         name = 'Frogger (Trevor Philips Enterprises)',
@@ -2367,6 +2530,7 @@ return {
         price = 6367865,
         category = 'helicopters',
         hash = `frogger2`,
+        shop = 'air'
     },
     fugitive = {
         name = 'Fugitive',
@@ -2375,6 +2539,7 @@ return {
         price = 67317,
         category = 'sedans',
         hash = `fugitive`,
+        shop = 'pdm'
     },
     furia = {
         name = 'Furia',
@@ -2383,6 +2548,7 @@ return {
         price = 83110,
         category = 'super',
         hash = `furia`,
+        shop = 'luxury'
     },
     furoregt = {
         name = 'Furore GT',
@@ -2391,6 +2557,7 @@ return {
         price = 84346,
         category = 'sports',
         hash = `furoregt`,
+        shop = 'luxury'
     },
     fusilade = {
         name = 'Fusilade',
@@ -2398,7 +2565,7 @@ return {
         model = 'fusilade',
         price = 81251,
         category = 'sports',
-        hash = `fusilade`,
+        hash = `fusilade`
     },
     futo = {
         name = 'Futo',
@@ -2407,6 +2574,7 @@ return {
         price = 74336,
         category = 'sports',
         hash = `futo`,
+        shop = 'pdm'
     },
     futo2 = {
         name = 'Futo GTX',
@@ -2415,6 +2583,7 @@ return {
         price = 75463,
         category = 'sports',
         hash = `futo2`,
+        shop = 'luxury'
     },
     gargoyle = {
         name = 'Gargoyle',
@@ -2423,6 +2592,7 @@ return {
         price = 25195,
         category = 'motorcycles',
         hash = `gargoyle`,
+        shop = 'pdm'
     },
     gauntlet = {
         name = 'Gauntlet',
@@ -2431,6 +2601,7 @@ return {
         price = 78237,
         category = 'muscle',
         hash = `gauntlet`,
+        shop = 'pdm'
     },
     gauntlet2 = {
         name = 'Redwood Gauntlet',
@@ -2439,6 +2610,7 @@ return {
         price = 80506,
         category = 'muscle',
         hash = `gauntlet2`,
+        shop = 'pdm'
     },
     gauntlet3 = {
         name = 'Gauntlet Classic',
@@ -2447,6 +2619,7 @@ return {
         price = 73572,
         category = 'muscle',
         hash = `gauntlet3`,
+        shop = 'pdm'
     },
     gauntlet4 = {
         name = 'Gauntlet Hellfire',
@@ -2455,6 +2628,7 @@ return {
         price = 81048,
         category = 'muscle',
         hash = `gauntlet4`,
+        shop = 'pdm'
     },
     gauntlet5 = {
         name = 'Gauntlet Classic Custom',
@@ -2463,6 +2637,7 @@ return {
         price = 80250,
         category = 'muscle',
         hash = `gauntlet5`,
+        shop = 'pdm'
     },
     gauntlet6 = {
         name = 'Hotring Hellfire',
@@ -2470,7 +2645,7 @@ return {
         model = 'gauntlet6',
         price = 81665,
         category = 'sports',
-        hash = `gauntlet6`,
+        hash = `gauntlet6`
     },
     gb200 = {
         name = 'GB 200',
@@ -2479,6 +2654,7 @@ return {
         price = 74534,
         category = 'sports',
         hash = `gb200`,
+        shop = 'luxury'
     },
     gburrito = {
         name = 'Gang Burrito (Lost MC)',
@@ -2486,7 +2662,7 @@ return {
         model = 'gburrito',
         price = 61195,
         category = 'vans',
-        hash = `gburrito`,
+        hash = `gburrito`
     },
     gburrito2 = {
         name = 'Burrito Custom',
@@ -2495,6 +2671,7 @@ return {
         price = 66162,
         category = 'vans',
         hash = `gburrito2`,
+        shop = 'pdm'
     },
     glendale = {
         name = 'Glendale',
@@ -2503,6 +2680,7 @@ return {
         price = 65948,
         category = 'sedans',
         hash = `glendale`,
+        shop = 'pdm'
     },
     glendale2 = {
         name = 'Glendale Custom',
@@ -2511,22 +2689,24 @@ return {
         price = 66105,
         category = 'sedans',
         hash = `glendale2`,
+        shop = 'pdm'
     },
     gp1 = {
+        name = 'GP1',
         brand = 'Progen',
+        model = 'gp1',
+        price = 84220,
         category = 'super',
         hash = `gp1`,
-        model = 'gp1',
-        name = 'GP1',
-        price = 84220,
+        shop = 'luxury'
     },
     graintrailer = {
-        brand = '',
-        category = 'utility',
-        hash = `graintrailer`,
-        model = 'graintrailer',
         name = 'Grain Trailer',
+        brand = '',
+        model = 'graintrailer',
         price = 5668,
+        category = 'utility',
+        hash = `graintrailer`
     },
     granger = {
         name = 'Granger',
@@ -2535,6 +2715,7 @@ return {
         price = 60692,
         category = 'suvs',
         hash = `granger`,
+        shop = 'pdm'
     },
     granger2 = {
         name = 'Granger 3600LX',
@@ -2543,6 +2724,7 @@ return {
         price = 57057,
         category = 'suvs',
         hash = `granger2`,
+        shop = 'pdm'
     },
     greenwood = {
         name = 'Greenwood',
@@ -2551,6 +2733,7 @@ return {
         price = 78897,
         category = 'muscle',
         hash = `greenwood`,
+        shop = 'pdm'
     },
     gresley = {
         name = 'Gresley',
@@ -2559,6 +2742,7 @@ return {
         price = 63694,
         category = 'suvs',
         hash = `gresley`,
+        shop = 'pdm'
     },
     growler = {
         name = 'Growler',
@@ -2567,6 +2751,7 @@ return {
         price = 82635,
         category = 'sports',
         hash = `growler`,
+        shop = 'luxury'
     },
     gt500 = {
         name = 'GT500',
@@ -2575,6 +2760,7 @@ return {
         price = 76158,
         category = 'sportsclassics',
         hash = `gt500`,
+        shop = 'pdm'
     },
     guardian = {
         name = 'Guardian',
@@ -2583,6 +2769,7 @@ return {
         price = 65628,
         category = 'industrial',
         hash = `guardian`,
+        shop = 'pdm'
     },
     habanero = {
         name = 'Habanero',
@@ -2591,6 +2778,7 @@ return {
         price = 65442,
         category = 'suvs',
         hash = `habanero`,
+        shop = 'pdm'
     },
     hakuchou = {
         name = 'Hakuchou',
@@ -2599,6 +2787,7 @@ return {
         price = 25975,
         category = 'motorcycles',
         hash = `hakuchou`,
+        shop = 'pdm'
     },
     hakuchou2 = {
         name = 'Hakuchou Drag',
@@ -2607,6 +2796,7 @@ return {
         price = 27374,
         category = 'motorcycles',
         hash = `hakuchou2`,
+        shop = 'pdm'
     },
     halftrack = {
         name = 'Half-track',
@@ -2614,7 +2804,7 @@ return {
         model = 'halftrack',
         price = 34933,
         category = 'military',
-        hash = `halftrack`,
+        hash = `halftrack`
     },
     handler = {
         name = 'Dock Handler',
@@ -2622,7 +2812,7 @@ return {
         model = 'handler',
         price = 14549,
         category = 'industrial',
-        hash = `handler`,
+        hash = `handler`
     },
     hauler = {
         name = 'Hauler',
@@ -2630,7 +2820,7 @@ return {
         model = 'hauler',
         price = 48240,
         category = 'commercial',
-        hash = `hauler`,
+        hash = `hauler`
     },
     hauler2 = {
         name = 'Hauler Custom',
@@ -2638,7 +2828,7 @@ return {
         model = 'hauler2',
         price = 70102,
         category = 'commercial',
-        hash = `hauler2`,
+        hash = `hauler2`
     },
     havok = {
         name = 'Havok',
@@ -2647,6 +2837,7 @@ return {
         price = 6462758,
         category = 'helicopters',
         hash = `havok`,
+        shop = 'air'
     },
     hellion = {
         name = 'Hellion',
@@ -2655,6 +2846,7 @@ return {
         price = 66525,
         category = 'offroad',
         hash = `hellion`,
+        shop = 'pdm'
     },
     hermes = {
         name = 'Hermes',
@@ -2663,6 +2855,7 @@ return {
         price = 68776,
         category = 'muscle',
         hash = `hermes`,
+        shop = 'pdm'
     },
     hexer = {
         name = 'Hexer',
@@ -2671,14 +2864,16 @@ return {
         price = 22521,
         category = 'motorcycles',
         hash = `hexer`,
+        shop = 'pdm'
     },
     hotknife = {
-        brand = 'Vapid',
         name = 'Hotknife',
+        brand = 'Vapid',
         model = 'hotknife',
         price = 74328,
         category = 'muscle',
         hash = `hotknife`,
+        shop = 'pdm'
     },
     hotring = {
         name = 'Hotring Sabre',
@@ -2686,7 +2881,7 @@ return {
         model = 'hotring',
         price = 79724,
         category = 'sports',
-        hash = `hotring`,
+        hash = `hotring`
     },
     howard = {
         name = 'Howard NX-25',
@@ -2695,6 +2890,7 @@ return {
         price = 2587839,
         category = 'planes',
         hash = `howard`,
+        shop = 'air'
     },
     hunter = {
         name = 'FH-1 Hunter',
@@ -2702,7 +2898,7 @@ return {
         model = 'hunter',
         price = 6546934,
         category = 'helicopters',
-        hash = `hunter`,
+        hash = `hunter`
     },
     huntley = {
         name = 'Huntley S',
@@ -2711,6 +2907,7 @@ return {
         price = 74869,
         category = 'suvs',
         hash = `huntley`,
+        shop = 'pdm'
     },
     hustler = {
         name = 'Hustler',
@@ -2719,6 +2916,7 @@ return {
         price = 72900,
         category = 'muscle',
         hash = `hustler`,
+        shop = 'pdm'
     },
     hydra = {
         name = 'Hydra',
@@ -2726,7 +2924,7 @@ return {
         model = 'hydra',
         price = 2193367,
         category = 'planes',
-        hash = `hydra`,
+        hash = `hydra`
     },
     ignus = {
         name = 'Ignus',
@@ -2735,6 +2933,7 @@ return {
         price = 87219,
         category = 'super',
         hash = `ignus`,
+        shop = 'pdm'
     },
     imorgon = {
         name = 'Imorgon',
@@ -2743,6 +2942,7 @@ return {
         price = 76854,
         category = 'sports',
         hash = `imorgon`,
+        shop = 'luxury'
     },
     impaler = {
         name = 'Impaler',
@@ -2751,6 +2951,7 @@ return {
         price = 74584,
         category = 'muscle',
         hash = `impaler`,
+        shop = 'pdm'
     },
     impaler2 = {
         name = 'Apocalypse Impaler',
@@ -2759,6 +2960,7 @@ return {
         price = 84076,
         category = 'muscle',
         hash = `impaler2`,
+        shop = 'pdm'
     },
     impaler3 = {
         name = 'Future Shock Impaler',
@@ -2767,6 +2969,7 @@ return {
         price = 84076,
         category = 'muscle',
         hash = `impaler3`,
+        shop = 'pdm'
     },
     impaler4 = {
         name = 'Nightmare Impaler',
@@ -2775,6 +2978,7 @@ return {
         price = 84076,
         category = 'muscle',
         hash = `impaler4`,
+        shop = 'pdm'
     },
     impaler5 = {
         name = 'Impaler SZ',
@@ -2782,7 +2986,7 @@ return {
         model = 'impaler5',
         price = 78875,
         category = 'sedans',
-        hash = `impaler5`,
+        hash = `impaler5`
     },
     impaler6 = {
         name = 'Impaler LX',
@@ -2790,7 +2994,7 @@ return {
         model = 'impaler6',
         price = 77917,
         category = 'muscle',
-        hash = `impaler6`,
+        hash = `impaler6`
     },
     imperator = {
         name = 'Apocalypse Imperator',
@@ -2799,6 +3003,7 @@ return {
         price = 80296,
         category = 'muscle',
         hash = `imperator`,
+        shop = 'pdm'
     },
     imperator2 = {
         name = 'Future Shock Imperator',
@@ -2807,6 +3012,7 @@ return {
         price = 80296,
         category = 'muscle',
         hash = `imperator2`,
+        shop = 'pdm'
     },
     imperator3 = {
         name = 'Nightmare Imperator',
@@ -2815,6 +3021,7 @@ return {
         price = 80296,
         category = 'muscle',
         hash = `imperator3`,
+        shop = 'pdm'
     },
     inductor = {
         name = 'Inductor',
@@ -2822,7 +3029,7 @@ return {
         model = 'inductor',
         price = 2607,
         category = 'cycles',
-        hash = `inductor`,
+        hash = `inductor`
     },
     inductor2 = {
         name = 'Junk Energy Inductor',
@@ -2830,7 +3037,7 @@ return {
         model = 'inductor2',
         price = 2607,
         category = 'cycles',
-        hash = `inductor2`,
+        hash = `inductor2`
     },
     infernus = {
         name = 'Infernus',
@@ -2839,6 +3046,7 @@ return {
         price = 81077,
         category = 'super',
         hash = `infernus`,
+        shop = 'luxury'
     },
     infernus2 = {
         name = 'Infernus Classic',
@@ -2847,6 +3055,7 @@ return {
         price = 79349,
         category = 'sportsclassics',
         hash = `infernus2`,
+        shop = 'pdm'
     },
     ingot = {
         name = 'Ingot',
@@ -2855,6 +3064,7 @@ return {
         price = 53344,
         category = 'sedans',
         hash = `ingot`,
+        shop = 'pdm'
     },
     innovation = {
         name = 'Innovation',
@@ -2863,6 +3073,7 @@ return {
         price = 23509,
         category = 'motorcycles',
         hash = `innovation`,
+        shop = 'pdm'
     },
     insurgent = {
         name = 'Insurgent Pick-Up',
@@ -2870,7 +3081,7 @@ return {
         model = 'insurgent',
         price = 59045,
         category = 'offroad',
-        hash = `insurgent`,
+        hash = `insurgent`
     },
     insurgent2 = {
         name = 'Insurgent',
@@ -2878,7 +3089,7 @@ return {
         model = 'insurgent2',
         price = 59045,
         category = 'offroad',
-        hash = `insurgent2`,
+        hash = `insurgent2`
     },
     insurgent3 = {
         name = 'Insurgent Pick-Up Custom',
@@ -2886,7 +3097,7 @@ return {
         model = 'insurgent3',
         price = 59045,
         category = 'offroad',
-        hash = `insurgent3`,
+        hash = `insurgent3`
     },
     intruder = {
         name = 'Intruder',
@@ -2895,62 +3106,69 @@ return {
         price = 65682,
         category = 'sedans',
         hash = `intruder`,
+        shop = 'pdm'
     },
     issi2 = {
+        name = 'Issi',
         brand = 'Weeny',
+        model = 'issi2',
+        price = 69371,
         category = 'compacts',
         hash = `issi2`,
-        model = 'issi2',
-        name = 'Issi',
-        price = 69371,
+        shop = 'pdm'
     },
     issi3 = {
+        name = 'Issi Classic',
         brand = 'Weeny',
+        model = 'issi3',
+        price = 65593,
         category = 'compacts',
         hash = `issi3`,
-        model = 'issi3',
-        name = 'Issi Classic',
-        price = 65593,
+        shop = 'pdm'
     },
     issi4 = {
+        name = 'Apocalypse Issi',
         brand = 'Weeny',
+        model = 'issi4',
+        price = 74235,
         category = 'compacts',
         hash = `issi4`,
-        model = 'issi4',
-        name = 'Apocalypse Issi',
-        price = 74235,
+        shop = 'pdm'
     },
     issi5 = {
+        name = 'Future Shock Issi',
         brand = 'Weeny',
+        model = 'issi5',
+        price = 74235,
         category = 'compacts',
         hash = `issi5`,
-        model = 'issi5',
-        name = 'Future Shock Issi',
-        price = 74235,
+        shop = 'pdm'
     },
     issi6 = {
+        name = 'Nightmare Issi',
         brand = 'Weeny',
+        model = 'issi6',
+        price = 74235,
         category = 'compacts',
         hash = `issi6`,
-        model = 'issi6',
-        name = 'Nightmare Issi',
-        price = 74235,
+        shop = 'pdm'
     },
     issi7 = {
+        name = 'Issi Sport',
         brand = 'Weeny',
+        model = 'issi7',
+        price = 70443,
         category = 'sports',
         hash = `issi7`,
-        model = 'issi7',
-        name = 'Issi Sport',
-        price = 70443,
+        shop = 'pdm'
     },
     issi8 = {
-        brand = 'Weeny',
-        category = 'suvs',
-        hash = `issi8`,
-        model = 'issi8',
         name = 'Issi Rally',
+        brand = 'Weeny',
+        model = 'issi8',
         price = 79711,
+        category = 'suvs',
+        hash = `issi8`
     },
     italigtb = {
         name = 'Itali GTB',
@@ -2959,6 +3177,7 @@ return {
         price = 86900,
         category = 'super',
         hash = `italigtb`,
+        shop = 'luxury'
     },
     italigtb2 = {
         name = 'Itali GTB Custom',
@@ -2967,6 +3186,7 @@ return {
         price = 87587,
         category = 'super',
         hash = `italigtb2`,
+        shop = 'luxury'
     },
     italigto = {
         name = 'Itali GTO',
@@ -2975,6 +3195,7 @@ return {
         price = 87475,
         category = 'sports',
         hash = `italigto`,
+        shop = 'luxury'
     },
     italirsx = {
         name = 'Itali RSX',
@@ -2983,14 +3204,16 @@ return {
         price = 87682,
         category = 'sports',
         hash = `italirsx`,
+        shop = 'luxury'
     },
     iwagen = {
-        brand = 'Obey',
         name = 'I-Wagen',
+        brand = 'Obey',
         model = 'iwagen',
         price = 55888,
         category = 'suvs',
         hash = `iwagen`,
+        shop = 'pdm'
     },
     jackal = {
         name = 'Jackal',
@@ -2999,6 +3222,7 @@ return {
         price = 76324,
         category = 'coupes',
         hash = `jackal`,
+        shop = 'pdm'
     },
     jb700 = {
         name = 'JB 700',
@@ -3007,6 +3231,7 @@ return {
         price = 82400,
         category = 'sportsclassics',
         hash = `jb700`,
+        shop = 'pdm'
     },
     jb7002 = {
         name = 'JB 700W',
@@ -3015,6 +3240,7 @@ return {
         price = 82400,
         category = 'sportsclassics',
         hash = `jb7002`,
+        shop = 'pdm'
     },
     jester = {
         name = 'Jester',
@@ -3023,6 +3249,7 @@ return {
         price = 76685,
         category = 'sports',
         hash = `jester`,
+        shop = 'luxury'
     },
     jester2 = {
         name = 'Jester (Racecar)',
@@ -3031,6 +3258,7 @@ return {
         price = 78165,
         category = 'sports',
         hash = `jester2`,
+        shop = 'luxury'
     },
     jester3 = {
         name = 'Jester Classic',
@@ -3039,6 +3267,7 @@ return {
         price = 80462,
         category = 'sports',
         hash = `jester3`,
+        shop = 'luxury'
     },
     jester4 = {
         name = 'Jester RR',
@@ -3047,6 +3276,7 @@ return {
         price = 79879,
         category = 'sports',
         hash = `jester4`,
+        shop = 'luxury'
     },
     jet = {
         name = 'Jet',
@@ -3054,7 +3284,7 @@ return {
         model = 'jet',
         price = 1537948,
         category = 'planes',
-        hash = `jet`,
+        hash = `jet`
     },
     jetmax = {
         name = 'Jetmax',
@@ -3063,6 +3293,7 @@ return {
         price = 478680,
         category = 'boats',
         hash = `jetmax`,
+        shop = 'boats'
     },
     journey = {
         name = 'Journey',
@@ -3071,6 +3302,7 @@ return {
         price = 52886,
         category = 'vans',
         hash = `journey`,
+        shop = 'pdm'
     },
     journey2 = {
         name = 'Journey II',
@@ -3078,7 +3310,7 @@ return {
         model = 'journey2',
         price = 52886,
         category = 'vans',
-        hash = `journey2`,
+        hash = `journey2`
     },
     jubilee = {
         name = 'Jubilee',
@@ -3087,6 +3319,7 @@ return {
         price = 71210,
         category = 'suvs',
         hash = `jubilee`,
+        shop = 'pdm'
     },
     jugular = {
         name = 'Jugular',
@@ -3095,6 +3328,7 @@ return {
         price = 81412,
         category = 'sports',
         hash = `jugular`,
+        shop = 'luxury'
     },
     kalahari = {
         name = 'Kalahari',
@@ -3103,6 +3337,7 @@ return {
         price = 59046,
         category = 'offroad',
         hash = `kalahari`,
+        shop = 'pdm'
     },
     kamacho = {
         name = 'Kamacho',
@@ -3111,6 +3346,7 @@ return {
         price = 67315,
         category = 'offroad',
         hash = `kamacho`,
+        shop = 'pdm'
     },
     kanjo = {
         name = 'Blista Kanjo',
@@ -3119,6 +3355,7 @@ return {
         price = 73478,
         category = 'compacts',
         hash = `kanjo`,
+        shop = 'pdm'
     },
     kanjosj = {
         name = 'Kanjo SJ',
@@ -3127,6 +3364,7 @@ return {
         price = 73789,
         category = 'coupes',
         hash = `kanjosj`,
+        shop = 'pdm'
     },
     khamelion = {
         name = 'Khamelion',
@@ -3135,6 +3373,7 @@ return {
         price = 53292,
         category = 'sports',
         hash = `khamelion`,
+        shop = 'luxury'
     },
     khanjali = {
         name = 'TM-02 Khanjali',
@@ -3142,7 +3381,7 @@ return {
         model = 'khanjali',
         price = 30243,
         category = 'military',
-        hash = `khanjali`,
+        hash = `khanjali`
     },
     komoda = {
         name = 'Komoda',
@@ -3151,6 +3390,7 @@ return {
         price = 83129,
         category = 'sports',
         hash = `komoda`,
+        shop = 'luxury'
     },
     kosatka = {
         name = 'Kosatka',
@@ -3158,7 +3398,7 @@ return {
         model = 'kosatka',
         price = 624016,
         category = 'boats',
-        hash = `kosatka`,
+        hash = `kosatka`
     },
     krieger = {
         name = 'Krieger',
@@ -3167,6 +3407,7 @@ return {
         price = 87715,
         category = 'super',
         hash = `krieger`,
+        shop = 'luxury'
     },
     kuruma = {
         name = 'Kuruma',
@@ -3175,6 +3416,7 @@ return {
         price = 77445,
         category = 'sports',
         hash = `kuruma`,
+        shop = 'luxury'
     },
     kuruma2 = {
         name = 'Kuruma (Armored)',
@@ -3183,6 +3425,7 @@ return {
         price = 75885,
         category = 'sports',
         hash = `kuruma2`,
+        shop = 'luxury'
     },
     l35 = {
         name = 'Walton L35',
@@ -3190,7 +3433,7 @@ return {
         model = 'l35',
         price = 64429,
         category = 'offroad',
-        hash = `l35`,
+        hash = `l35`
     },
     landstalker = {
         name = 'Landstalker',
@@ -3199,6 +3442,7 @@ return {
         price = 61393,
         category = 'suvs',
         hash = `landstalker`,
+        shop = 'pdm'
     },
     landstalker2 = {
         name = 'Landstalker XL',
@@ -3207,6 +3451,7 @@ return {
         price = 62744,
         category = 'suvs',
         hash = `landstalker2`,
+        shop = 'pdm'
     },
     lazer = {
         name = 'P-996 LAZER',
@@ -3214,7 +3459,7 @@ return {
         model = 'lazer',
         price = 2374069,
         category = 'planes',
-        hash = `lazer`,
+        hash = `lazer`
     },
     le7b = {
         name = 'RE-7B',
@@ -3223,6 +3468,7 @@ return {
         price = 84125,
         category = 'super',
         hash = `le7b`,
+        shop = 'luxury'
     },
     lectro = {
         name = 'Lectro',
@@ -3231,6 +3477,7 @@ return {
         price = 27225,
         category = 'motorcycles',
         hash = `lectro`,
+        shop = 'pdm'
     },
     lguard = {
         name = 'Lifeguard',
@@ -3238,7 +3485,7 @@ return {
         model = 'lguard',
         price = 62617,
         category = 'emergency',
-        hash = `lguard`,
+        hash = `lguard`
     },
     limo2 = {
         name = 'Turreted Limo',
@@ -3246,7 +3493,7 @@ return {
         model = 'limo2',
         price = 65584,
         category = 'sedans',
-        hash = `limo2`,
+        hash = `limo2`
     },
     lm87 = {
         name = 'LM87',
@@ -3255,6 +3502,7 @@ return {
         price = 84509,
         category = 'super',
         hash = `lm87`,
+        shop = 'luxury'
     },
     locust = {
         name = 'Locust',
@@ -3263,6 +3511,7 @@ return {
         price = 81371,
         category = 'sports',
         hash = `locust`,
+        shop = 'luxury'
     },
     longfin = {
         name = 'Longfin',
@@ -3271,6 +3520,7 @@ return {
         price = 500680,
         category = 'boats',
         hash = `longfin`,
+        shop = 'boats'
     },
     lurcher = {
         name = 'Lurcher',
@@ -3279,6 +3529,7 @@ return {
         price = 78245,
         category = 'muscle',
         hash = `lurcher`,
+        shop = 'pdm'
     },
     luxor = {
         name = 'Luxor',
@@ -3287,6 +3538,7 @@ return {
         price = 1818934,
         category = 'planes',
         hash = `luxor`,
+        shop = 'air'
     },
     luxor2 = {
         name = 'Luxor Deluxe',
@@ -3295,6 +3547,7 @@ return {
         price = 1834048,
         category = 'planes',
         hash = `luxor2`,
+        shop = 'air'
     },
     lynx = {
         name = 'Lynx',
@@ -3303,6 +3556,7 @@ return {
         price = 81739,
         category = 'sports',
         hash = `lynx`,
+        shop = 'luxury'
     },
     mamba = {
         name = 'Mamba',
@@ -3311,6 +3565,7 @@ return {
         price = 81429,
         category = 'sportsclassics',
         hash = `mamba`,
+        shop = 'pdm'
     },
     mammatus = {
         name = 'Mammatus',
@@ -3319,6 +3574,7 @@ return {
         price = 1321065,
         category = 'planes',
         hash = `mammatus`,
+        shop = 'air'
     },
     manana = {
         name = 'Manana',
@@ -3327,6 +3583,7 @@ return {
         price = 60635,
         category = 'sportsclassics',
         hash = `manana`,
+        shop = 'pdm'
     },
     manana2 = {
         name = 'Manana Custom',
@@ -3335,6 +3592,7 @@ return {
         price = 71516,
         category = 'muscle',
         hash = `manana2`,
+        shop = 'pdm'
     },
     manchez = {
         name = 'Manchez',
@@ -3343,6 +3601,7 @@ return {
         price = 23138,
         category = 'motorcycles',
         hash = `manchez`,
+        shop = 'pdm'
     },
     manchez2 = {
         name = 'Manchez Scout',
@@ -3351,6 +3610,7 @@ return {
         price = 21545,
         category = 'motorcycles',
         hash = `manchez2`,
+        shop = 'pdm'
     },
     manchez3 = {
         name = 'Manchez Scout C',
@@ -3358,7 +3618,7 @@ return {
         model = 'manchez3',
         price = 21632,
         category = 'motorcycles',
-        hash = `manchez3`,
+        hash = `manchez3`
     },
     marquis = {
         name = 'Marquis',
@@ -3367,6 +3627,7 @@ return {
         price = 94680,
         category = 'boats',
         hash = `marquis`,
+        shop = 'boats'
     },
     marshall = {
         name = 'Marshall',
@@ -3374,7 +3635,7 @@ return {
         model = 'marshall',
         price = 57276,
         category = 'offroad',
-        hash = `marshall`,
+        hash = `marshall`
     },
     massacro = {
         name = 'Massacro',
@@ -3383,6 +3644,7 @@ return {
         price = 83972,
         category = 'sports',
         hash = `massacro`,
+        shop = 'luxury'
     },
     massacro2 = {
         name = 'Massacro Racecar',
@@ -3391,6 +3653,7 @@ return {
         price = 83972,
         category = 'sports',
         hash = `massacro2`,
+        shop = 'luxury'
     },
     maverick = {
         name = 'Maverick',
@@ -3399,6 +3662,7 @@ return {
         price = 6031333,
         category = 'helicopters',
         hash = `maverick`,
+        shop = 'air'
     },
     menacer = {
         name = 'Menacer',
@@ -3406,7 +3670,7 @@ return {
         model = 'menacer',
         price = 53078,
         category = 'offroad',
-        hash = `menacer`,
+        hash = `menacer`
     },
     mesa = {
         name = 'Mesa',
@@ -3415,6 +3679,7 @@ return {
         price = 57125,
         category = 'suvs',
         hash = `mesa`,
+        shop = 'pdm'
     },
     mesa2 = {
         name = 'Mesa (Snow)',
@@ -3422,7 +3687,7 @@ return {
         model = 'mesa2',
         price = 57125,
         category = 'suvs',
-        hash = `mesa2`,
+        hash = `mesa2`
     },
     mesa3 = {
         name = 'Mesa (Merryweather)',
@@ -3431,6 +3696,7 @@ return {
         price = 57125,
         category = 'offroad',
         hash = `mesa3`,
+        shop = 'pdm'
     },
     metrotrain = {
         name = 'Freight Train (Tram)',
@@ -3438,7 +3704,7 @@ return {
         model = 'metrotrain',
         price = 194680,
         category = 'trains',
-        hash = `metrotrain`,
+        hash = `metrotrain`
     },
     michelli = {
         name = 'Michelli GT',
@@ -3447,6 +3713,7 @@ return {
         price = 74020,
         category = 'sportsclassics',
         hash = `michelli`,
+        shop = 'pdm'
     },
     microlight = {
         name = 'Ultralight',
@@ -3454,7 +3721,7 @@ return {
         model = 'microlight',
         price = 987645,
         category = 'planes',
-        hash = `microlight`,
+        hash = `microlight`
     },
     miljet = {
         name = 'Miljet',
@@ -3462,7 +3729,7 @@ return {
         model = 'miljet',
         price = 1849116,
         category = 'planes',
-        hash = `miljet`,
+        hash = `miljet`
     },
     minitank = {
         name = 'Invade and Persuade Tank',
@@ -3470,7 +3737,7 @@ return {
         model = 'minitank',
         price = 24911,
         category = 'military',
-        hash = `minitank`,
+        hash = `minitank`
     },
     minivan = {
         name = 'Minivan',
@@ -3479,6 +3746,7 @@ return {
         price = 58370,
         category = 'vans',
         hash = `minivan`,
+        shop = 'pdm'
     },
     minivan2 = {
         name = 'Minivan Custom',
@@ -3487,14 +3755,15 @@ return {
         price = 58450,
         category = 'vans',
         hash = `minivan2`,
+        shop = 'pdm'
     },
     mixer = {
-        brand = 'HVY',
-        category = 'industrial',
-        hash = `mixer`,
-        model = 'mixer',
         name = 'Mixer',
+        brand = 'HVY',
+        model = 'mixer',
         price = 53283,
+        category = 'industrial',
+        hash = `mixer`
     },
     mixer2 = {
         name = 'Mixer',
@@ -3502,7 +3771,7 @@ return {
         model = 'mixer2',
         price = 53283,
         category = 'industrial',
-        hash = `mixer2`,
+        hash = `mixer2`
     },
     mogul = {
         name = 'Mogul',
@@ -3510,7 +3779,7 @@ return {
         model = 'mogul',
         price = 1489140,
         category = 'planes',
-        hash = `mogul`,
+        hash = `mogul`
     },
     molotok = {
         name = 'V-65 Molotok',
@@ -3518,7 +3787,7 @@ return {
         model = 'molotok',
         price = 2145700,
         category = 'planes',
-        hash = `molotok`,
+        hash = `molotok`
     },
     monroe = {
         name = 'Monroe',
@@ -3527,6 +3796,7 @@ return {
         price = 82544,
         category = 'sportsclassics',
         hash = `monroe`,
+        shop = 'pdm'
     },
     monster = {
         name = 'Liberator',
@@ -3534,7 +3804,7 @@ return {
         model = 'monster',
         price = 57276,
         category = 'offroad',
-        hash = `monster`,
+        hash = `monster`
     },
     monster3 = {
         name = 'Apocalypse Sasquatch',
@@ -3542,7 +3812,7 @@ return {
         model = 'monster3',
         price = 64365,
         category = 'offroad',
-        hash = `monster3`,
+        hash = `monster3`
     },
     monster4 = {
         name = 'Future Shock Sasquatch',
@@ -3550,7 +3820,7 @@ return {
         model = 'monster4',
         price = 64365,
         category = 'offroad',
-        hash = `monster4`,
+        hash = `monster4`
     },
     monster5 = {
         name = 'Nightmare Sasquatch',
@@ -3558,7 +3828,7 @@ return {
         model = 'monster5',
         price = 64365,
         category = 'offroad',
-        hash = `monster5`,
+        hash = `monster5`
     },
     monstrociti = {
         name = 'MonstroCiti',
@@ -3566,7 +3836,7 @@ return {
         model = 'monstrociti',
         price = 68406,
         category = 'offroad',
-        hash = `monstrociti`,
+        hash = `monstrociti`
     },
     moonbeam = {
         name = 'Moonbeam',
@@ -3575,6 +3845,7 @@ return {
         price = 68586,
         category = 'muscle',
         hash = `moonbeam`,
+        shop = 'pdm'
     },
     moonbeam2 = {
         name = 'Moonbeam Custom',
@@ -3583,6 +3854,7 @@ return {
         price = 68586,
         category = 'muscle',
         hash = `moonbeam2`,
+        shop = 'pdm'
     },
     mower = {
         name = 'Lawn Mower',
@@ -3590,7 +3862,7 @@ return {
         model = 'mower',
         price = 12234,
         category = 'utility',
-        hash = `mower`,
+        hash = `mower`
     },
     mule = {
         name = 'Mule',
@@ -3598,7 +3870,7 @@ return {
         model = 'mule',
         price = 47273,
         category = 'commercial',
-        hash = `mule`,
+        hash = `mule`
     },
     mule2 = {
         name = 'Mule (Ramp Door)',
@@ -3606,7 +3878,7 @@ return {
         model = 'mule2',
         price = 47273,
         category = 'commercial',
-        hash = `mule2`,
+        hash = `mule2`
     },
     mule3 = {
         name = 'Mule (Heist)',
@@ -3614,7 +3886,7 @@ return {
         model = 'mule3',
         price = 52599,
         category = 'commercial',
-        hash = `mule3`,
+        hash = `mule3`
     },
     mule4 = {
         name = 'Mule Custom',
@@ -3622,7 +3894,7 @@ return {
         model = 'mule4',
         price = 47273,
         category = 'commercial',
-        hash = `mule4`,
+        hash = `mule4`
     },
     mule5 = {
         name = 'Box Truck Mule',
@@ -3631,6 +3903,7 @@ return {
         price = 52599,
         category = 'commercial',
         hash = `mule5`,
+        shop = 'pdm'
     },
     nebula = {
         name = 'Nebula',
@@ -3639,6 +3912,7 @@ return {
         price = 62877,
         category = 'sportsclassics',
         hash = `nebula`,
+        shop = 'pdm'
     },
     nemesis = {
         name = 'Nemesis',
@@ -3647,6 +3921,7 @@ return {
         price = 23612,
         category = 'motorcycles',
         hash = `nemesis`,
+        shop = 'pdm'
     },
     neo = {
         name = 'Neo',
@@ -3655,6 +3930,7 @@ return {
         price = 85696,
         category = 'sports',
         hash = `neo`,
+        shop = 'luxury'
     },
     neon = {
         name = 'Neon',
@@ -3663,6 +3939,7 @@ return {
         price = 65765,
         category = 'sports',
         hash = `neon`,
+        shop = 'luxury'
     },
     nero = {
         name = 'Nero',
@@ -3671,6 +3948,7 @@ return {
         price = 87515,
         category = 'super',
         hash = `nero`,
+        shop = 'luxury'
     },
     nero2 = {
         name = 'Nero Custom',
@@ -3679,6 +3957,7 @@ return {
         price = 88062,
         category = 'super',
         hash = `nero2`,
+        shop = 'luxury'
     },
     nightblade = {
         name = 'Nightblade',
@@ -3687,6 +3966,7 @@ return {
         price = 24551,
         category = 'motorcycles',
         hash = `nightblade`,
+        shop = 'pdm'
     },
     nightshade = {
         name = 'Nightshade',
@@ -3695,6 +3975,7 @@ return {
         price = 67005,
         category = 'muscle',
         hash = `nightshade`,
+        shop = 'pdm'
     },
     nightshark = {
         name = 'Nightshark',
@@ -3702,7 +3983,7 @@ return {
         model = 'nightshark',
         price = 61604,
         category = 'offroad',
-        hash = `nightshark`,
+        hash = `nightshark`
     },
     nimbus = {
         name = 'Nimbus',
@@ -3711,6 +3992,7 @@ return {
         price = 1896246,
         category = 'planes',
         hash = `nimbus`,
+        shop = 'air'
     },
     ninef = {
         name = '9F',
@@ -3719,6 +4001,7 @@ return {
         price = 81139,
         category = 'sports',
         hash = `ninef`,
+        shop = 'luxury'
     },
     ninef2 = {
         name = '9F Cabrio',
@@ -3727,6 +4010,7 @@ return {
         price = 81139,
         category = 'sports',
         hash = `ninef2`,
+        shop = 'luxury'
     },
     nokota = {
         name = 'P-45 Nokota',
@@ -3734,7 +4018,7 @@ return {
         model = 'nokota',
         price = 2079976,
         category = 'planes',
-        hash = `nokota`,
+        hash = `nokota`
     },
     novak = {
         name = 'Novak',
@@ -3743,6 +4027,7 @@ return {
         price = 78077,
         category = 'suvs',
         hash = `novak`,
+        shop = 'pdm'
     },
     omnis = {
         name = 'Omnis',
@@ -3751,6 +4036,7 @@ return {
         price = 73163,
         category = 'sports',
         hash = `omnis`,
+        shop = 'luxury'
     },
     omnisegt = {
         name = 'Omnis e-GT',
@@ -3759,6 +4045,7 @@ return {
         price = 80374,
         category = 'sports',
         hash = `omnisegt`,
+        shop = 'luxury'
     },
     openwheel1 = {
         name = 'BR8',
@@ -3766,7 +4053,7 @@ return {
         model = 'openwheel1',
         price = 106997,
         category = 'openwheel',
-        hash = `openwheel1`,
+        hash = `openwheel1`
     },
     openwheel2 = {
         name = 'DR1',
@@ -3774,7 +4061,7 @@ return {
         model = 'openwheel2',
         price = 107315,
         category = 'openwheel',
-        hash = `openwheel2`,
+        hash = `openwheel2`
     },
     oppressor = {
         name = 'Oppressor',
@@ -3783,6 +4070,7 @@ return {
         price = 76316,
         category = 'motorcycles',
         hash = `oppressor`,
+        shop = 'luxury'
     },
     oppressor2 = {
         name = 'Oppressor Mk II',
@@ -3790,7 +4078,7 @@ return {
         model = 'oppressor2',
         price = 74148,
         category = 'motorcycles',
-        hash = `oppressor2`,
+        hash = `oppressor2`
     },
     oracle = {
         name = 'Oracle XS',
@@ -3799,6 +4087,7 @@ return {
         price = 75192,
         category = 'coupes',
         hash = `oracle`,
+        shop = 'pdm'
     },
     oracle2 = {
         name = 'Oracle',
@@ -3807,6 +4096,7 @@ return {
         price = 76907,
         category = 'coupes',
         hash = `oracle2`,
+        shop = 'pdm'
     },
     osiris = {
         name = 'Osiris',
@@ -3815,6 +4105,7 @@ return {
         price = 82889,
         category = 'super',
         hash = `osiris`,
+        shop = 'luxury'
     },
     outlaw = {
         name = 'Outlaw',
@@ -3823,6 +4114,7 @@ return {
         price = 60938,
         category = 'offroad',
         hash = `outlaw`,
+        shop = 'pdm'
     },
     packer = {
         name = 'Packer',
@@ -3830,7 +4122,7 @@ return {
         model = 'packer',
         price = 60714,
         category = 'commercial',
-        hash = `packer`,
+        hash = `packer`
     },
     panthere = {
         name = 'Panthere',
@@ -3838,7 +4130,7 @@ return {
         model = 'panthere',
         price = 82311,
         category = 'sports',
-        hash = `panthere`,
+        hash = `panthere`
     },
     panto = {
         name = 'Panto',
@@ -3847,6 +4139,7 @@ return {
         price = 67549,
         category = 'compacts',
         hash = `panto`,
+        shop = 'pdm'
     },
     paradise = {
         name = 'Paradise',
@@ -3855,6 +4148,7 @@ return {
         price = 63310,
         category = 'vans',
         hash = `paradise`,
+        shop = 'pdm'
     },
     paragon = {
         name = 'Paragon',
@@ -3863,6 +4157,7 @@ return {
         price = 75255,
         category = 'sports',
         hash = `paragon`,
+        shop = 'luxury'
     },
     paragon2 = {
         name = 'Paragon R (Armored)',
@@ -3870,7 +4165,7 @@ return {
         model = 'paragon2',
         price = 74900,
         category = 'sports',
-        hash = `paragon2`,
+        hash = `paragon2`
     },
     pariah = {
         name = 'Pariah',
@@ -3879,6 +4174,7 @@ return {
         price = 81207,
         category = 'sports',
         hash = `pariah`,
+        shop = 'luxury'
     },
     patriot = {
         name = 'Patriot',
@@ -3887,6 +4183,7 @@ return {
         price = 63246,
         category = 'suvs',
         hash = `patriot`,
+        shop = 'pdm'
     },
     patriot2 = {
         name = 'Patriot Stretch',
@@ -3894,7 +4191,7 @@ return {
         model = 'patriot2',
         price = 59238,
         category = 'suvs',
-        hash = `patriot2`,
+        hash = `patriot2`
     },
     patriot3 = {
         name = 'Mil-Spec Patriot',
@@ -3903,6 +4200,7 @@ return {
         price = 62402,
         category = 'offroad',
         hash = `patriot3`,
+        shop = 'pdm'
     },
     patrolboat = {
         name = 'Kurtz 31 Patrol Boat',
@@ -3910,7 +4208,7 @@ return {
         model = 'patrolboat',
         price = 430680,
         category = 'boats',
-        hash = `patrolboat`,
+        hash = `patrolboat`
     },
     pbus = {
         name = 'Prison Bus',
@@ -3918,7 +4216,7 @@ return {
         model = 'pbus',
         price = 46633,
         category = 'emergency',
-        hash = `pbus`,
+        hash = `pbus`
     },
     pbus2 = {
         name = 'Festival Bus',
@@ -3926,7 +4224,7 @@ return {
         model = 'pbus2',
         price = 38412,
         category = 'service',
-        hash = `pbus2`,
+        hash = `pbus2`
     },
     pcj = {
         name = 'PCJ-600',
@@ -3935,6 +4233,7 @@ return {
         price = 20997,
         category = 'motorcycles',
         hash = `pcj`,
+        shop = 'pdm'
     },
     penetrator = {
         name = 'Penetrator',
@@ -3943,6 +4242,7 @@ return {
         price = 81919,
         category = 'super',
         hash = `penetrator`,
+        shop = 'luxury'
     },
     penumbra = {
         name = 'Penumbra',
@@ -3951,6 +4251,7 @@ return {
         price = 67839,
         category = 'sports',
         hash = `penumbra`,
+        shop = 'luxury'
     },
     penumbra2 = {
         name = 'Penumbra FF',
@@ -3959,6 +4260,7 @@ return {
         price = 74920,
         category = 'sports',
         hash = `penumbra2`,
+        shop = 'luxury'
     },
     peyote = {
         name = 'Peyote',
@@ -3967,6 +4269,7 @@ return {
         price = 60635,
         category = 'sportsclassics',
         hash = `peyote`,
+        shop = 'pdm'
     },
     peyote2 = {
         name = 'Peyote Gasser',
@@ -3975,6 +4278,7 @@ return {
         price = 77875,
         category = 'muscle',
         hash = `peyote2`,
+        shop = 'pdm'
     },
     peyote3 = {
         name = 'Peyote Custom',
@@ -3983,6 +4287,7 @@ return {
         price = 70150,
         category = 'sportsclassics',
         hash = `peyote3`,
+        shop = 'pdm'
     },
     pfister811 = {
         name = '811',
@@ -3991,6 +4296,7 @@ return {
         price = 88499,
         category = 'super',
         hash = `pfister811`,
+        shop = 'luxury'
     },
     phantom = {
         name = 'Phantom',
@@ -3998,7 +4304,7 @@ return {
         model = 'phantom',
         price = 56656,
         category = 'commercial',
-        hash = `phantom`,
+        hash = `phantom`
     },
     phantom2 = {
         name = 'Phantom Wedge',
@@ -4006,7 +4312,7 @@ return {
         model = 'phantom2',
         price = 72230,
         category = 'commercial',
-        hash = `phantom2`,
+        hash = `phantom2`
     },
     phantom3 = {
         name = 'Phantom Custom',
@@ -4014,7 +4320,7 @@ return {
         model = 'phantom3',
         price = 69772,
         category = 'commercial',
-        hash = `phantom3`,
+        hash = `phantom3`
     },
     phantom4 = {
         name = 'Phantom (Christmas)',
@@ -4022,7 +4328,7 @@ return {
         model = 'phantom4',
         price = 56656,
         category = 'commercial',
-        hash = `phantom4`,
+        hash = `phantom4`
     },
     phoenix = {
         name = 'Phoenix',
@@ -4031,6 +4337,7 @@ return {
         price = 78433,
         category = 'muscle',
         hash = `phoenix`,
+        shop = 'pdm'
     },
     picador = {
         name = 'Picador',
@@ -4039,6 +4346,7 @@ return {
         price = 67839,
         category = 'muscle',
         hash = `picador`,
+        shop = 'pdm'
     },
     pigalle = {
         name = 'Pigalle',
@@ -4047,6 +4355,7 @@ return {
         price = 82282,
         category = 'sportsclassics',
         hash = `pigalle`,
+        shop = 'pdm'
     },
     polgauntlet = {
         name = 'Gauntlet Interceptor',
@@ -4054,7 +4363,7 @@ return {
         model = 'polgauntlet',
         price = 81768,
         category = 'emergency',
-        hash = `polgauntlet`,
+        hash = `polgauntlet`
     },
     police = {
         name = 'Police Cruiser',
@@ -4062,7 +4371,7 @@ return {
         model = 'police',
         price = 71053,
         category = 'emergency',
-        hash = `police`,
+        hash = `police`
     },
     police2 = {
         name = 'Police Cruiser',
@@ -4070,7 +4379,7 @@ return {
         model = 'police2',
         price = 76794,
         category = 'emergency',
-        hash = `police2`,
+        hash = `police2`
     },
     police3 = {
         name = 'Police Cruiser (Interceptor)',
@@ -4078,7 +4387,7 @@ return {
         model = 'police3',
         price = 80470,
         category = 'emergency',
-        hash = `police3`,
+        hash = `police3`
     },
     police4 = {
         name = 'Unmarked Cruiser',
@@ -4086,7 +4395,7 @@ return {
         model = 'police4',
         price = 71053,
         category = 'emergency',
-        hash = `police4`,
+        hash = `police4`
     },
     police5 = {
         name = 'Stanier LE Cruiser',
@@ -4094,7 +4403,7 @@ return {
         model = 'police5',
         price = 71053,
         category = 'emergency',
-        hash = `police5`,
+        hash = `police5`
     },
     policeb = {
         name = 'Police Bike',
@@ -4102,7 +4411,7 @@ return {
         model = 'policeb',
         price = 23078,
         category = 'emergency',
-        hash = `policeb`,
+        hash = `policeb`
     },
     policeold1 = {
         name = 'Police Rancher',
@@ -4110,7 +4419,7 @@ return {
         model = 'policeold1',
         price = 58720,
         category = 'emergency',
-        hash = `policeold1`,
+        hash = `policeold1`
     },
     policeold2 = {
         name = 'Police Roadcruiser',
@@ -4118,7 +4427,7 @@ return {
         model = 'policeold2',
         price = 71053,
         category = 'emergency',
-        hash = `policeold2`,
+        hash = `policeold2`
     },
     policet = {
         name = 'Police Transporter',
@@ -4126,7 +4435,7 @@ return {
         model = 'policet',
         price = 61195,
         category = 'emergency',
-        hash = `policet`,
+        hash = `policet`
     },
     polmav = {
         name = 'Police Maverick',
@@ -4134,7 +4443,7 @@ return {
         model = 'polmav',
         price = 6293144,
         category = 'helicopters',
-        hash = `polmav`,
+        hash = `polmav`
     },
     pony = {
         name = 'Pony',
@@ -4142,7 +4451,7 @@ return {
         model = 'pony',
         price = 61195,
         category = 'vans',
-        hash = `pony`,
+        hash = `pony`
     },
     pony2 = {
         name = 'Pony (Smoke on the Water)',
@@ -4150,7 +4459,7 @@ return {
         model = 'pony2',
         price = 61195,
         category = 'vans',
-        hash = `pony2`,
+        hash = `pony2`
     },
     postlude = {
         name = 'Postlude',
@@ -4159,6 +4468,7 @@ return {
         price = 69683,
         category = 'coupes',
         hash = `postlude`,
+        shop = 'pdm'
     },
     pounder = {
         name = 'Pounder',
@@ -4166,7 +4476,7 @@ return {
         model = 'pounder',
         price = 55550,
         category = 'commercial',
-        hash = `pounder`,
+        hash = `pounder`
     },
     pounder2 = {
         name = 'Pounder Custom',
@@ -4174,7 +4484,7 @@ return {
         model = 'pounder2',
         price = 60635,
         category = 'commercial',
-        hash = `pounder2`,
+        hash = `pounder2`
     },
     powersurge = {
         name = 'Powersurge',
@@ -4182,7 +4492,7 @@ return {
         model = 'powersurge',
         price = 23026,
         category = 'motorcycles',
-        hash = `powersurge`,
+        hash = `powersurge`
     },
     prairie = {
         name = 'Prairie',
@@ -4191,6 +4501,7 @@ return {
         price = 67519,
         category = 'compacts',
         hash = `prairie`,
+        shop = 'pdm'
     },
     pranger = {
         name = 'Park Ranger',
@@ -4198,7 +4509,7 @@ return {
         model = 'pranger',
         price = 62617,
         category = 'emergency',
-        hash = `pranger`,
+        hash = `pranger`
     },
     predator = {
         name = 'Police Predator',
@@ -4206,7 +4517,7 @@ return {
         model = 'predator',
         price = 412680,
         category = 'boats',
-        hash = `predator`,
+        hash = `predator`
     },
     premier = {
         name = 'Premier',
@@ -4215,6 +4526,7 @@ return {
         price = 63694,
         category = 'sedans',
         hash = `premier`,
+        shop = 'pdm'
     },
     previon = {
         name = 'Previon',
@@ -4223,6 +4535,7 @@ return {
         price = 78200,
         category = 'coupes',
         hash = `previon`,
+        shop = 'pdm'
     },
     primo = {
         name = 'Primo',
@@ -4231,6 +4544,7 @@ return {
         price = 64174,
         category = 'sedans',
         hash = `primo`,
+        shop = 'pdm'
     },
     primo2 = {
         name = 'Primo Custom',
@@ -4239,6 +4553,7 @@ return {
         price = 64174,
         category = 'sedans',
         hash = `primo2`,
+        shop = 'pdm'
     },
     proptrailer = {
         name = 'Prop Trailer',
@@ -4246,7 +4561,7 @@ return {
         model = 'proptrailer',
         price = 5668,
         category = 'utility',
-        hash = `proptrailer`,
+        hash = `proptrailer`
     },
     prototipo = {
         name = 'X80 Proto',
@@ -4255,6 +4570,7 @@ return {
         price = 88458,
         category = 'super',
         hash = `prototipo`,
+        shop = 'luxury'
     },
     pyro = {
         name = 'Pyro',
@@ -4262,7 +4578,7 @@ return {
         model = 'pyro',
         price = 2140960,
         category = 'planes',
-        hash = `pyro`,
+        hash = `pyro`
     },
     r300 = {
         name = '300R',
@@ -4270,7 +4586,7 @@ return {
         model = 'r300',
         price = 79467,
         category = 'sports',
-        hash = `r300`,
+        hash = `r300`
     },
     radi = {
         name = 'Radius',
@@ -4279,6 +4595,7 @@ return {
         price = 65522,
         category = 'suvs',
         hash = `radi`,
+        shop = 'pdm'
     },
     raiden = {
         name = 'Raiden',
@@ -4286,7 +4603,7 @@ return {
         model = 'raiden',
         price = 64370,
         category = 'sports',
-        hash = `raiden`,
+        hash = `raiden`
     },
     raiju = {
         name = 'F-160 Raiju',
@@ -4294,7 +4611,7 @@ return {
         model = 'raiju',
         price = 2712193,
         category = 'planes',
-        hash = `raiju`,
+        hash = `raiju`
     },
     raketrailer = {
         name = 'Trailer (Rake)',
@@ -4302,7 +4619,7 @@ return {
         model = 'raketrailer',
         price = 5668,
         category = 'utility',
-        hash = `raketrailer`,
+        hash = `raketrailer`
     },
     rallytruck = {
         name = 'Dune',
@@ -4310,7 +4627,7 @@ return {
         model = 'rallytruck',
         price = 67837,
         category = 'service',
-        hash = `rallytruck`,
+        hash = `rallytruck`
     },
     rancherxl = {
         name = 'Rancher XL',
@@ -4319,6 +4636,7 @@ return {
         price = 58720,
         category = 'offroad',
         hash = `rancherxl`,
+        shop = 'pdm'
     },
     rancherxl2 = {
         name = 'Rancher XL (Snow)',
@@ -4326,7 +4644,7 @@ return {
         model = 'rancherxl2',
         price = 58720,
         category = 'offroad',
-        hash = `rancherxl2`,
+        hash = `rancherxl2`
     },
     rapidgt = {
         name = 'Rapid GT',
@@ -4335,6 +4653,7 @@ return {
         price = 83599,
         category = 'sports',
         hash = `rapidgt`,
+        shop = 'luxury'
     },
     rapidgt2 = {
         name = 'Rapid GT Cabrio',
@@ -4343,6 +4662,7 @@ return {
         price = 83599,
         category = 'sports',
         hash = `rapidgt2`,
+        shop = 'luxury'
     },
     rapidgt3 = {
         name = 'Rapid GT Classic',
@@ -4351,6 +4671,7 @@ return {
         price = 77766,
         category = 'sportsclassics',
         hash = `rapidgt3`,
+        shop = 'pdm'
     },
     raptor = {
         name = 'Raptor',
@@ -4359,6 +4680,7 @@ return {
         price = 72091,
         category = 'sports',
         hash = `raptor`,
+        shop = 'luxury'
     },
     ratbike = {
         name = 'Rat Bike',
@@ -4367,6 +4689,7 @@ return {
         price = 19441,
         category = 'motorcycles',
         hash = `ratbike`,
+        shop = 'pdm'
     },
     ratel = {
         name = 'Ratel',
@@ -4374,7 +4697,7 @@ return {
         model = 'ratel',
         price = 72415,
         category = 'offroad',
-        hash = `ratel`,
+        hash = `ratel`
     },
     ratloader = {
         name = 'Rat-Loader',
@@ -4382,7 +4705,7 @@ return {
         model = 'ratloader',
         price = 61779,
         category = 'muscle',
-        hash = `ratloader`,
+        hash = `ratloader`
     },
     ratloader2 = {
         name = 'Rat-Truck',
@@ -4391,6 +4714,7 @@ return {
         price = 65562,
         category = 'muscle',
         hash = `ratloader2`,
+        shop = 'pdm'
     },
     rcbandito = {
         name = 'RC Bandito',
@@ -4398,7 +4722,7 @@ return {
         model = 'rcbandito',
         price = 44530,
         category = 'offroad',
-        hash = `rcbandito`,
+        hash = `rcbandito`
     },
     reaper = {
         name = 'Reaper',
@@ -4407,6 +4731,7 @@ return {
         price = 82990,
         category = 'super',
         hash = `reaper`,
+        shop = 'luxury'
     },
     rebel = {
         name = 'Rusty Rebel',
@@ -4414,7 +4739,7 @@ return {
         model = 'rebel',
         price = 63694,
         category = 'offroad',
-        hash = `rebel`,
+        hash = `rebel`
     },
     rebel2 = {
         name = 'Rebel',
@@ -4423,6 +4748,7 @@ return {
         price = 63694,
         category = 'offroad',
         hash = `rebel2`,
+        shop = 'pdm'
     },
     rebla = {
         name = 'Rebla GTS',
@@ -4431,6 +4757,7 @@ return {
         price = 77543,
         category = 'suvs',
         hash = `rebla`,
+        shop = 'pdm'
     },
     reever = {
         name = 'Reever',
@@ -4439,6 +4766,7 @@ return {
         price = 26269,
         category = 'motorcycles',
         hash = `reever`,
+        shop = 'pdm'
     },
     regina = {
         name = 'Regina',
@@ -4447,6 +4775,7 @@ return {
         price = 50997,
         category = 'sedans',
         hash = `regina`,
+        shop = 'pdm'
     },
     remus = {
         name = 'Remus',
@@ -4455,6 +4784,7 @@ return {
         price = 78314,
         category = 'sports',
         hash = `remus`,
+        shop = 'luxury'
     },
     rentalbus = {
         name = 'Rental Shuttle Bus',
@@ -4462,7 +4792,7 @@ return {
         model = 'rentalbus',
         price = 42321,
         category = 'service',
-        hash = `rentalbus`,
+        hash = `rentalbus`
     },
     retinue = {
         name = 'Retinue',
@@ -4471,6 +4801,7 @@ return {
         price = 70738,
         category = 'sportsclassics',
         hash = `retinue`,
+        shop = 'pdm'
     },
     retinue2 = {
         name = 'Retinue MKII',
@@ -4479,6 +4810,7 @@ return {
         price = 76099,
         category = 'sportsclassics',
         hash = `retinue2`,
+        shop = 'pdm'
     },
     revolter = {
         name = 'Revolter',
@@ -4487,6 +4819,7 @@ return {
         price = 74872,
         category = 'sports',
         hash = `revolter`,
+        shop = 'luxury'
     },
     rhapsody = {
         name = 'Rhapsody',
@@ -4495,6 +4828,7 @@ return {
         price = 68425,
         category = 'compacts',
         hash = `rhapsody`,
+        shop = 'pdm'
     },
     rhinehart = {
         name = 'Rhinehart',
@@ -4503,6 +4837,7 @@ return {
         price = 78276,
         category = 'sedans',
         hash = `rhinehart`,
+        shop = 'pdm'
     },
     rhino = {
         name = 'Rhino Tank',
@@ -4510,7 +4845,7 @@ return {
         model = 'rhino',
         price = 30613,
         category = 'military',
-        hash = `rhino`,
+        hash = `rhino`
     },
     riata = {
         name = 'Riata',
@@ -4519,6 +4854,7 @@ return {
         price = 66525,
         category = 'offroad',
         hash = `riata`,
+        shop = 'pdm'
     },
     riot = {
         name = 'Police Riot',
@@ -4526,7 +4862,7 @@ return {
         model = 'riot',
         price = 56588,
         category = 'emergency',
-        hash = `riot`,
+        hash = `riot`
     },
     riot2 = {
         name = 'RCV',
@@ -4534,7 +4870,7 @@ return {
         model = 'riot2',
         price = 59094,
         category = 'emergency',
-        hash = `riot2`,
+        hash = `riot2`
     },
     ripley = {
         name = 'Ripley',
@@ -4542,7 +4878,7 @@ return {
         model = 'ripley',
         price = 38773,
         category = 'utility',
-        hash = `ripley`,
+        hash = `ripley`
     },
     rocoto = {
         name = 'Rocoto',
@@ -4551,6 +4887,7 @@ return {
         price = 67755,
         category = 'suvs',
         hash = `rocoto`,
+        shop = 'pdm'
     },
     rogue = {
         name = 'Rogue',
@@ -4558,7 +4895,7 @@ return {
         model = 'rogue',
         price = 2070400,
         category = 'planes',
-        hash = `rogue`,
+        hash = `rogue`
     },
     romero = {
         name = 'Romero Hearse',
@@ -4566,7 +4903,7 @@ return {
         model = 'romero',
         price = 53105,
         category = 'sedans',
-        hash = `romero`,
+        hash = `romero`
     },
     rrocket = {
         name = 'Rampant Rocket',
@@ -4574,7 +4911,7 @@ return {
         model = 'rrocket',
         price = 26257,
         category = 'motorcycles',
-        hash = `rrocket`,
+        hash = `rrocket`
     },
     rt3000 = {
         name = 'RT3000',
@@ -4583,6 +4920,7 @@ return {
         price = 80216,
         category = 'sports',
         hash = `rt3000`,
+        shop = 'luxury'
     },
     rubble = {
         name = 'Rubble',
@@ -4590,7 +4928,7 @@ return {
         model = 'rubble',
         price = 54789,
         category = 'industrial',
-        hash = `rubble`,
+        hash = `rubble`
     },
     ruffian = {
         name = 'Ruffian',
@@ -4599,6 +4937,7 @@ return {
         price = 24413,
         category = 'motorcycles',
         hash = `ruffian`,
+        shop = 'pdm'
     },
     ruiner = {
         name = 'Ruiner',
@@ -4607,6 +4946,7 @@ return {
         price = 80117,
         category = 'muscle',
         hash = `ruiner`,
+        shop = 'pdm'
     },
     ruiner2 = {
         name = 'Ruiner 2000',
@@ -4615,6 +4955,7 @@ return {
         price = 186491,
         category = 'muscle',
         hash = `ruiner2`,
+        shop = 'pdm'
     },
     ruiner3 = {
         name = 'Ruiner (Wrecked)',
@@ -4622,7 +4963,7 @@ return {
         model = 'ruiner3',
         price = 80117,
         category = 'muscle',
-        hash = `ruiner3`,
+        hash = `ruiner3`
     },
     ruiner4 = {
         name = 'Ruiner ZZ-8',
@@ -4631,6 +4972,7 @@ return {
         price = 80458,
         category = 'muscle',
         hash = `ruiner4`,
+        shop = 'pdm'
     },
     rumpo = {
         name = 'Rumpo',
@@ -4639,6 +4981,7 @@ return {
         price = 63310,
         category = 'vans',
         hash = `rumpo`,
+        shop = 'pdm'
     },
     rumpo2 = {
         name = 'Rumpo (Deludamol)',
@@ -4646,7 +4989,7 @@ return {
         model = 'rumpo2',
         price = 63310,
         category = 'vans',
-        hash = `rumpo2`,
+        hash = `rumpo2`
     },
     rumpo3 = {
         name = 'Rumpo Custom',
@@ -4655,6 +4998,7 @@ return {
         price = 59206,
         category = 'vans',
         hash = `rumpo3`,
+        shop = 'pdm'
     },
     ruston = {
         name = 'Ruston',
@@ -4663,6 +5007,7 @@ return {
         price = 78365,
         category = 'sports',
         hash = `ruston`,
+        shop = 'luxury'
     },
     s80 = {
         name = 'S80RR',
@@ -4671,6 +5016,7 @@ return {
         price = 83208,
         category = 'super',
         hash = `s80`,
+        shop = 'luxury'
     },
     sabregt = {
         name = 'Sabre Turbo',
@@ -4679,6 +5025,7 @@ return {
         price = 77450,
         category = 'muscle',
         hash = `sabregt`,
+        shop = 'pdm'
     },
     sabregt2 = {
         name = 'Sabre GT',
@@ -4687,6 +5034,7 @@ return {
         price = 77489,
         category = 'muscle',
         hash = `sabregt2`,
+        shop = 'pdm'
     },
     sadler = {
         name = 'Sadler',
@@ -4695,6 +5043,7 @@ return {
         price = 62297,
         category = 'utility',
         hash = `sadler`,
+        shop = 'pdm'
     },
     sadler2 = {
         name = 'Sadler (Snow)',
@@ -4702,7 +5051,7 @@ return {
         model = 'sadler2',
         price = 62297,
         category = 'utility',
-        hash = `sadler2`,
+        hash = `sadler2`
     },
     sanchez = {
         name = 'Sanchez (livery)',
@@ -4711,6 +5060,7 @@ return {
         price = 20686,
         category = 'motorcycles',
         hash = `sanchez`,
+        shop = 'pdm'
     },
     sanchez2 = {
         name = 'Sanchez',
@@ -4719,6 +5069,7 @@ return {
         price = 20686,
         category = 'motorcycles',
         hash = `sanchez2`,
+        shop = 'pdm'
     },
     sanctus = {
         name = 'Sanctus',
@@ -4727,6 +5078,7 @@ return {
         price = 24351,
         category = 'motorcycles',
         hash = `sanctus`,
+        shop = 'pdm'
     },
     sandking = {
         name = 'Sandking',
@@ -4735,6 +5087,7 @@ return {
         price = 63694,
         category = 'offroad',
         hash = `sandking`,
+        shop = 'pdm'
     },
     sandking2 = {
         name = 'Sandking SWB',
@@ -4743,6 +5096,7 @@ return {
         price = 63694,
         category = 'offroad',
         hash = `sandking2`,
+        shop = 'pdm'
     },
     savage = {
         name = 'Savage',
@@ -4750,7 +5104,7 @@ return {
         model = 'savage',
         price = 6962237,
         category = 'helicopters',
-        hash = `savage`,
+        hash = `savage`
     },
     savestra = {
         name = 'Savestra',
@@ -4759,6 +5113,7 @@ return {
         price = 72617,
         category = 'sportsclassics',
         hash = `savestra`,
+        shop = 'pdm'
     },
     sc1 = {
         name = 'SC1',
@@ -4767,6 +5122,7 @@ return {
         price = 79257,
         category = 'super',
         hash = `sc1`,
+        shop = 'luxury'
     },
     scarab = {
         name = 'Apocalypse Scarab',
@@ -4774,7 +5130,7 @@ return {
         model = 'scarab',
         price = 39724,
         category = 'military',
-        hash = `scarab`,
+        hash = `scarab`
     },
     scarab2 = {
         name = 'Future Shock Scarab',
@@ -4782,7 +5138,7 @@ return {
         model = 'scarab2',
         price = 39724,
         category = 'military',
-        hash = `scarab2`,
+        hash = `scarab2`
     },
     scarab3 = {
         name = 'Nightmare Scarab',
@@ -4790,7 +5146,7 @@ return {
         model = 'scarab3',
         price = 39724,
         category = 'military',
-        hash = `scarab3`,
+        hash = `scarab3`
     },
     schafter2 = {
         name = 'Schafter',
@@ -4799,6 +5155,7 @@ return {
         price = 65682,
         category = 'sedans',
         hash = `schafter2`,
+        shop = 'pdm'
     },
     schafter3 = {
         name = 'Schafter V12',
@@ -4807,6 +5164,7 @@ return {
         price = 83088,
         category = 'sports',
         hash = `schafter3`,
+        shop = 'luxury'
     },
     schafter4 = {
         name = 'Schafter LWB',
@@ -4815,6 +5173,7 @@ return {
         price = 65602,
         category = 'sports',
         hash = `schafter4`,
+        shop = 'luxury'
     },
     schafter5 = {
         name = 'Schafter V12 (Armored)',
@@ -4822,7 +5181,7 @@ return {
         model = 'schafter5',
         price = 83008,
         category = 'sedans',
-        hash = `schafter5`,
+        hash = `schafter5`
     },
     schafter6 = {
         name = 'Schafter LWB (Armored)',
@@ -4830,7 +5189,7 @@ return {
         model = 'schafter6',
         price = 62476,
         category = 'sedans',
-        hash = `schafter6`,
+        hash = `schafter6`
     },
     schlagen = {
         name = 'Schlagen GT',
@@ -4839,6 +5198,7 @@ return {
         price = 86368,
         category = 'sports',
         hash = `schlagen`,
+        shop = 'luxury'
     },
     schwarzer = {
         name = 'Schwartzer',
@@ -4847,6 +5207,7 @@ return {
         price = 80250,
         category = 'sports',
         hash = `schwarzer`,
+        shop = 'luxury'
     },
     scorcher = {
         name = 'Scorcher',
@@ -4855,6 +5216,7 @@ return {
         price = 2782,
         category = 'cycles',
         hash = `scorcher`,
+        shop = 'pdm'
     },
     scramjet = {
         name = 'Scramjet',
@@ -4862,7 +5224,7 @@ return {
         model = 'scramjet',
         price = 370681,
         category = 'super',
-        hash = `scramjet`,
+        hash = `scramjet`
     },
     scrap = {
         name = 'Scrap Truck',
@@ -4870,7 +5232,7 @@ return {
         model = 'scrap',
         price = 52886,
         category = 'utility',
-        hash = `scrap`,
+        hash = `scrap`
     },
     seabreeze = {
         name = 'Seabreeze',
@@ -4878,7 +5240,7 @@ return {
         model = 'seabreeze',
         price = 2211729,
         category = 'planes',
-        hash = `seabreeze`,
+        hash = `seabreeze`
     },
     seashark = {
         name = 'Seashark',
@@ -4887,6 +5249,7 @@ return {
         price = 414680,
         category = 'boats',
         hash = `seashark`,
+        shop = 'boats'
     },
     seashark2 = {
         name = 'Seashark (Lifeguard)',
@@ -4895,6 +5258,7 @@ return {
         price = 414680,
         category = 'boats',
         hash = `seashark2`,
+        shop = 'boats'
     },
     seashark3 = {
         name = 'Seashark (Yacht)',
@@ -4903,6 +5267,7 @@ return {
         price = 414680,
         category = 'boats',
         hash = `seashark3`,
+        shop = 'boats'
     },
     seasparrow = {
         name = 'Sea Sparrow',
@@ -4911,6 +5276,7 @@ return {
         price = 6293144,
         category = 'helicopters',
         hash = `seasparrow`,
+        shop = 'air'
     },
     seasparrow2 = {
         name = 'Sparrow',
@@ -4919,14 +5285,16 @@ return {
         price = 7760028,
         category = 'helicopters',
         hash = `seasparrow2`,
+        shop = 'air'
     },
     seasparrow3 = {
         name = 'Sparrow (Prop)',
+        brand = '',
         model = 'seasparrow3',
         price = 7760028,
-        brand = '',
         category = 'helicopters',
         hash = `seasparrow3`,
+        shop = 'air'
     },
     seminole = {
         name = 'Seminole',
@@ -4935,6 +5303,7 @@ return {
         price = 61393,
         category = 'suvs',
         hash = `seminole`,
+        shop = 'pdm'
     },
     seminole2 = {
         name = 'Seminole Frontier',
@@ -4943,6 +5312,7 @@ return {
         price = 64904,
         category = 'suvs',
         hash = `seminole2`,
+        shop = 'pdm'
     },
     sentinel = {
         name = 'Sentinel',
@@ -4951,6 +5321,7 @@ return {
         price = 75585,
         category = 'coupes',
         hash = `sentinel`,
+        shop = 'pdm'
     },
     sentinel2 = {
         name = ' Sentinel XS',
@@ -4959,6 +5330,7 @@ return {
         price = 75585,
         category = 'coupes',
         hash = `sentinel2`,
+        shop = 'pdm'
     },
     sentinel3 = {
         name = 'Sentinel Classic',
@@ -4967,6 +5339,7 @@ return {
         price = 74166,
         category = 'sports',
         hash = `sentinel3`,
+        shop = 'pdm'
     },
     sentinel4 = {
         name = 'Sentinel Classic Widebody',
@@ -4975,6 +5348,7 @@ return {
         price = 78990,
         category = 'sports',
         hash = `sentinel4`,
+        shop = 'luxury'
     },
     serrano = {
         name = 'Serrano',
@@ -4983,6 +5357,7 @@ return {
         price = 66517,
         category = 'suvs',
         hash = `serrano`,
+        shop = 'pdm'
     },
     seven70 = {
         name = 'Seven-70',
@@ -4991,6 +5366,7 @@ return {
         price = 84734,
         category = 'sports',
         hash = `seven70`,
+        shop = 'luxury'
     },
     shamal = {
         name = 'Shamal',
@@ -4999,6 +5375,7 @@ return {
         price = 1818934,
         category = 'planes',
         hash = `shamal`,
+        shop = 'air'
     },
     sheava = {
         name = 'ETR1',
@@ -5007,6 +5384,7 @@ return {
         price = 81139,
         category = 'super',
         hash = `sheava`,
+        shop = 'luxury'
     },
     sheriff = {
         name = 'Sheriff Cruiser',
@@ -5014,7 +5392,7 @@ return {
         model = 'sheriff',
         price = 71186,
         category = 'emergency',
-        hash = `sheriff`,
+        hash = `sheriff`
     },
     sheriff2 = {
         name = 'Sheriff SUV',
@@ -5022,7 +5400,7 @@ return {
         model = 'sheriff2',
         price = 62617,
         category = 'emergency',
-        hash = `sheriff2`,
+        hash = `sheriff2`
     },
     shinobi = {
         name = 'Shinobi',
@@ -5031,6 +5409,7 @@ return {
         price = 27244,
         category = 'motorcycles',
         hash = `shinobi`,
+        shop = 'pdm'
     },
     shotaro = {
         name = 'Shotaro Concept',
@@ -5039,6 +5418,7 @@ return {
         price = 26899,
         category = 'motorcycles',
         hash = `shotaro`,
+        shop = 'pdm'
     },
     skylift = {
         name = 'Skylift',
@@ -5046,7 +5426,7 @@ return {
         model = 'skylift',
         price = 5363475,
         category = 'helicopters',
-        hash = `skylift`,
+        hash = `skylift`
     },
     slamtruck = {
         name = 'Slam Truck',
@@ -5055,6 +5435,7 @@ return {
         price = 62937,
         category = 'utility',
         hash = `slamtruck`,
+        shop = 'pdm'
     },
     slamvan = {
         name = 'Slam Van',
@@ -5063,6 +5444,7 @@ return {
         price = 66207,
         category = 'muscle',
         hash = `slamvan`,
+        shop = 'pdm'
     },
     slamvan2 = {
         name = 'Lost Slam Van',
@@ -5071,6 +5453,7 @@ return {
         price = 67165,
         category = 'muscle',
         hash = `slamvan2`,
+        shop = 'pdm'
     },
     slamvan3 = {
         name = 'Slam Van Custom',
@@ -5079,6 +5462,7 @@ return {
         price = 67005,
         category = 'muscle',
         hash = `slamvan3`,
+        shop = 'pdm'
     },
     slamvan4 = {
         name = 'Apocalypse Slamvan',
@@ -5086,7 +5470,7 @@ return {
         model = 'slamvan4',
         price = 68476,
         category = 'muscle',
-        hash = `slamvan4`,
+        hash = `slamvan4`
     },
     slamvan5 = {
         name = 'Future Shock Slamvan',
@@ -5094,7 +5478,7 @@ return {
         model = 'slamvan5',
         price = 68476,
         category = 'muscle',
-        hash = `slamvan5`,
+        hash = `slamvan5`
     },
     slamvan6 = {
         name = 'Nightmare Slamvan',
@@ -5102,7 +5486,7 @@ return {
         model = 'slamvan6',
         price = 68476,
         category = 'muscle',
-        hash = `slamvan6`,
+        hash = `slamvan6`
     },
     sm722 = {
         name = 'SM722',
@@ -5111,6 +5495,7 @@ return {
         price = 80260,
         category = 'sports',
         hash = `sm722`,
+        shop = 'luxury'
     },
     sovereign = {
         name = 'Sovereign',
@@ -5119,6 +5504,7 @@ return {
         price = 23078,
         category = 'motorcycles',
         hash = `sovereign`,
+        shop = 'pdm'
     },
     specter = {
         name = 'Specter',
@@ -5127,6 +5513,7 @@ return {
         price = 81060,
         category = 'sports',
         hash = `specter`,
+        shop = 'luxury'
     },
     specter2 = {
         name = 'Specter Custom',
@@ -5134,7 +5521,7 @@ return {
         model = 'specter2',
         price = 82332,
         category = 'sports',
-        hash = `specter2`,
+        hash = `specter2`
     },
     speeder = {
         name = 'Speeder (Yacht)',
@@ -5143,6 +5530,7 @@ return {
         price = 462680,
         category = 'boats',
         hash = `speeder`,
+        shop = 'boats'
     },
     speeder2 = {
         name = 'Speeder',
@@ -5151,6 +5539,7 @@ return {
         price = 462680,
         category = 'boats',
         hash = `speeder2`,
+        shop = 'boats'
     },
     speedo = {
         name = 'Speedo',
@@ -5159,6 +5548,7 @@ return {
         price = 66002,
         category = 'vans',
         hash = `speedo`,
+        shop = 'pdm'
     },
     speedo2 = {
         name = 'Clown Van',
@@ -5166,7 +5556,7 @@ return {
         model = 'speedo2',
         price = 66002,
         category = 'vans',
-        hash = `speedo2`,
+        hash = `speedo2`
     },
     speedo4 = {
         name = 'Speedo Custom (Nightclub)',
@@ -5175,6 +5565,7 @@ return {
         price = 70653,
         category = 'vans',
         hash = `speedo4`,
+        shop = 'pdm'
     },
     speedo5 = {
         name = 'Speedo Custom',
@@ -5182,7 +5573,7 @@ return {
         model = 'speedo5',
         price = 70653,
         category = 'vans',
-        hash = `speedo5`,
+        hash = `speedo5`
     },
     squaddie = {
         name = 'Squaddie',
@@ -5190,7 +5581,7 @@ return {
         model = 'squaddie',
         price = 63238,
         category = 'suvs',
-        hash = `squaddie`,
+        hash = `squaddie`
     },
     squalo = {
         name = 'Squalo',
@@ -5199,6 +5590,7 @@ return {
         price = 362680,
         category = 'boats',
         hash = `squalo`,
+        shop = 'boats'
     },
     stafford = {
         name = 'Stafford',
@@ -5207,6 +5599,7 @@ return {
         price = 62882,
         category = 'sedans',
         hash = `stafford`,
+        shop = 'pdm'
     },
     stalion = {
         name = 'Stallion',
@@ -5215,6 +5608,7 @@ return {
         price = 74781,
         category = 'muscle',
         hash = `stalion`,
+        shop = 'pdm'
     },
     stalion2 = {
         name = 'Stallion Burgershot',
@@ -5223,6 +5617,7 @@ return {
         price = 79092,
         category = 'muscle',
         hash = `stalion2`,
+        shop = 'pdm'
     },
     stanier = {
         name = 'Stanier',
@@ -5231,6 +5626,7 @@ return {
         price = 71053,
         category = 'sedans',
         hash = `stanier`,
+        shop = 'pdm'
     },
     starling = {
         name = 'LF-22 Starling',
@@ -5238,7 +5634,7 @@ return {
         model = 'starling',
         price = 5890500,
         category = 'planes',
-        hash = `starling`,
+        hash = `starling`
     },
     stinger = {
         name = 'Stinger',
@@ -5247,6 +5643,7 @@ return {
         price = 74712,
         category = 'sportsclassics',
         hash = `stinger`,
+        shop = 'pdm'
     },
     stingergt = {
         name = 'Stinger GT',
@@ -5255,6 +5652,7 @@ return {
         price = 74712,
         category = 'sportsclassics',
         hash = `stingergt`,
+        shop = 'pdm'
     },
     stingertt = {
         name = 'Itali GTO Stinger TT',
@@ -5262,7 +5660,7 @@ return {
         model = 'stingertt',
         price = 87213,
         category = 'sports',
-        hash = `stingertt`,
+        hash = `stingertt`
     },
     stockade = {
         name = 'Stockade',
@@ -5270,7 +5668,7 @@ return {
         model = 'stockade',
         price = 56588,
         category = 'commercial',
-        hash = `stockade`,
+        hash = `stockade`
     },
     stockade3 = {
         name = 'Stockade (Bobcat Security/Snow)',
@@ -5278,7 +5676,7 @@ return {
         model = 'stockade3',
         price = 56588,
         category = 'commercial',
-        hash = `stockade3`,
+        hash = `stockade3`
     },
     stratum = {
         name = 'Stratum',
@@ -5287,6 +5685,7 @@ return {
         price = 68894,
         category = 'sedans',
         hash = `stratum`,
+        shop = 'pdm'
     },
     streamer216 = {
         name = 'Streamer216',
@@ -5294,7 +5693,7 @@ return {
         model = 'streamer216',
         price = 1574232,
         category = 'planes',
-        hash = `streamer216`,
+        hash = `streamer216`
     },
     streiter = {
         name = 'Streiter',
@@ -5303,6 +5702,7 @@ return {
         price = 71204,
         category = 'sports',
         hash = `streiter`,
+        shop = 'luxury'
     },
     stretch = {
         name = 'Stretch',
@@ -5311,6 +5711,7 @@ return {
         price = 63950,
         category = 'sedans',
         hash = `stretch`,
+        shop = 'pdm'
     },
     strikeforce = {
         name = 'B-11 Strikeforce',
@@ -5318,7 +5719,7 @@ return {
         model = 'strikeforce',
         price = 1810529,
         category = 'planes',
-        hash = `strikeforce`,
+        hash = `strikeforce`
     },
     stromberg = {
         name = 'Stromberg',
@@ -5327,6 +5728,7 @@ return {
         price = 76526,
         category = 'sportsclassics',
         hash = `stromberg`,
+        shop = 'pdm'
     },
     stryder = {
         name = 'Stryder',
@@ -5335,6 +5737,7 @@ return {
         price = 26711,
         category = 'motorcycles',
         hash = `stryder`,
+        shop = 'pdm'
     },
     stunt = {
         name = 'Mallard',
@@ -5343,6 +5746,7 @@ return {
         price = 1702472,
         category = 'planes',
         hash = `stunt`,
+        shop = 'air'
     },
     submersible = {
         name = 'Submersible',
@@ -5350,7 +5754,7 @@ return {
         model = 'submersible',
         price = 718616,
         category = 'boats',
-        hash = `submersible`,
+        hash = `submersible`
     },
     submersible2 = {
         name = 'Kraken',
@@ -5358,7 +5762,7 @@ return {
         model = 'submersible2',
         price = 787416,
         category = 'boats',
-        hash = `submersible2`,
+        hash = `submersible2`
     },
     sugoi = {
         name = 'Sugoi',
@@ -5367,6 +5771,7 @@ return {
         price = 75269,
         category = 'sports',
         hash = `sugoi`,
+        shop = 'luxury'
     },
     sultan = {
         name = 'Sultan',
@@ -5375,6 +5780,7 @@ return {
         price = 74392,
         category = 'sports',
         hash = `sultan`,
+        shop = 'luxury'
     },
     sultan2 = {
         name = 'Sultan Custom',
@@ -5383,14 +5789,16 @@ return {
         price = 77184,
         category = 'sports',
         hash = `sultan2`,
+        shop = 'luxury'
     },
     sultan3 = {
         name = 'Sultan Classic Custom',
         brand = 'Karin',
-        category = 'sports',
-        hash = `sultan3`,
         model = 'sultan3',
         price = 78067,
+        category = 'sports',
+        hash = `sultan3`,
+        shop = 'luxury'
     },
     sultanrs = {
         name = 'Sultan RS',
@@ -5399,6 +5807,7 @@ return {
         price = 82197,
         category = 'super',
         hash = `sultanrs`,
+        shop = 'luxury'
     },
     suntrap = {
         name = 'Suntrap',
@@ -5407,14 +5816,16 @@ return {
         price = 362680,
         category = 'boats',
         hash = `suntrap`,
+        shop = 'boats'
     },
     superd = {
+        name = 'Super Diamond',
         brand = 'Enus',
+        model = 'superd',
+        price = 74712,
         category = 'sedans',
         hash = `superd`,
-        model = 'superd',
-        name = 'Super Diamond',
-        price = 74712,
+        shop = 'pdm'
     },
     supervolito = {
         name = 'SuperVolito',
@@ -5423,6 +5834,7 @@ return {
         price = 6905749,
         category = 'helicopters',
         hash = `supervolito`,
+        shop = 'air'
     },
     supervolito2 = {
         name = 'SuperVolito Carbon',
@@ -5431,6 +5843,7 @@ return {
         price = 6905749,
         category = 'helicopters',
         hash = `supervolito2`,
+        shop = 'air'
     },
     surano = {
         name = 'Surano',
@@ -5439,6 +5852,7 @@ return {
         price = 83971,
         category = 'sports',
         hash = `surano`,
+        shop = 'luxury'
     },
     surfer = {
         name = 'Surfer',
@@ -5447,6 +5861,7 @@ return {
         price = 34505,
         category = 'vans',
         hash = `surfer`,
+        shop = 'pdm'
     },
     surfer2 = {
         name = 'Surfer',
@@ -5454,7 +5869,7 @@ return {
         model = 'surfer2',
         price = 34505,
         category = 'vans',
-        hash = `surfer2`,
+        hash = `surfer2`
     },
     surfer3 = {
         name = 'Surfer Custom',
@@ -5462,7 +5877,7 @@ return {
         model = 'surfer3',
         price = 34505,
         category = 'vans',
-        hash = `surfer3`,
+        hash = `surfer3`
     },
     surge = {
         name = 'Surge',
@@ -5471,6 +5886,7 @@ return {
         price = 40605,
         category = 'sedans',
         hash = `surge`,
+        shop = 'pdm'
     },
     swift = {
         name = 'Swift',
@@ -5479,6 +5895,7 @@ return {
         price = 6504898,
         category = 'helicopters',
         hash = `swift`,
+        shop = 'air'
     },
     swift2 = {
         name = 'Swift Deluxe',
@@ -5487,6 +5904,7 @@ return {
         price = 6588870,
         category = 'helicopters',
         hash = `swift2`,
+        shop = 'air'
     },
     swinger = {
         name = 'Swinger',
@@ -5495,6 +5913,7 @@ return {
         price = 81274,
         category = 'sportsclassics',
         hash = `swinger`,
+        shop = 'pdm'
     },
     t20 = {
         name = 'Progen T20',
@@ -5503,6 +5922,7 @@ return {
         price = 83022,
         category = 'super',
         hash = `t20`,
+        shop = 'luxury'
     },
     taco = {
         name = 'Taco Van',
@@ -5510,7 +5930,7 @@ return {
         model = 'taco',
         price = 47273,
         category = 'vans',
-        hash = `taco`,
+        hash = `taco`
     },
     tahoma = {
         name = 'Tahoma Coupe',
@@ -5518,7 +5938,7 @@ return {
         model = 'tahoma',
         price = 72249,
         category = 'muscle',
-        hash = `tahoma`,
+        hash = `tahoma`
     },
     tailgater = {
         name = 'Tailgater',
@@ -5527,6 +5947,7 @@ return {
         price = 64174,
         category = 'sedans',
         hash = `tailgater`,
+        shop = 'pdm'
     },
     tailgater2 = {
         name = 'Tailgater S',
@@ -5535,6 +5956,7 @@ return {
         price = 77411,
         category = 'sedans',
         hash = `tailgater2`,
+        shop = 'pdm'
     },
     taipan = {
         name = 'Taipan',
@@ -5543,6 +5965,7 @@ return {
         price = 89537,
         category = 'super',
         hash = `taipan`,
+        shop = 'luxury'
     },
     tampa = {
         name = 'Tampa',
@@ -5551,6 +5974,7 @@ return {
         price = 70442,
         category = 'muscle',
         hash = `tampa`,
+        shop = 'pdm'
     },
     tampa2 = {
         name = 'Drift Tampa',
@@ -5559,6 +5983,7 @@ return {
         price = 75751,
         category = 'sports',
         hash = `tampa2`,
+        shop = 'pdm'
     },
     tampa3 = {
         name = 'Weaponized Tampa',
@@ -5566,7 +5991,7 @@ return {
         model = 'tampa3',
         price = 75751,
         category = 'muscle',
-        hash = `tampa3`,
+        hash = `tampa3`
     },
     tanker = {
         name = 'Tanker Trailer',
@@ -5574,7 +5999,7 @@ return {
         model = 'tanker',
         price = 5748,
         category = 'utility',
-        hash = `tanker`,
+        hash = `tanker`
     },
     tanker2 = {
         name = 'Tanker Trailer',
@@ -5582,7 +6007,7 @@ return {
         model = 'tanker2',
         price = 5748,
         category = 'utility',
-        hash = `tanker2`,
+        hash = `tanker2`
     },
     tankercar = {
         name = 'Freight Train (Tanker Trailer)',
@@ -5590,7 +6015,7 @@ return {
         model = 'tankercar',
         price = 194680,
         category = 'trains',
-        hash = `tankercar`,
+        hash = `tankercar`
     },
     taxi = {
         name = 'Taxi',
@@ -5598,7 +6023,7 @@ return {
         model = 'taxi',
         price = 71053,
         category = 'service',
-        hash = `taxi`,
+        hash = `taxi`
     },
     technical = {
         name = 'Technical',
@@ -5606,7 +6031,7 @@ return {
         model = 'technical',
         price = 63854,
         category = 'offroad',
-        hash = `technical`,
+        hash = `technical`
     },
     technical2 = {
         name = 'Technical Aqua',
@@ -5614,7 +6039,7 @@ return {
         model = 'technical2',
         price = 65910,
         category = 'offroad',
-        hash = `technical2`,
+        hash = `technical2`
     },
     technical3 = {
         name = 'Technical Custom',
@@ -5622,7 +6047,7 @@ return {
         model = 'technical3',
         price = 63854,
         category = 'offroad',
-        hash = `technical3`,
+        hash = `technical3`
     },
     tempesta = {
         name = 'Tempesta',
@@ -5631,6 +6056,7 @@ return {
         price = 81980,
         category = 'super',
         hash = `tempesta`,
+        shop = 'luxury'
     },
     tenf = {
         name = '10F',
@@ -5639,6 +6065,7 @@ return {
         price = 82128,
         category = 'sports',
         hash = `tenf`,
+        shop = 'luxury'
     },
     tenf2 = {
         name = '10F Widebody',
@@ -5647,6 +6074,7 @@ return {
         price = 82729,
         category = 'sports',
         hash = `tenf2`,
+        shop = 'luxury'
     },
     terbyte = {
         name = 'Terrorbyte',
@@ -5654,7 +6082,7 @@ return {
         model = 'terbyte',
         price = 50669,
         category = 'commercial',
-        hash = `terbyte`,
+        hash = `terbyte`
     },
     terminus = {
         name = 'Terminus',
@@ -5662,7 +6090,7 @@ return {
         model = 'terminus',
         price = 71490,
         category = 'offroad',
-        hash = `terminus`,
+        hash = `terminus`
     },
     tezeract = {
         name = 'Tezeract',
@@ -5671,6 +6099,7 @@ return {
         price = 76330,
         category = 'super',
         hash = `tezeract`,
+        shop = 'luxury'
     },
     thrax = {
         name = 'Thrax',
@@ -5679,6 +6108,7 @@ return {
         price = 83929,
         category = 'super',
         hash = `thrax`,
+        shop = 'luxury'
     },
     thrust = {
         name = 'Thrust',
@@ -5687,6 +6117,7 @@ return {
         price = 25865,
         category = 'motorcycles',
         hash = `thrust`,
+        shop = 'pdm'
     },
     thruster = {
         name = 'Thruster',
@@ -5694,7 +6125,7 @@ return {
         model = 'thruster',
         price = 6768641,
         category = 'military',
-        hash = `thruster`,
+        hash = `thruster`
     },
     tigon = {
         name = 'Tigon',
@@ -5703,6 +6134,7 @@ return {
         price = 86363,
         category = 'super',
         hash = `tigon`,
+        shop = 'luxury'
     },
     tiptruck = {
         name = 'Tipper',
@@ -5710,7 +6142,7 @@ return {
         model = 'tiptruck',
         price = 47273,
         category = 'industrial',
-        hash = `tiptruck`,
+        hash = `tiptruck`
     },
     tiptruck2 = {
         name = 'Tipper',
@@ -5718,7 +6150,7 @@ return {
         model = 'tiptruck2',
         price = 47273,
         category = 'industrial',
-        hash = `tiptruck2`,
+        hash = `tiptruck2`
     },
     titan = {
         name = 'Titan',
@@ -5726,7 +6158,7 @@ return {
         model = 'titan',
         price = 1521752,
         category = 'planes',
-        hash = `titan`,
+        hash = `titan`
     },
     toreador = {
         name = 'Toreador',
@@ -5735,6 +6167,7 @@ return {
         price = 235089,
         category = 'sportsclassics',
         hash = `toreador`,
+        shop = 'pdm'
     },
     torero = {
         name = 'Torero',
@@ -5743,6 +6176,7 @@ return {
         price = 78457,
         category = 'sportsclassics',
         hash = `torero`,
+        shop = 'pdm'
     },
     torero2 = {
         name = 'Torero XO',
@@ -5751,6 +6185,7 @@ return {
         price = 87548,
         category = 'super',
         hash = `torero2`,
+        shop = 'luxury'
     },
     tornado = {
         name = 'Tornado',
@@ -5759,6 +6194,7 @@ return {
         price = 60635,
         category = 'sportsclassics',
         hash = `tornado`,
+        shop = 'pdm'
     },
     tornado2 = {
         name = 'Tornado Gang',
@@ -5767,6 +6203,7 @@ return {
         price = 60635,
         category = 'sportsclassics',
         hash = `tornado2`,
+        shop = 'pdm'
     },
     tornado3 = {
         name = 'Tornado (Beater)',
@@ -5774,7 +6211,7 @@ return {
         model = 'tornado3',
         price = 60635,
         category = 'sportsclassics',
-        hash = `tornado3`,
+        hash = `tornado3`
     },
     tornado4 = {
         name = 'Tornado (Mariachi)',
@@ -5782,7 +6219,7 @@ return {
         model = 'tornado4',
         price = 60635,
         category = 'sportsclassics',
-        hash = `tornado4`,
+        hash = `tornado4`
     },
     tornado5 = {
         name = 'Tornado Custom',
@@ -5791,6 +6228,7 @@ return {
         price = 60890,
         category = 'sportsclassics',
         hash = `tornado5`,
+        shop = 'pdm'
     },
     tornado6 = {
         name = 'Tornado Rat Rod',
@@ -5798,7 +6236,7 @@ return {
         model = 'tornado6',
         price = 66096,
         category = 'sportsclassics',
-        hash = `tornado6`,
+        hash = `tornado6`
     },
     toro = {
         name = 'Toro',
@@ -5807,6 +6245,7 @@ return {
         price = 486680,
         category = 'boats',
         hash = `toro`,
+        shop = 'boats'
     },
     toro2 = {
         name = 'Toro (Yacht)',
@@ -5815,6 +6254,7 @@ return {
         price = 486680,
         category = 'boats',
         hash = `toro2`,
+        shop = 'boats'
     },
     toros = {
         name = 'Toros',
@@ -5823,6 +6263,7 @@ return {
         price = 81091,
         category = 'suvs',
         hash = `toros`,
+        shop = 'pdm'
     },
     tourbus = {
         name = 'Tour Bus',
@@ -5830,7 +6271,7 @@ return {
         model = 'tourbus',
         price = 42321,
         category = 'service',
-        hash = `tourbus`,
+        hash = `tourbus`
     },
     towtruck = {
         name = 'Tow Truck',
@@ -5838,7 +6279,7 @@ return {
         model = 'towtruck',
         price = 57488,
         category = 'utility',
-        hash = `towtruck`,
+        hash = `towtruck`
     },
     towtruck2 = {
         name = 'Tow Truck (Small)',
@@ -5846,7 +6287,7 @@ return {
         model = 'towtruck2',
         price = 54821,
         category = 'utility',
-        hash = `towtruck2`,
+        hash = `towtruck2`
     },
     towtruck3 = {
         name = 'Tow Truck (Beater)',
@@ -5854,7 +6295,7 @@ return {
         model = 'towtruck3',
         price = 62901,
         category = 'utility',
-        hash = `towtruck3`,
+        hash = `towtruck3`
     },
     towtruck4 = {
         name = 'Tow Truck',
@@ -5862,7 +6303,7 @@ return {
         model = 'towtruck4',
         price = 62901,
         category = 'utility',
-        hash = `towtruck4`,
+        hash = `towtruck4`
     },
     tr2 = {
         name = 'Trailer (Car Carrier)',
@@ -5870,7 +6311,7 @@ return {
         model = 'tr2',
         price = 5748,
         category = 'utility',
-        hash = `tr2`,
+        hash = `tr2`
     },
     tr3 = {
         name = 'Trailer (Boat)',
@@ -5878,7 +6319,7 @@ return {
         model = 'tr3',
         price = 5748,
         category = 'utility',
-        hash = `tr3`,
+        hash = `tr3`
     },
     tr4 = {
         name = 'Trailer (Packed Car Carrier)',
@@ -5886,7 +6327,7 @@ return {
         model = 'tr4',
         price = 5748,
         category = 'utility',
-        hash = `tr4`,
+        hash = `tr4`
     },
     tractor = {
         name = 'Tractor',
@@ -5894,7 +6335,7 @@ return {
         model = 'tractor',
         price = 22677,
         category = 'utility',
-        hash = `tractor`,
+        hash = `tractor`
     },
     tractor2 = {
         name = 'Fieldmaster',
@@ -5902,7 +6343,7 @@ return {
         model = 'tractor2',
         price = 24703,
         category = 'utility',
-        hash = `tractor2`,
+        hash = `tractor2`
     },
     tractor3 = {
         name = 'Fieldmaster (Snow)',
@@ -5910,7 +6351,7 @@ return {
         model = 'tractor3',
         price = 24703,
         category = 'utility',
-        hash = `tractor3`,
+        hash = `tractor3`
     },
     trailerlarge = {
         name = 'Mobile Operations Center',
@@ -5918,7 +6359,7 @@ return {
         model = 'trailerlarge',
         price = 5668,
         category = 'utility',
-        hash = `trailerlarge`,
+        hash = `trailerlarge`
     },
     trailerlogs = {
         name = 'Trailer (Logs)',
@@ -5926,7 +6367,7 @@ return {
         model = 'trailerlogs',
         price = 5748,
         category = 'utility',
-        hash = `trailerlogs`,
+        hash = `trailerlogs`
     },
     trailers = {
         name = 'Trailer (Container)',
@@ -5934,7 +6375,7 @@ return {
         model = 'trailers',
         price = 5668,
         category = 'utility',
-        hash = `trailers`,
+        hash = `trailers`
     },
     trailers2 = {
         name = 'Trailer (Box)',
@@ -5942,7 +6383,7 @@ return {
         model = 'trailers2',
         price = 5668,
         category = 'utility',
-        hash = `trailers2`,
+        hash = `trailers2`
     },
     trailers3 = {
         name = 'Trailer (Ramp box)',
@@ -5950,7 +6391,7 @@ return {
         model = 'trailers3',
         price = 5668,
         category = 'utility',
-        hash = `trailers3`,
+        hash = `trailers3`
     },
     trailers4 = {
         name = 'Trailer (Container)',
@@ -5958,7 +6399,7 @@ return {
         model = 'trailers4',
         price = 5668,
         category = 'utility',
-        hash = `trailers4`,
+        hash = `trailers4`
     },
     trailers5 = {
         name = 'Trailer (Christmas)',
@@ -5966,7 +6407,7 @@ return {
         model = 'trailers5',
         price = 5668,
         category = 'utility',
-        hash = `trailers5`,
+        hash = `trailers5`
     },
     trailersmall = {
         name = 'Trailer (Storage/generator)',
@@ -5974,7 +6415,7 @@ return {
         model = 'trailersmall',
         price = 5668,
         category = 'utility',
-        hash = `trailersmall`,
+        hash = `trailersmall`
     },
     trailersmall2 = {
         name = 'Anti-Aircraft Trailer',
@@ -5982,7 +6423,7 @@ return {
         model = 'trailersmall2',
         price = 5668,
         category = 'military',
-        hash = `trailersmall2`,
+        hash = `trailersmall2`
     },
     trash = {
         name = 'Trashmaster',
@@ -5990,7 +6431,7 @@ return {
         model = 'trash',
         price = 59939,
         category = 'service',
-        hash = `trash`,
+        hash = `trash`
     },
     trash2 = {
         name = 'Trashmaster (Heist)',
@@ -5998,7 +6439,7 @@ return {
         model = 'trash2',
         price = 59939,
         category = 'service',
-        hash = `trash2`,
+        hash = `trash2`
     },
     trflat = {
         name = 'Trailer (Flatbed)',
@@ -6006,7 +6447,7 @@ return {
         model = 'trflat',
         price = 5668,
         category = 'utility',
-        hash = `trflat`,
+        hash = `trflat`
     },
     tribike = {
         name = 'Whippet Race Bike',
@@ -6015,6 +6456,7 @@ return {
         price = 3622,
         category = 'cycles',
         hash = `tribike`,
+        shop = 'pdm'
     },
     tribike2 = {
         name = 'Endurex Race Bike',
@@ -6023,6 +6465,7 @@ return {
         price = 3622,
         category = 'cycles',
         hash = `tribike2`,
+        shop = 'pdm'
     },
     tribike3 = {
         name = 'Tri-Cycles Race Bike',
@@ -6031,6 +6474,7 @@ return {
         price = 3622,
         category = 'cycles',
         hash = `tribike3`,
+        shop = 'pdm'
     },
     trophytruck = {
         name = 'Trophy Truck',
@@ -6039,6 +6483,7 @@ return {
         price = 71559,
         category = 'offroad',
         hash = `trophytruck`,
+        shop = 'pdm'
     },
     trophytruck2 = {
         name = 'Desert Raid',
@@ -6047,6 +6492,7 @@ return {
         price = 71559,
         category = 'offroad',
         hash = `trophytruck2`,
+        shop = 'pdm'
     },
     tropic = {
         name = 'Tropic',
@@ -6055,6 +6501,7 @@ return {
         price = 390680,
         category = 'boats',
         hash = `tropic`,
+        shop = 'boats'
     },
     tropic2 = {
         name = 'Tropic (Yacht)',
@@ -6063,6 +6510,7 @@ return {
         price = 390680,
         category = 'boats',
         hash = `tropic2`,
+        shop = 'boats'
     },
     tropos = {
         name = 'Tropos Rallye',
@@ -6071,6 +6519,7 @@ return {
         price = 71140,
         category = 'sports',
         hash = `tropos`,
+        shop = 'luxury'
     },
     tug = {
         name = 'Tug',
@@ -6078,7 +6527,7 @@ return {
         model = 'tug',
         price = 67079,
         category = 'boats',
-        hash = `tug`,
+        hash = `tug`
     },
     tula = {
         name = 'Tula',
@@ -6086,7 +6535,7 @@ return {
         model = 'tula',
         price = 1321065,
         category = 'planes',
-        hash = `tula`,
+        hash = `tula`
     },
     tulip = {
         name = 'Tulip',
@@ -6095,6 +6544,7 @@ return {
         price = 80611,
         category = 'muscle',
         hash = `tulip`,
+        shop = 'pdm'
     },
     tulip2 = {
         name = 'Tulip M-100',
@@ -6102,7 +6552,7 @@ return {
         model = 'tulip2',
         price = 74746,
         category = 'muscle',
-        hash = `tulip2`,
+        hash = `tulip2`
     },
     turismo2 = {
         name = 'Turismo Classic',
@@ -6111,6 +6561,7 @@ return {
         price = 81835,
         category = 'sportsclassics',
         hash = `turismo2`,
+        shop = 'pdm'
     },
     turismo3 = {
         name = 'Turismo Omaggio',
@@ -6118,7 +6569,7 @@ return {
         model = 'turismo3',
         price = 83545,
         category = 'super',
-        hash = `turismo3`,
+        hash = `turismo3`
     },
     turismor = {
         name = 'Grotti Turismo R',
@@ -6127,6 +6578,7 @@ return {
         price = 85403,
         category = 'super',
         hash = `turismor`,
+        shop = 'luxury'
     },
     tvtrailer = {
         name = 'Trailer (Fame or Shame)',
@@ -6134,7 +6586,7 @@ return {
         model = 'tvtrailer',
         price = 5668,
         category = 'utility',
-        hash = `tvtrailer`,
+        hash = `tvtrailer`
     },
     tvtrailer2 = {
         name = 'Trailer',
@@ -6142,7 +6594,7 @@ return {
         model = 'tvtrailer2',
         price = 5668,
         category = 'utility',
-        hash = `tvtrailer2`,
+        hash = `tvtrailer2`
     },
     tyrant = {
         name = 'Tyrant',
@@ -6151,6 +6603,7 @@ return {
         price = 88321,
         category = 'super',
         hash = `tyrant`,
+        shop = 'luxury'
     },
     tyrus = {
         name = 'Tyrus',
@@ -6159,6 +6612,7 @@ return {
         price = 84350,
         category = 'super',
         hash = `tyrus`,
+        shop = 'luxury'
     },
     utillitruck = {
         name = 'Utility Truck (Cherry Picker)',
@@ -6166,7 +6620,7 @@ return {
         model = 'utillitruck',
         price = 50131,
         category = 'utility',
-        hash = `utillitruck`,
+        hash = `utillitruck`
     },
     utillitruck2 = {
         name = 'Utility Truck (Cargo)',
@@ -6174,7 +6628,7 @@ return {
         model = 'utillitruck2',
         price = 50131,
         category = 'utility',
-        hash = `utillitruck2`,
+        hash = `utillitruck2`
     },
     utillitruck3 = {
         name = 'Utility Truck (Van)',
@@ -6182,7 +6636,7 @@ return {
         model = 'utillitruck3',
         price = 50131,
         category = 'utility',
-        hash = `utillitruck3`,
+        hash = `utillitruck3`
     },
     vacca = {
         name = 'Vacca',
@@ -6191,6 +6645,7 @@ return {
         price = 83666,
         category = 'super',
         hash = `vacca`,
+        shop = 'luxury'
     },
     vader = {
         name = 'Vader',
@@ -6199,6 +6654,7 @@ return {
         price = 22163,
         category = 'motorcycles',
         hash = `vader`,
+        shop = 'pdm'
     },
     vagner = {
         name = 'Vagner',
@@ -6207,6 +6663,7 @@ return {
         price = 87808,
         category = 'super',
         hash = `vagner`,
+        shop = 'luxury'
     },
     vagrant = {
         name = 'Vagrant',
@@ -6215,6 +6672,7 @@ return {
         price = 77576,
         category = 'offroad',
         hash = `vagrant`,
+        shop = 'pdm'
     },
     valkyrie = {
         name = 'Valkyrie',
@@ -6222,7 +6680,7 @@ return {
         model = 'valkyrie',
         price = 6116097,
         category = 'helicopters',
-        hash = `valkyrie`,
+        hash = `valkyrie`
     },
     valkyrie2 = {
         name = 'Valkyrie MOD.0',
@@ -6230,7 +6688,7 @@ return {
         model = 'valkyrie2',
         price = 6116097,
         category = 'helicopters',
-        hash = `valkyrie2`,
+        hash = `valkyrie2`
     },
     vamos = {
         name = 'Vamos',
@@ -6239,6 +6697,7 @@ return {
         price = 75751,
         category = 'muscle',
         hash = `vamos`,
+        shop = 'pdm'
     },
     vectre = {
         name = 'Vectre',
@@ -6247,6 +6706,7 @@ return {
         price = 73202,
         category = 'sports',
         hash = `vectre`,
+        shop = 'luxury'
     },
     velum = {
         name = 'Velum',
@@ -6255,6 +6715,7 @@ return {
         price = 1439638,
         category = 'planes',
         hash = `velum`,
+        shop = 'air'
     },
     velum2 = {
         name = 'Velum',
@@ -6263,6 +6724,7 @@ return {
         price = 1439638,
         category = 'planes',
         hash = `velum2`,
+        shop = 'air'
     },
     verlierer2 = {
         name = 'Verlierer',
@@ -6271,6 +6733,7 @@ return {
         price = 83280,
         category = 'sports',
         hash = `verlierer2`,
+        shop = 'luxury'
     },
     verus = {
         name = 'Verus',
@@ -6279,6 +6742,7 @@ return {
         price = 16526,
         category = 'offroad',
         hash = `verus`,
+        shop = 'pdm'
     },
     vestra = {
         name = 'Vestra',
@@ -6287,6 +6751,7 @@ return {
         price = 1982877,
         category = 'planes',
         hash = `vestra`,
+        shop = 'air'
     },
     vetir = {
         name = 'Vetir',
@@ -6294,7 +6759,7 @@ return {
         model = 'vetir',
         price = 38828,
         category = 'military',
-        hash = `vetir`,
+        hash = `vetir`
     },
     veto = {
         name = 'Veto Classic',
@@ -6302,7 +6767,7 @@ return {
         model = 'veto',
         price = 42608,
         category = 'sports',
-        hash = `veto`,
+        hash = `veto`
     },
     veto2 = {
         name = 'Veto Modern',
@@ -6310,7 +6775,7 @@ return {
         model = 'veto2',
         price = 45282,
         category = 'sports',
-        hash = `veto2`,
+        hash = `veto2`
     },
     vigero = {
         name = 'Vigero',
@@ -6319,6 +6784,7 @@ return {
         price = 77482,
         category = 'muscle',
         hash = `vigero`,
+        shop = 'pdm'
     },
     vigero2 = {
         name = 'Vigero ZX',
@@ -6327,6 +6793,7 @@ return {
         price = 82143,
         category = 'muscle',
         hash = `vigero2`,
+        shop = 'pdm'
     },
     vigero3 = {
         name = 'Vigero ZX Convertible',
@@ -6334,7 +6801,7 @@ return {
         model = 'vigero3',
         price = 81866,
         category = 'muscle',
-        hash = `vigero3`,
+        hash = `vigero3`
     },
     vigilante = {
         name = 'Vigilante',
@@ -6342,7 +6809,7 @@ return {
         model = 'vigilante',
         price = 261085,
         category = 'super',
-        hash = `vigilante`,
+        hash = `vigilante`
     },
     vindicator = {
         name = 'Vindicator',
@@ -6351,6 +6818,7 @@ return {
         price = 31055,
         category = 'motorcycles',
         hash = `vindicator`,
+        shop = 'pdm'
     },
     virgo = {
         name = 'Virgo',
@@ -6359,6 +6827,7 @@ return {
         price = 60554,
         category = 'muscle',
         hash = `virgo`,
+        shop = 'pdm'
     },
     virgo2 = {
         name = 'Virgo Custom Classic',
@@ -6367,6 +6836,7 @@ return {
         price = 60758,
         category = 'muscle',
         hash = `virgo2`,
+        shop = 'pdm'
     },
     virgo3 = {
         name = 'Virgo Custom Classic',
@@ -6375,14 +6845,15 @@ return {
         price = 60554,
         category = 'muscle',
         hash = `virgo3`,
+        shop = 'pdm'
     },
     virtue = {
-        brand = 'Ocelot',
-        category = 'super',
-        hash = `virtue`,
-        model = 'virtue',
         name = 'Virtue',
+        brand = 'Ocelot',
+        model = 'virtue',
         price = 76383,
+        category = 'super',
+        hash = `virtue`
     },
     viseris = {
         name = 'Viseris',
@@ -6391,6 +6862,7 @@ return {
         price = 78246,
         category = 'sportsclassics',
         hash = `viseris`,
+        shop = 'pdm'
     },
     visione = {
         name = 'Visione',
@@ -6399,6 +6871,7 @@ return {
         price = 85576,
         category = 'super',
         hash = `visione`,
+        shop = 'luxury'
     },
     vivanite = {
         name = 'Vivanite',
@@ -6406,7 +6879,7 @@ return {
         model = 'vivanite',
         price = 46334,
         category = 'suvs',
-        hash = `vivanite`,
+        hash = `vivanite`
     },
     volatol = {
         name = 'Volatol',
@@ -6414,7 +6887,7 @@ return {
         model = 'volatol',
         price = 1570129,
         category = 'planes',
-        hash = `volatol`,
+        hash = `volatol`
     },
     volatus = {
         name = 'Volatus',
@@ -6423,6 +6896,7 @@ return {
         price = 6589212,
         category = 'helicopters',
         hash = `volatus`,
+        shop = 'air'
     },
     voltic = {
         name = 'Voltic',
@@ -6431,6 +6905,7 @@ return {
         price = 60326,
         category = 'super',
         hash = `voltic`,
+        shop = 'luxury'
     },
     voltic2 = {
         name = 'Rocket Voltic',
@@ -6439,14 +6914,16 @@ return {
         price = 180978,
         category = 'super',
         hash = `voltic2`,
+        shop = 'luxury'
     },
     voodoo = {
+        name = 'Voodoo Custom',
         brand = 'Declasse',
+        model = 'voodoo',
+        price = 66162,
         category = 'muscle',
         hash = `voodoo`,
-        model = 'voodoo',
-        name = 'Voodoo Custom',
-        price = 66162,
+        shop = 'pdm'
     },
     voodoo2 = {
         name = 'Voodoo',
@@ -6454,7 +6931,7 @@ return {
         model = 'voodoo2',
         price = 63070,
         category = 'muscle',
-        hash = `voodoo2`,
+        hash = `voodoo2`
     },
     vortex = {
         name = 'Vortex',
@@ -6463,6 +6940,7 @@ return {
         price = 25612,
         category = 'motorcycles',
         hash = `vortex`,
+        shop = 'pdm'
     },
     vstr = {
         name = 'V-STR',
@@ -6471,6 +6949,7 @@ return {
         price = 79649,
         category = 'sports',
         hash = `vstr`,
+        shop = 'luxury'
     },
     warrener = {
         name = 'Warrener',
@@ -6479,6 +6958,7 @@ return {
         price = 64367,
         category = 'sedans',
         hash = `warrener`,
+        shop = 'pdm'
     },
     warrener2 = {
         name = 'Warrener HKR',
@@ -6487,6 +6967,7 @@ return {
         price = 67374,
         category = 'sedans',
         hash = `warrener2`,
+        shop = 'pdm'
     },
     washington = {
         name = 'Washington',
@@ -6495,6 +6976,7 @@ return {
         price = 71053,
         category = 'sedans',
         hash = `washington`,
+        shop = 'pdm'
     },
     wastelander = {
         name = 'Wastelander',
@@ -6502,7 +6984,7 @@ return {
         model = 'wastelander',
         price = 67837,
         category = 'service',
-        hash = `wastelander`,
+        hash = `wastelander`
     },
     weevil = {
         name = 'Weevil',
@@ -6511,6 +6993,7 @@ return {
         price = 53983,
         category = 'compacts',
         hash = `weevil`,
+        shop = 'pdm'
     },
     weevil2 = {
         name = 'Weevil Custom',
@@ -6519,6 +7002,7 @@ return {
         price = 83800,
         category = 'muscle',
         hash = `weevil2`,
+        shop = 'pdm'
     },
     windsor = {
         name = 'Windsor',
@@ -6527,6 +7011,7 @@ return {
         price = 79422,
         category = 'coupes',
         hash = `windsor`,
+        shop = 'pdm'
     },
     windsor2 = {
         name = 'Windsor Drop',
@@ -6535,6 +7020,7 @@ return {
         price = 79252,
         category = 'coupes',
         hash = `windsor2`,
+        shop = 'pdm'
     },
     winky = {
         name = 'Winky',
@@ -6543,6 +7029,7 @@ return {
         price = 49504,
         category = 'offroad',
         hash = `winky`,
+        shop = 'pdm'
     },
     wolfsbane = {
         name = 'Wolfsbane',
@@ -6551,6 +7038,7 @@ return {
         price = 19441,
         category = 'motorcycles',
         hash = `wolfsbane`,
+        shop = 'pdm'
     },
     xa21 = {
         name = 'XA-21',
@@ -6559,6 +7047,7 @@ return {
         price = 82892,
         category = 'super',
         hash = `xa21`,
+        shop = 'luxury'
     },
     xls = {
         name = 'XLS',
@@ -6567,6 +7056,7 @@ return {
         price = 72768,
         category = 'suvs',
         hash = `xls`,
+        shop = 'pdm'
     },
     xls2 = {
         name = 'XLS (Armored)',
@@ -6574,7 +7064,7 @@ return {
         model = 'xls2',
         price = 72800,
         category = 'suvs',
-        hash = `xls2`,
+        hash = `xls2`
     },
     yosemite = {
         name = 'Yosemite',
@@ -6583,6 +7073,7 @@ return {
         price = 69338,
         category = 'muscle',
         hash = `yosemite`,
+        shop = 'pdm'
     },
     yosemite2 = {
         name = 'Yosemite Drift',
@@ -6591,6 +7082,7 @@ return {
         price = 74171,
         category = 'muscle',
         hash = `yosemite2`,
+        shop = 'pdm'
     },
     yosemite3 = {
         name = 'Yosemite Rancher',
@@ -6599,6 +7091,7 @@ return {
         price = 66896,
         category = 'offroad',
         hash = `yosemite3`,
+        shop = 'pdm'
     },
     youga = {
         name = 'Youga',
@@ -6607,6 +7100,7 @@ return {
         price = 55630,
         category = 'vans',
         hash = `youga`,
+        shop = 'pdm'
     },
     youga2 = {
         name = 'Youga Classic',
@@ -6615,6 +7109,7 @@ return {
         price = 55630,
         category = 'vans',
         hash = `youga2`,
+        shop = 'pdm'
     },
     youga3 = {
         name = 'Youga Classic 4x4',
@@ -6623,6 +7118,7 @@ return {
         price = 63150,
         category = 'vans',
         hash = `youga3`,
+        shop = 'pdm'
     },
     youga4 = {
         name = 'Youga Custom',
@@ -6631,6 +7127,7 @@ return {
         price = 60252,
         category = 'vans',
         hash = `youga4`,
+        shop = 'pdm'
     },
     z190 = {
         name = '190Z',
@@ -6639,6 +7136,7 @@ return {
         price = 73299,
         category = 'sportsclassics',
         hash = `z190`,
+        shop = 'pdm'
     },
     zeno = {
         name = 'Zeno',
@@ -6647,6 +7145,7 @@ return {
         price = 89601,
         category = 'super',
         hash = `zeno`,
+        shop = 'pdm'
     },
     zentorno = {
         name = 'Zentorno',
@@ -6655,6 +7154,7 @@ return {
         price = 82795,
         category = 'super',
         hash = `zentorno`,
+        shop = 'luxury'
     },
     zhaba = {
         name = 'Zhaba',
@@ -6662,7 +7162,7 @@ return {
         model = 'zhaba',
         price = 50950,
         category = 'offroad',
-        hash = `zhaba`,
+        hash = `zhaba`
     },
     zion = {
         name = 'Zion',
@@ -6671,6 +7171,7 @@ return {
         price = 77752,
         category = 'coupes',
         hash = `zion`,
+        shop = 'pdm'
     },
     zion2 = {
         name = 'Zion Cabrio',
@@ -6679,6 +7180,7 @@ return {
         price = 77752,
         category = 'coupes',
         hash = `zion2`,
+        shop = 'pdm'
     },
     zion3 = {
         name = 'Zion Classic',
@@ -6687,6 +7189,7 @@ return {
         price = 74281,
         category = 'sportsclassics',
         hash = `zion3`,
+        shop = 'pdm'
     },
     zombiea = {
         name = 'Zombie Bobber',
@@ -6695,6 +7198,7 @@ return {
         price = 23182,
         category = 'motorcycles',
         hash = `zombiea`,
+        shop = 'pdm'
     },
     zombieb = {
         name = 'Zombie Chopper',
@@ -6703,6 +7207,7 @@ return {
         price = 23182,
         category = 'motorcycles',
         hash = `zombieb`,
+        shop = 'pdm'
     },
     zorrusso = {
         name = 'Pegassi Zorrusso',
@@ -6711,6 +7216,7 @@ return {
         price = 85159,
         category = 'super',
         hash = `zorrusso`,
+        shop = 'luxury'
     },
     zr350 = {
         name = 'ZR350',
@@ -6719,6 +7225,7 @@ return {
         price = 79974,
         category = 'sports',
         hash = `zr350`,
+        shop = 'luxury'
     },
     zr380 = {
         name = 'Apocalypse ZR380',
@@ -6726,7 +7233,7 @@ return {
         model = 'zr380',
         price = 83632,
         category = 'sports',
-        hash = `zr380`,
+        hash = `zr380`
     },
     zr3802 = {
         name = 'Future Shock ZR380',
@@ -6734,7 +7241,7 @@ return {
         model = 'zr3802',
         price = 83632,
         category = 'sports',
-        hash = `zr3802`,
+        hash = `zr3802`
     },
     zr3803 = {
         name = 'Nightmare ZR380',
@@ -6742,7 +7249,7 @@ return {
         model = 'zr3803',
         price = 83632,
         category = 'sports',
-        hash = `zr3803`,
+        hash = `zr3803`
     },
     ztype = {
         name = 'Z-Type',
@@ -6751,5 +7258,6 @@ return {
         price = 84821,
         category = 'sportsclassics',
         hash = `ztype`,
-    }
+        shop = 'pdm'
+    },
 }


### PR DESCRIPTION
## Description

Bring the shop field back, added the shops from the vehicleshop config with a script, that's why for some vehicles the order might be corrected (also the trailing commas are cleaned up)

Some team members might be against this idk where we left this off..
## Checklist

<!-- Put an x inside the [ ] to check an item, like so: [x] -->

- [x] I have personally loaded this code into an updated Qbox project and checked all of its functionality.
- [x] My pull request fits the contribution guidelines & code conventions.
