### PR TITLE
chore(server): deprecate permissions in favor of cfg ACE

### DIFF
--- a/bridge/qb/server/main.lua
+++ b/bridge/qb/server/main.lua
@@ -57,7 +57,7 @@ RegisterNetEvent('QBCore:CallCommand', function(command, args)
     local src = source --[[@as Source]]
     local player = GetPlayer(src)
     if not player then return end
-    if IsPlayerAceAllowed(src, string.format('command.%s', command)) then
+    if IsPlayerAceAllowed(src --[[@as string]], string.format('command.%s', command)) then
         local commandString = command
         for _, value in pairs(args) do
             commandString = string.format('%s %s', commandString, value)

--- a/config/queue.lua
+++ b/config/queue.lua
@@ -26,7 +26,7 @@ return {
     ---If a player doesn't pass any predicate and a sub-queue with no predicate does not exist they will not be let into the server unless a player slot is available.
     ---@type SubQueueConfig[]
     subQueues = {
-        { name = 'Admin Queue', predicate = function(source) return HasPermission(source, 'admin') end, cardOptions = { color = 'good' } },
+        { name = 'Admin Queue', predicate = function(source) return IsPlayerAceAllowed(source --[[@as string]], 'admin') end, cardOptions = { color = 'good' } },
         { name = 'Regular Queue' },
     },
 

--- a/config/server.lua
+++ b/config/server.lua
@@ -84,6 +84,7 @@ return {
         whitelistPermission = 'admin', -- Permission that's able to enter the server when the whitelist is on
         discord = '', -- Discord invite link
         checkDuplicateLicense = true, -- Check for duplicate rockstar license on join
+        ---@deprecated use cfg ACE system instead
         permissions = { 'god', 'admin', 'mod' }, -- Add as many groups as you want here after creating them in your server.cfg
     },
 

--- a/server/commands.lua
+++ b/server/commands.lua
@@ -98,7 +98,7 @@ lib.addCommand('openserver', {
         Notify(source, locale('error.server_already_open'), 'error')
         return
     end
-    if HasPermission(source, 'admin') then
+    if IsPlayerAceAllowed(source, 'admin') then
         config.server.closed = false
         Notify(source, locale('success.server_opened'), 'success')
     else
@@ -117,12 +117,12 @@ lib.addCommand('closeserver', {
         Notify(source, locale('error.server_already_closed'), 'error')
         return
     end
-    if HasPermission(source, 'admin') then
+    if IsPlayerAceAllowed(source, 'admin') then
         local reason = args[locale("command.closeserver.params.reason.name")] or 'No reason specified'
         config.server.closed = true
         config.server.closedReason = reason
         for k in pairs(QBX.Players) do
-            if not HasPermission(k, config.server.whitelistPermission) then
+            if not IsPlayerAceAllowed(k --[[@as string]], config.server.whitelistPermission) then
                 DropPlayer(k, reason)
             end
         end
@@ -305,7 +305,7 @@ lib.addCommand('ooc', {
                 multiline = true,
                 args = {('OOC | %s'):format(GetPlayerName(source)), message}
             })
-        elseif HasPermission(v --[[@as Source]], 'admin') then
+        elseif IsPlayerAceAllowed(v --[[@as string]], 'admin') then
             if IsOptin(v --[[@as Source]]) then
                 TriggerClientEvent('chat:addMessage', v --[[@as Source]], {
                     color = { 0, 0, 255},

--- a/server/events.lua
+++ b/server/events.lua
@@ -163,26 +163,26 @@ end)
 ---@param reason string
 RegisterNetEvent('QBCore:Server:CloseServer', function(reason)
     local src = source --[[@as Source]]
-    if HasPermission(src, 'admin') then
+    if IsPlayerAceAllowed(src --[[@as string]], 'admin') then
         reason = reason or 'No reason specified'
         serverConfig.closed = true
         serverConfig.closedReason = reason
         for k in pairs(QBX.Players) do
-            if not HasPermission(k, serverConfig.whitelistPermission) then
-                DropPlayer(k, reason)
+            if not IsPlayerAceAllowed(k --[[@as string]], serverConfig.whitelistPermission) then
+                DropPlayer(k --[[@as string]], reason)
             end
         end
     else
-        DropPlayer(src, locale("error.no_permission"))
+        DropPlayer(src --[[@as string]], locale("error.no_permission"))
     end
 end)
 
 RegisterNetEvent('QBCore:Server:OpenServer', function()
     local src = source --[[@as Source]]
-    if HasPermission(src, 'admin') then
+    if IsPlayerAceAllowed(src --[[@as string]], 'admin') then
         serverConfig.closed = false
     else
-        DropPlayer(src, locale("error.no_permission"))
+        DropPlayer(src --[[@as string]], locale("error.no_permission"))
     end
 end)
 

--- a/server/functions.lua
+++ b/server/functions.lua
@@ -214,15 +214,15 @@ exports('CanUseItem', CanUseItem)
 ---@return boolean
 function IsWhitelisted(source)
     if not serverConfig.whitelist then return true end
-    if HasPermission(source, serverConfig.whitelistPermission) then return true end
+    if IsPlayerAceAllowed(source --[[@as string]], serverConfig.whitelistPermission) then return true end
     return false
 end
 
 exports('IsWhitelisted', IsWhitelisted)
 
 -- Setting & Removing Permissions
--- TODO: Should these be moved to the utility module?
 
+---@deprecated use cfg ACEs instead
 ---@param source Source
 ---@param permission string
 function AddPermission(source, permission)
@@ -234,8 +234,10 @@ function AddPermission(source, permission)
     end
 end
 
+---@deprecated use cfg ACEs instead
 exports('AddPermission', AddPermission)
 
+---@deprecated use cfg ACEs instead
 ---@param source Source
 ---@param permission string
 function RemovePermission(source, permission)
@@ -262,9 +264,11 @@ function RemovePermission(source, permission)
     end
 end
 
+---@deprecated use cfg ACEs instead
 exports('RemovePermission', RemovePermission)
 
 -- Checking for Permission Level
+---@deprecated use IsPlayerAceAllowed
 ---@param source Source
 ---@param permission string|string[]
 ---@return boolean
@@ -280,8 +284,10 @@ function HasPermission(source, permission)
     return false
 end
 
+---@deprecated use IsPlayerAceAllowed
 exports('HasPermission', HasPermission)
 
+---@deprecated use cfg ACEs instead
 ---@param source Source
 ---@return table<string, boolean>
 function GetPermission(source)
@@ -294,6 +300,7 @@ function GetPermission(source)
     return perms
 end
 
+---@deprecated use cfg ACEs instead
 exports('GetPermission', GetPermission)
 
 -- Opt in or out of admin reports
@@ -301,7 +308,7 @@ exports('GetPermission', GetPermission)
 ---@return boolean
 function IsOptin(source)
     local license = GetPlayerIdentifierByType(source --[[@as string]], 'license2') or GetPlayerIdentifierByType(source --[[@as string]], 'license')
-    if not license or not HasPermission(source, 'admin') then return false end
+    if not license or not IsPlayerAceAllowed(source --[[@as string]], 'admin') then return false end
     local player = GetPlayer(source)
     return player.PlayerData.optin
 end
@@ -312,7 +319,7 @@ exports('IsOptin', IsOptin)
 ---@param source Source
 function ToggleOptin(source)
     local license = GetPlayerIdentifierByType(source --[[@as string]], 'license2') or GetPlayerIdentifierByType(source --[[@as string]], 'license')
-    if not license or not HasPermission(source, 'admin') then return end
+    if not license or not IsPlayerAceAllowed(source --[[@as string]], 'admin') then return end
     local player = GetPlayer(source)
     player.PlayerData.optin = not player.PlayerData.optin
     player.Functions.SetPlayerData('optin', player.PlayerData.optin)


### PR DESCRIPTION
The abstraction built into qb on top of ACE permissions is confusing without adding value. Deprecated with the recommendation that developers use native ACE permissions + ox_lib to manage permissions.