### PR TITLE
refactor: format strings using colon syntax

### DIFF
--- a/bridge/qb/server/functions.lua
+++ b/bridge/qb/server/functions.lua
@@ -68,7 +68,7 @@ end
 local discordLink = GetConvar('qbx:discordlink', 'discord.gg/qbox')
 ---@deprecated use setKickReason or deferrals for connecting players, and the DropPlayer native directly otherwise
 functions.Kick = function(source, reason, setKickReason, deferrals)
-    reason = '\n' .. reason .. '\n🔸 Check our Discord for further information: ' .. discordLink
+    reason = ('\n %s \n 🔸 Check our Discord for further information: %s'):format(reason, discordLink)
     if setKickReason then
         setKickReason(reason)
     end
@@ -135,7 +135,7 @@ functions.GetPlate = qbx.getVehiclePlate
 -- Single add item
 ---@deprecated incompatible with ox_inventory. Update ox_inventory item config instead.
 local function AddItem(itemName, item)
-    lib.print.warn(string.format("%s invoked Deprecated function AddItem. This is incompatible with ox_inventory", GetInvokingResource() or 'unknown resource'))
+    lib.print.warn(('%s invoked deprecated function AddItem. This is incompatible with ox_inventory'):format(GetInvokingResource() or 'unknown resource'))
     if type(itemName) ~= "string" then
         return false, "invalid_item_name"
     end
@@ -157,7 +157,7 @@ createQbExport('AddItem', AddItem)
 -- Single update item
 ---@deprecated incompatible with ox_inventory. Update ox_inventory item config instead.
 local function UpdateItem(itemName, item)
-    lib.print.warn(string.format("%s invoked deprecated function UpdateItem. This is incompatible with ox_inventory", GetInvokingResource() or 'unknown resource'))
+    lib.print.warn(('%s invoked deprecated function UpdateItem. This is incompatible with ox_inventory'):format(GetInvokingResource() or 'unknown resource'))
     if type(itemName) ~= "string" then
         return false, "invalid_item_name"
     end
@@ -176,7 +176,7 @@ createQbExport('UpdateItem', UpdateItem)
 -- Multiple Add Items
 ---@deprecated incompatible with ox_inventory. Update ox_inventory item config instead.
 local function AddItems(items)
-    lib.print.warn(string.format("%s invoked deprecated function AddItems. This is incompatible with ox_inventory", GetInvokingResource() or 'unknown resource'))
+    lib.print.warn(('%s invoked deprecated function AddItems. This is incompatible with ox_inventory'):format(GetInvokingResource() or 'unknown resource'))
     local shouldContinue = true
     local message = "success"
     local errorItem = nil
@@ -211,7 +211,7 @@ createQbExport('AddItems', AddItems)
 -- Single Remove Item
 ---@deprecated incompatible with ox_inventory. Update ox_inventory item config instead.
 local function RemoveItem(itemName)
-    lib.print.warn(string.format("%s invoked deprecated function RemoveItem. This is incompatible with ox_inventory", GetInvokingResource() or 'unknown resource'))
+    lib.print.warn(('%s invoked deprecated function RemoveItem. This is incompatible with ox_inventory'):format(GetInvokingResource() or 'unknown resource'))
     if type(itemName) ~= "string" then
         return false, "invalid_item_name"
     end

--- a/bridge/qb/server/main.lua
+++ b/bridge/qb/server/main.lua
@@ -57,10 +57,10 @@ RegisterNetEvent('QBCore:CallCommand', function(command, args)
     local src = source --[[@as Source]]
     local player = GetPlayer(src)
     if not player then return end
-    if IsPlayerAceAllowed(src --[[@as string]], string.format('command.%s', command)) then
+    if IsPlayerAceAllowed(src --[[@as string]], ('command.%s'):format(command)) then
         local commandString = command
         for _, value in pairs(args) do
-            commandString = string.format('%s %s', commandString, value)
+            commandString = ('%s %s'):format(commandString, value)
         end
         TriggerClientEvent('QBCore:Command:CallCommand', src, commandString)
     end

--- a/bridge/qb/shared/export-function.lua
+++ b/bridge/qb/shared/export-function.lua
@@ -1,5 +1,5 @@
 return function (name, cb)
-    AddEventHandler(string.format('__cfx_export_qb-core_%s', name), function(setCB)
+    AddEventHandler(('__cfx_export_qb-core_%s'):format(name), function(setCB)
         setCB(cb)
     end)
 end

--- a/client/character.lua
+++ b/client/character.lua
@@ -278,9 +278,9 @@ local function chooseCharacter()
     local options = {}
     for i = 1, amount do
         local character = characters[i]
-        local name = character and character.charinfo.firstname .. ' ' .. character.charinfo.lastname
+        local name = character and ('%s %s'):format(character.charinfo.firstname, character.charinfo.lastname)
         options[i] = {
-            title = character and string.format('%s %s - %s', character.charinfo.firstname, character.charinfo.lastname, character.citizenid) or locale('info.multichar_new_character', i),
+            title = character and ('%s %s - %s'):format(character.charinfo.firstname, character.charinfo.lastname, character.citizenid) or locale('info.multichar_new_character', i),
             metadata = character and {
                 Name = name,
                 Gender = character.charinfo.gender == 0 and locale('info.char_male') or locale('info.char_female'),
@@ -312,7 +312,7 @@ local function chooseCharacter()
         if character then
             lib.registerContext({
                 id = 'qbx_core_multichar_character_'..i,
-                title = string.format('%s %s - %s', character.charinfo.firstname, character.charinfo.lastname, character.citizenid),
+                title = ('%s %s - %s'):format(character.charinfo.firstname, character.charinfo.lastname, character.citizenid),
                 canClose = false,
                 menu = 'qbx_core_multichar_characters',
                 options = {

--- a/client/discord.lua
+++ b/client/discord.lua
@@ -5,8 +5,7 @@ if not discord.enabled then return end
 
 AddStateBagChangeHandler('PlayerCount', '', function(bagName, _, value)
     if bagName == 'global' and value then
-        local players = 'Players %s/' .. maxPlayers
-        SetRichPresence((players):format(value))
+        SetRichPresence(('Players %s/%s'):format(value, maxPlayers))
     end
 end)
 

--- a/config/server.lua
+++ b/config/server.lua
@@ -8,7 +8,7 @@ return {
         moneyTypes = { cash = 500, bank = 5000, crypto = 0 }, -- type = startamount - Add or remove money types for your server (for ex. blackmoney = 0), remember once added it will not be removed from the database!
         dontAllowMinus = { 'cash', 'crypto' }, -- Money that is not allowed going in minus
         paycheckTimeout = 10, -- The time in minutes that it will give the paycheck
-        paycheckSociety = false -- If true paycheck will come from the society account that the player is employed at
+        paycheckSociety = false -- If true paycheck will come from the society account that the player is employed at, requires qb-management
     },
 
     player = {
@@ -45,7 +45,7 @@ return {
             },
             WalletId = {
                 valueFunction = function()
-                    return 'QBX-' .. math.random(1111111, 9999999)
+                    return 'QB-' .. math.random(11111111, 99999999)
                 end,
             },
             SerialNumber = {

--- a/config/server.lua
+++ b/config/server.lua
@@ -8,7 +8,7 @@ return {
         moneyTypes = { cash = 500, bank = 5000, crypto = 0 }, -- type = startamount - Add or remove money types for your server (for ex. blackmoney = 0), remember once added it will not be removed from the database!
         dontAllowMinus = { 'cash', 'crypto' }, -- Money that is not allowed going in minus
         paycheckTimeout = 10, -- The time in minutes that it will give the paycheck
-        paycheckSociety = false -- If true paycheck will come from the society account that the player is employed at, requires qb-management
+        paycheckSociety = false -- If true paycheck will come from the society account that the player is employed at
     },
 
     player = {
@@ -45,7 +45,7 @@ return {
             },
             WalletId = {
                 valueFunction = function()
-                    return 'QB-' .. math.random(11111111, 99999999)
+                    return 'QBX-' .. math.random(1111111, 9999999)
                 end,
             },
             SerialNumber = {

--- a/modules/utils.lua
+++ b/modules/utils.lua
@@ -164,7 +164,7 @@ if isServer then
     ---@param setKickReason? fun(reason: string)
     ---@param deferrals? Deferrals
     function KickWithReason(source, reason, setKickReason, deferrals) -- luacheck: ignore
-        reason = '\n' .. reason .. '\n🔸 Check our Discord for further information: ' .. discordLink
+        reason = ('\n %s \n 🔸 Check our Discord for further information: %s'):format(reason, discordLink)
         if setKickReason then
             setKickReason(reason)
         end

--- a/server/character.lua
+++ b/server/character.lua
@@ -53,9 +53,9 @@ lib.callback.register('qbx_core:server:loadCharacter', function(source, citizenI
         webhook = config.logging.webhook['joinleave'],
         event = 'Loaded',
         color = 'green',
-        message = '**' .. GetPlayerName(source) .. '** (' .. (GetPlayerIdentifierByType(source, 'discord') or 'undefined') .. ' |  ||' .. (GetPlayerIdentifierByType(source, 'ip') or 'undefined') .. '|| | ' ..(GetPlayerIdentifierByType(source, 'license2') or GetPlayerIdentifierByType(source, 'license') or 'undefined') .. ' | ' .. citizenId .. ' | ' .. source .. ') loaded'
+        message = ('**%s** (%s |  ||%s|| | %s | %s | %s) loaded'):format(GetPlayerName(source), GetPlayerIdentifierByType(source, 'discord') or 'undefined', GetPlayerIdentifierByType(source, 'ip') or 'undefined', GetPlayerIdentifierByType(source, 'license2') or GetPlayerIdentifierByType(source, 'license') or 'undefined', citizenId, source)
     })
-    lib.print.info(GetPlayerName(source) .. ' (Citizen ID: ' .. citizenId .. ') has succesfully loaded!')
+    lib.print.info(('%s (Citizen ID: %s) has successfully loaded!'):format(GetPlayerName(source), citizenId))
 end)
 
 ---@param data unknown
@@ -72,7 +72,7 @@ lib.callback.register('qbx_core:server:createCharacter', function(source, data)
         SetPlayerRoutingBucket(source, 0)
     end
 
-    lib.print.info(GetPlayerName(source) .. ' has created a character')
+    lib.print.info(('%s has created a character'):format(GetPlayerName(source)))
     return newData
 end)
 

--- a/server/commands.lua
+++ b/server/commands.lua
@@ -318,7 +318,7 @@ lib.addCommand('ooc', {
                     event = 'OOC',
                     color = 'white',
                     tags = config.logging.role,
-                    message = '**' .. GetPlayerName(source) .. '** (CitizenID: ' .. player.PlayerData.citizenid .. ' | ID: ' .. source .. ') **Message:** ' .. message
+                    message = ('**%s** (CitizenID: %s | ID: %s) **Message:** %s'):format(GetPlayerName(source), player.PlayerData.citizenid, source, message)
                 })
             end
         end

--- a/server/events.lua
+++ b/server/events.lua
@@ -46,7 +46,7 @@ AddEventHandler('playerDropped', function(reason)
         webhook = loggingConfig.webhook['joinleave'],
         event = 'Dropped',
         color = 'red',
-        message = '**' .. GetPlayerName(src) .. '** (' .. player.PlayerData.license .. ') left..' ..'\n **Reason:** ' .. reason,
+        message = ('**%s** (%s) left...\n **Reason:** %s'):format(GetPlayerName(src), player.PlayerData.license, reason),
     })
     player.Functions.Save()
     QBX.Player_Buckets[player.PlayerData.license] = nil

--- a/server/functions.lua
+++ b/server/functions.lua
@@ -339,7 +339,7 @@ function IsPlayerBanned(source)
     if not result then return false end
     if os.time() < result.expire then
         local timeTable = os.date('*t', tonumber(result.expire))
-        return true, 'You have been banned from the server:\n' .. result.reason .. '\nYour ban expires ' .. timeTable.day .. '/' .. timeTable.month .. '/' .. timeTable.year .. ' ' .. timeTable.hour .. ':' .. timeTable.min .. '\n'
+        return true, ('You have been banned from the server:\n%s\nYour ban expires in %s/%s/%s %s:%s\n'):format(result.reason, timeTable.day, timeTable.month, timeTable.year, timeTable.hour, timeTable.min)
     else
         CreateThread(function()
             storage.deleteBan({
@@ -416,7 +416,7 @@ local function ExploitBan(playerId, origin)
         event = 'Anti-Cheat',
         color = 'red',
         tags = loggingConfig.role,
-        message = name .. " has been banned for exploiting " .. origin
+        message = ('%s has been banned for exploiting %s'):format(name, origin)
     })
 end
 

--- a/server/player.lua
+++ b/server/player.lua
@@ -847,7 +847,7 @@ function DeleteCharacter(source, citizenid)
             event = 'Anti-Cheat',
             color = 'white',
             tags = config.logging.role,
-            message('%s has been dropped for character deleting exploit'):format(GetPlayerName(source)),
+            message = ('%s has been dropped for character deleting exploit'):format(GetPlayerName(source)),
         })
     end
 end

--- a/server/player.lua
+++ b/server/player.lua
@@ -589,7 +589,7 @@ function CreatePlayer(playerData, Offline)
                 event = 'AddMoney',
                 color = 'lightgreen',
                 tags = tags,
-                message = '**' .. GetPlayerName(self.PlayerData.source) .. ' (citizenid: ' .. self.PlayerData.citizenid .. ' | id: ' .. self.PlayerData.source .. ')** $' .. amount .. ' (' .. moneytype .. ') added, new ' .. moneytype .. ' balance: ' .. self.PlayerData.money[moneytype] .. ' reason: ' .. reason,
+                message = ('**%s (citizenid: %s | id: %s)** $%s (%s) added, new %s balance: $%s reason: %s'):format(GetPlayerName(self.PlayerData.source), self.PlayerData.citizenid, self.PlayerData.source, amount, moneytype, moneytype, self.PlayerData.money[moneytype], reason),
             })
             TriggerClientEvent('hud:client:OnMoneyChange', self.PlayerData.source, moneytype, amount, false)
             TriggerClientEvent('QBCore:Client:OnMoneyChange', self.PlayerData.source, moneytype, amount, "add", reason)
@@ -626,7 +626,7 @@ function CreatePlayer(playerData, Offline)
                 event = 'RemoveMoney',
                 color = 'red',
                 tags = tags,
-                message = '**' .. GetPlayerName(self.PlayerData.source) .. ' (citizenid: ' .. self.PlayerData.citizenid .. ' | id: ' .. self.PlayerData.source .. ')** $' .. amount .. ' (' .. moneytype .. ') removed, new ' .. moneytype .. ' balance: ' .. self.PlayerData.money[moneytype] .. ' reason: ' .. reason,
+                message = ('** %s (citizenid: %s | id: %s)** $%s (%s) removed, new %s balance: $%s reason: %s'):format(GetPlayerName(self.PlayerData.source), self.PlayerData.citizenid, self.PlayerData.source, amount, moneytype, moneytype, self.PlayerData.money[moneytype], reason),
             })
             TriggerClientEvent('hud:client:OnMoneyChange', self.PlayerData.source, moneytype, amount, true)
             if moneytype == 'bank' then
@@ -658,7 +658,7 @@ function CreatePlayer(playerData, Offline)
                 webhook = config.logging.webhook['playermoney'],
                 event = 'SetMoney',
                 color = 'green',
-                message = '**' .. GetPlayerName(self.PlayerData.source) .. ' (citizenid: ' .. self.PlayerData.citizenid .. ' | id: ' .. self.PlayerData.source .. ')** $' .. amount .. ' (' .. moneytype .. ') set, new ' .. moneytype .. ' balance: ' .. self.PlayerData.money[moneytype] .. ' reason: ' .. reason,
+                message = ('**%s (citizenid: %s | id: %s)** $%s (%s) set, new %s balance: $%s reason: %s'):format(GetPlayerName(self.PlayerData.source), self.PlayerData.citizenid, self.PlayerData.source, amount, moneytype, moneytype, self.PlayerData.money[moneytype], reason),
             })
             TriggerClientEvent('hud:client:OnMoneyChange', self.PlayerData.source, moneytype, math.abs(difference), difference < 0)
             TriggerClientEvent('QBCore:Client:OnMoneyChange', self.PlayerData.source, moneytype, amount, "set", reason)
@@ -835,7 +835,7 @@ function DeleteCharacter(source, citizenid)
                     webhook = config.logging.webhook['joinleave'],
                     event = 'Character Deleted',
                     color = 'red',
-                    message = '**' .. GetPlayerName(source) .. '** ' .. license2 .. ' deleted **' .. citizenid .. '**..'
+                    message = ('**%s** deleted **%s**...'):format(GetPlayerName(source), citizenid, source),
                 })
             end
         end)
@@ -847,7 +847,7 @@ function DeleteCharacter(source, citizenid)
             event = 'Anti-Cheat',
             color = 'white',
             tags = config.logging.role,
-            message = GetPlayerName(source) .. ' Has Been Dropped For Character Deletion Exploit',
+            message('%s has been dropped for character deleting exploit'):format(GetPlayerName(source)),
         })
     end
 end
@@ -869,7 +869,7 @@ function ForceDeleteCharacter(citizenid)
                     webhook = config.logging.webhook['joinleave'],
                     event = 'Character Force Deleted',
                     color = 'red',
-                    message = 'Character **' .. citizenid .. '** got deleted'
+                    message = ('Character **%s** got deleted'):format(citizenid),
                 })
             end
         end)


### PR DESCRIPTION
## Description

We currently have a mix of string.format, colon syntax formatting, and just normal concatenation. This just standardizes the colon syntax over the other usages. 

## Checklist

- [x] I have personally loaded this code into an updated Qbox project and checked all of its functionality.
- [x] My pull request fits the contribution guidelines & code conventions.
