### PR TITLE
feat: setjob replace convar

### DIFF
--- a/server/player.lua
+++ b/server/player.lua
@@ -495,7 +495,7 @@ function CreatePlayer(playerData, Offline)
             return false
         end
         if setJobReplaces then
-            TemovePlayerFromJob(self.PlayerData.citizenid, self.PlayerData.job.name)
+            RemovePlayerFromJob(self.PlayerData.citizenid, self.PlayerData.job.name)
         end
         AddPlayerToJob(self.PlayerData.citizenid, jobName, grade)
         SetPlayerPrimaryJob(self.PlayerData.citizenid, jobName)

--- a/server/player.lua
+++ b/server/player.lua
@@ -4,6 +4,8 @@ local logger = require 'modules.logger'
 local storage = require 'server.storage.main'
 local maxJobsPerPlayer = GetConvarInt('qbx:max_jobs_per_player', 1)
 local maxGangsPerPlayer = GetConvarInt('qbx:max_gangs_per_player', 1)
+local setJobReplaces = GetConvar('qbx:setjob_replaces', 'true') == 'true'
+local setGangReplaces = GetConvar('qbx:setgang_replaces', 'true') == 'true'
 
 ---@class PlayerData : PlayerEntity
 ---@field jobs table<string, integer>
@@ -492,7 +494,9 @@ function CreatePlayer(playerData, Offline)
             lib.print.error(("cannot set job. Job %s does not have grade %s"):format(jobName, grade))
             return false
         end
-        removePlayerFromJob(self.PlayerData.citizenid, self.PlayerData.job.name)
+        if setJobReplaces then
+            removePlayerFromJob(self.PlayerData.citizenid, self.PlayerData.job.name)
+        end
         AddPlayerToJob(self.PlayerData.citizenid, jobName, grade)
         setPlayerPrimaryJob(self.PlayerData.citizenid, jobName)
         return true
@@ -514,7 +518,9 @@ function CreatePlayer(playerData, Offline)
             lib.print.error(("cannot set gang. Gang %s does not have grade %s"):format(gangName, grade))
             return false
         end
-        removePlayerFromGang(self.PlayerData.citizenid, self.PlayerData.gang.name)
+        if setGangReplaces then
+            removePlayerFromGang(self.PlayerData.citizenid, self.PlayerData.gang.name)
+        end
         AddPlayerToGang(self.PlayerData.citizenid, gangName, grade)
         setPlayerPrimaryGang(self.PlayerData.citizenid, gangName)
         return true


### PR DESCRIPTION
- Adds two new convars qbx:setjob_replace and qbx:setgang_replace
- These determine whether the player function SetJob & SetGang should replace your existing primary job/gang or not. They default to true, but some users may want to turn the replacement off.