### PR TITLE
refactor: vehicle props as statebag

### DIFF
--- a/client/events.lua
+++ b/client/events.lua
@@ -196,17 +196,23 @@ RegisterNetEvent('QBCore:Client:OnSharedUpdateMultiple', function(tableName, val
 end)
 
 -- Set vehicle props
----@param entity number
+---@param vehicle number
 ---@param props table<any, any>
-qbx.entityStateHandler('setVehicleProperties', function(entity, _, props)
+qbx.entityStateHandler('setVehicleProperties', function(vehicle, _, props)
     if not props then return end
 
     SetTimeout(0, function()
-        local state = Entity(entity).state
+        local state = Entity(vehicle).state
 
         while state.setVehicleProperties do
-            if NetworkGetEntityOwner(entity) == cache.playerId then
-                if lib.setVehicleProperties(entity, props) then
+            if NetworkGetEntityOwner(vehicle) == cache.playerId then
+                for i = -1, 0 do
+                    local ped = GetPedInVehicleSeat(vehicle, i)
+                    if ped ~= cache.ped and ped > 0 then
+                        DeleteEntity(ped)
+                    end
+                end
+                if lib.setVehicleProperties(vehicle, props) then
                     state:set('setVehicleProperties', nil, true)
                 end
             end

--- a/modules/lib.lua
+++ b/modules/lib.lua
@@ -265,8 +265,9 @@ if isServer then
             if owner ~= -1 then return owner end
         end, 5000)
 
+        Entity(veh).state:set('setVehicleProperties', props, true)
         local netId = NetworkGetNetworkIdFromEntity(veh)
-        lib.callback.await('qbx_core:client:vehicleSpawned', owner, netId, props)
+
         return netId
     end
 else

--- a/modules/lib.lua
+++ b/modules/lib.lua
@@ -227,6 +227,7 @@ if isServer then
     ]]
     ---@param params LibSpawnVehicleParams
     ---@return integer netId
+    ---@return number veh
     function qbx.spawnVehicle(params)
         local model = params.model
         local source = params.spawnSource
@@ -260,16 +261,11 @@ if isServer then
             SetPedIntoVehicle(ped, veh, -1)
         end
 
-        ---@diagnostic disable-next-line: unused-local
-        local owner = lib.waitFor(function()
-            local owner = NetworkGetEntityOwner(veh)
-            if owner ~= -1 then return owner end
-        end, 5000)
-
         Entity(veh).state:set('setVehicleProperties', props, true)
+        Entity(veh).state:set('initVehicle', true, true)
         local netId = NetworkGetNetworkIdFromEntity(veh)
 
-        return netId
+        return netId, veh
     end
 else
     ---@class LibDrawTextParams

--- a/modules/lib.lua
+++ b/modules/lib.lua
@@ -261,8 +261,8 @@ if isServer then
             SetPedIntoVehicle(ped, veh, -1)
         end
 
-        Entity(veh).state:set('setVehicleProperties', props, true)
         Entity(veh).state:set('initVehicle', true, true)
+        Entity(veh).state:set('setVehicleProperties', props, true)
         local netId = NetworkGetNetworkIdFromEntity(veh)
 
         return netId, veh

--- a/modules/lib.lua
+++ b/modules/lib.lua
@@ -260,6 +260,7 @@ if isServer then
             SetPedIntoVehicle(ped, veh, -1)
         end
 
+        ---@diagnostic disable-next-line: unused-local
         local owner = lib.waitFor(function()
             local owner = NetworkGetEntityOwner(veh)
             if owner ~= -1 then return owner end


### PR DESCRIPTION
## Description

<!-- What does your pull request change? Why should it be merged? Does it fix an issue? -->
Vehicle props are sadly a client side thing. This change moves the logic from a callback to a statebag which runs a loop on any client within scope to set the props on a vehicle. Extensive testing has shown this is the best method of ensuring that if you ask for a blue car with a wing that you get a blue car with a wing no matter who is zipping by at 400mph or if your client/server is a potato.

Fixes #316

Credit @FjamZoo for the ox_core version of this

## Checklist

<!-- Put an x inside the [ ] to check an item, like so: [x] -->

- [x] I have personally loaded this code into an updated Qbox project and checked all of its functionality.
- [x] My pull request fits the contribution guidelines & code conventions.
