### PR TITLE
feat: event on group updates

### DIFF
--- a/server/player.lua
+++ b/server/player.lua
@@ -256,8 +256,8 @@ function AddPlayerToGang(citizenid, gangName, grade)
     if not player.Offline then
         player.PlayerData.gangs[gangName] = grade
         player.Functions.SetPlayerData('gangs', player.PlayerData.gangs)
-        TriggerEvent('QBCore:Server:OnGangsUpdate', player.PlayerData.source, gangName, grade)
-        TriggerClientEvent('QBCore:Client:OnGangsUpdate', player.PlayerData.source, gangName, grade)
+        TriggerEvent('QBCore:Server:OnGroupUpdate', player.PlayerData.source, gangName, grade)
+        TriggerClientEvent('QBCore:Client:OnGroupUpdate', player.PlayerData.source, gangName, grade)
     end
     if player.PlayerData.gang.name == gangName then
         setPlayerPrimaryGang(citizenid, gangName)

--- a/server/player.lua
+++ b/server/player.lua
@@ -175,8 +175,8 @@ function RemovePlayerFromJob(citizenid, jobName)
 
     if not player.Offline then
         player.Functions.SetPlayerData('jobs', player.PlayerData.jobs)
-        TriggerEvent('QBCore:Server:OnJobsUpdate', player.PlayerData.source, jobName, nil)
-        TriggerClientEvent('QBCore:Client:OnJobsUpdate', player.PlayerData.source, jobName, nil)
+        TriggerEvent('QBCore:Server:OnGroupUpdate', player.PlayerData.source, jobName)
+        TriggerClientEvent('QBCore:Client:OnGroupUpdate', player.PlayerData.source, jobName)
     end
 end
 

--- a/server/player.lua
+++ b/server/player.lua
@@ -139,8 +139,8 @@ function AddPlayerToJob(citizenid, jobName, grade)
     if not player.Offline then
         player.PlayerData.jobs[jobName] = grade
         player.Functions.SetPlayerData('jobs', player.PlayerData.jobs)
-        TriggerEvent('QBCore:Server:OnJobsUpdate', player.PlayerData.source, player.PlayerData.jobs)
-        TriggerClientEvent('QBCore:Client:OnJobsUpdate', player.PlayerData.source, player.PlayerData.jobs)
+        TriggerEvent('QBCore:Server:OnJobsUpdate', player.PlayerData.source, jobName, grade)
+        TriggerClientEvent('QBCore:Client:OnJobsUpdate', player.PlayerData.source, jobName, grade)
     end
     if player.PlayerData.job.name == jobName then
         SetPlayerPrimaryJob(citizenid, jobName)
@@ -175,8 +175,8 @@ function RemovePlayerFromJob(citizenid, jobName)
 
     if not player.Offline then
         player.Functions.SetPlayerData('jobs', player.PlayerData.jobs)
-        TriggerEvent('QBCore:Server:OnJobsUpdate', player.PlayerData.source, player.PlayerData.jobs)
-        TriggerClientEvent('QBCore:Client:OnJobsUpdate', player.PlayerData.source, player.PlayerData.jobs)
+        TriggerEvent('QBCore:Server:OnJobsUpdate', player.PlayerData.source, jobName, nil)
+        TriggerClientEvent('QBCore:Client:OnJobsUpdate', player.PlayerData.source, jobName, nil)
     end
 end
 
@@ -256,8 +256,8 @@ function AddPlayerToGang(citizenid, gangName, grade)
     if not player.Offline then
         player.PlayerData.gangs[gangName] = grade
         player.Functions.SetPlayerData('gangs', player.PlayerData.gangs)
-        TriggerEvent('QBCore:Server:OnGangsUpdate', player.PlayerData.source, player.PlayerData.gangs)
-        TriggerClientEvent('QBCore:Client:OnGangsUpdate', player.PlayerData.source, player.PlayerData.gangs)
+        TriggerEvent('QBCore:Server:OnGangsUpdate', player.PlayerData.source, gangName, grade)
+        TriggerClientEvent('QBCore:Client:OnGangsUpdate', player.PlayerData.source, gangName, grade)
     end
     if player.PlayerData.gang.name == gangName then
         setPlayerPrimaryGang(citizenid, gangName)
@@ -300,8 +300,8 @@ local function removePlayerFromGang(citizenid, gangName)
 
     if not player.Offline then
         player.Functions.SetPlayerData('gangs', player.PlayerData.gangs)
-        TriggerEvent('QBCore:Server:OnGangsUpdate', player.PlayerData.source, player.PlayerData.gangs)
-        TriggerClientEvent('QBCore:Client:OnGangsUpdate', player.PlayerData.source, player.PlayerData.gangs)
+        TriggerEvent('QBCore:Server:OnGangsUpdate', player.PlayerData.source, gangName, nil)
+        TriggerClientEvent('QBCore:Client:OnGangsUpdate', player.PlayerData.source, gangName, nil)
     end
 end
 

--- a/server/player.lua
+++ b/server/player.lua
@@ -139,8 +139,8 @@ function AddPlayerToJob(citizenid, jobName, grade)
     if not player.Offline then
         player.PlayerData.jobs[jobName] = grade
         player.Functions.SetPlayerData('jobs', player.PlayerData.jobs)
-        TriggerEvent('QBCore:Server:OnGroupUpdate', player.PlayerData.source, jobName, grade)
-        TriggerClientEvent('QBCore:Client:OnGroupUpdate', player.PlayerData.source, jobName, grade)
+        TriggerEvent('qbx_core:server:onGroupUpdate', player.PlayerData.source, jobName, grade)
+        TriggerClientEvent('qbx_core:client:onGroupUpdate', player.PlayerData.source, jobName, grade)
     end
     if player.PlayerData.job.name == jobName then
         SetPlayerPrimaryJob(citizenid, jobName)
@@ -175,8 +175,8 @@ function RemovePlayerFromJob(citizenid, jobName)
 
     if not player.Offline then
         player.Functions.SetPlayerData('jobs', player.PlayerData.jobs)
-        TriggerEvent('QBCore:Server:OnGroupUpdate', player.PlayerData.source, jobName)
-        TriggerClientEvent('QBCore:Client:OnGroupUpdate', player.PlayerData.source, jobName)
+        TriggerEvent('qbx_core:server:onGroupUpdate', player.PlayerData.source, jobName)
+        TriggerClientEvent('qbx_core:client:onGroupUpdate', player.PlayerData.source, jobName)
     end
 end
 
@@ -256,8 +256,8 @@ function AddPlayerToGang(citizenid, gangName, grade)
     if not player.Offline then
         player.PlayerData.gangs[gangName] = grade
         player.Functions.SetPlayerData('gangs', player.PlayerData.gangs)
-        TriggerEvent('QBCore:Server:OnGroupUpdate', player.PlayerData.source, gangName, grade)
-        TriggerClientEvent('QBCore:Client:OnGroupUpdate', player.PlayerData.source, gangName, grade)
+        TriggerEvent('qbx_core:server:onGroupUpdate', player.PlayerData.source, gangName, grade)
+        TriggerClientEvent('qbx_core:client:onGroupUpdate', player.PlayerData.source, gangName, grade)
     end
     if player.PlayerData.gang.name == gangName then
         setPlayerPrimaryGang(citizenid, gangName)
@@ -300,8 +300,8 @@ local function removePlayerFromGang(citizenid, gangName)
 
     if not player.Offline then
         player.Functions.SetPlayerData('gangs', player.PlayerData.gangs)
-        TriggerEvent('QBCore:Server:OnGroupUpdate', player.PlayerData.source, gangName)
-        TriggerClientEvent('QBCore:Client:OnGroupUpdate', player.PlayerData.source, gangName)
+        TriggerEvent('qbx_core:server:onGroupUpdate', player.PlayerData.source, gangName)
+        TriggerClientEvent('qbx_core:client:onGroupUpdate', player.PlayerData.source, gangName)
     end
 end
 

--- a/server/player.lua
+++ b/server/player.lua
@@ -139,8 +139,8 @@ function AddPlayerToJob(citizenid, jobName, grade)
     if not player.Offline then
         player.PlayerData.jobs[jobName] = grade
         player.Functions.SetPlayerData('jobs', player.PlayerData.jobs)
-        TriggerEvent('QBCore:Server:OnJobsUpdate', player.PlayerData.source, jobName, grade)
-        TriggerClientEvent('QBCore:Client:OnJobsUpdate', player.PlayerData.source, jobName, grade)
+        TriggerEvent('QBCore:Server:OnGroupUpdate', player.PlayerData.source, jobName, grade)
+        TriggerClientEvent('QBCore:Client:OnGroupUpdate', player.PlayerData.source, jobName, grade)
     end
     if player.PlayerData.job.name == jobName then
         SetPlayerPrimaryJob(citizenid, jobName)

--- a/server/player.lua
+++ b/server/player.lua
@@ -300,8 +300,8 @@ local function removePlayerFromGang(citizenid, gangName)
 
     if not player.Offline then
         player.Functions.SetPlayerData('gangs', player.PlayerData.gangs)
-        TriggerEvent('QBCore:Server:OnGangsUpdate', player.PlayerData.source, gangName, nil)
-        TriggerClientEvent('QBCore:Client:OnGangsUpdate', player.PlayerData.source, gangName, nil)
+        TriggerEvent('QBCore:Server:OnGroupUpdate', player.PlayerData.source, gangName)
+        TriggerClientEvent('QBCore:Client:OnGroupUpdate', player.PlayerData.source, gangName)
     end
 end
 

--- a/server/player.lua
+++ b/server/player.lua
@@ -139,6 +139,8 @@ function AddPlayerToJob(citizenid, jobName, grade)
     if not player.Offline then
         player.PlayerData.jobs[jobName] = grade
         player.Functions.SetPlayerData('jobs', player.PlayerData.jobs)
+        TriggerEvent('QBCore:Server:OnJobsUpdate', player.PlayerData.source, player.PlayerData.jobs)
+        TriggerClientEvent('QBCore:Client:OnJobsUpdate', player.PlayerData.source, player.PlayerData.jobs)
     end
     if player.PlayerData.job.name == jobName then
         SetPlayerPrimaryJob(citizenid, jobName)
@@ -173,6 +175,8 @@ function RemovePlayerFromJob(citizenid, jobName)
 
     if not player.Offline then
         player.Functions.SetPlayerData('jobs', player.PlayerData.jobs)
+        TriggerEvent('QBCore:Server:OnJobsUpdate', player.PlayerData.source, player.PlayerData.jobs)
+        TriggerClientEvent('QBCore:Client:OnJobsUpdate', player.PlayerData.source, player.PlayerData.jobs)
     end
 end
 
@@ -252,6 +256,8 @@ function AddPlayerToGang(citizenid, gangName, grade)
     if not player.Offline then
         player.PlayerData.gangs[gangName] = grade
         player.Functions.SetPlayerData('gangs', player.PlayerData.gangs)
+        TriggerEvent('QBCore:Server:OnGangsUpdate', player.PlayerData.source, player.PlayerData.gangs)
+        TriggerClientEvent('QBCore:Client:OnGangsUpdate', player.PlayerData.source, player.PlayerData.gangs)
     end
     if player.PlayerData.gang.name == gangName then
         setPlayerPrimaryGang(citizenid, gangName)
@@ -294,6 +300,8 @@ local function removePlayerFromGang(citizenid, gangName)
 
     if not player.Offline then
         player.Functions.SetPlayerData('gangs', player.PlayerData.gangs)
+        TriggerEvent('QBCore:Server:OnGangsUpdate', player.PlayerData.source, player.PlayerData.gangs)
+        TriggerClientEvent('QBCore:Client:OnGangsUpdate', player.PlayerData.source, player.PlayerData.gangs)
     end
 end
 


### PR DESCRIPTION
## Description

<!-- What does your pull request change? Why should it be merged? Does it fix an issue? -->
When updating groups for a player we don't trigger any event that can be consumed to update other resources. This adds a new event for resources to listen to and perform various functions such as updating UIs etc.

## Checklist

<!-- Put an x inside the [ ] to check an item, like so: [x] -->

- [x] I have personally loaded this code into an updated Qbox project and checked all of its functionality.
- [x] My pull request fits the contribution guidelines & code conventions.
