### PR TITLE
refactor: set props before ped warp

### DIFF
--- a/modules/lib.lua
+++ b/modules/lib.lua
@@ -257,11 +257,11 @@ if isServer then
         while not DoesEntityExist(veh) do Wait(0) end
         while GetVehicleNumberPlateText(veh) == '' do Wait(0) end
 
-        Entity(veh).state:set('initVehicle', true, true)
-        Entity(veh).state:set('setVehicleProperties', props, true)
+        local state = Entity(veh).state
+        state:set('initVehicle', true, true)
+        state:set('setVehicleProperties', props, true)
 
         lib.waitFor(function()
-            local state = Entity(veh).state
             if state.setVehicleProperties then return false end
             return true
         end, 'Failed to set vehicle properties', 5000)

--- a/modules/lib.lua
+++ b/modules/lib.lua
@@ -257,12 +257,18 @@ if isServer then
         while not DoesEntityExist(veh) do Wait(0) end
         while GetVehicleNumberPlateText(veh) == '' do Wait(0) end
 
+        Entity(veh).state:set('initVehicle', true, true)
+        Entity(veh).state:set('setVehicleProperties', props, true)
+
+        lib.waitFor(function()
+            local state = Entity(veh).state
+            if state.setVehicleProperties then return false end
+            return true
+        end, 'Failed to set vehicle properties', 5000)
+
         if ped then
             SetPedIntoVehicle(ped, veh, -1)
         end
-
-        Entity(veh).state:set('initVehicle', true, true)
-        Entity(veh).state:set('setVehicleProperties', props, true)
         local netId = NetworkGetNetworkIdFromEntity(veh)
 
         return netId, veh


### PR DESCRIPTION
## Description

<!-- What does your pull request change? Why should it be merged? Does it fix an issue? -->
When warping a ped into a vehicle the vehicle props should already be set otherwise they may fail to set because of entity ownership changes. This moves the prop setting above warping the ped and yields until props are set.

Tested this with two folks with over 100ms latency to the server standing next to each other and props didn't fail to set at all. The wait is for up to 5000ms due to possible issues with streamed vehicles not loading for clients on slow links.

## Checklist

<!-- Put an x inside the [ ] to check an item, like so: [x] -->

- [x] I have personally loaded this code into an updated Qbox project and checked all of its functionality.
- [x] My pull request fits the contribution guidelines & code conventions.
