### PR TITLE
Add support for ox_lib Datadog and Grafana Loki logging

### DIFF
--- a/modules/logger.lua
+++ b/modules/logger.lua
@@ -137,7 +137,7 @@ end
 ---@field message string the message attached to the log
 ---@field webhook? string Discord logs only. url of the webhook this log should send to
 ---@field color? string Discord logs only. what color the message should be
----@field tags? string[] Discord logs only. tags in discord. Example: {'<@%roleid>', '@everyone'}
+---@field tags? string[] Discord logs or ox_lib logs. tags in discord. Example: {'<@%roleid>', '@everyone'}. ox_lib logs: tags for datadog and grafana loki
 
 ---Logs using ox_lib if ox_lib logging is configured. Additionally logs to discord if a web hook is passed.
 ---@param log Log
@@ -146,7 +146,7 @@ local function createLog(log)
         ---@diagnostic disable-next-line: param-type-mismatch
         discordLog(log)
     end
-    lib.logger(log.source, log.event, log.message) -- oxlib fails silently if logging isn't setup correctly.
+    lib.logger(log.source, log.event, log.message, log.tags) -- support for ox_lib datadog and grafana loki logging
 end
 
 return {

--- a/modules/logger.lua
+++ b/modules/logger.lua
@@ -137,7 +137,8 @@ end
 ---@field message string the message attached to the log
 ---@field webhook? string Discord logs only. url of the webhook this log should send to
 ---@field color? string Discord logs only. what color the message should be
----@field tags? string[] Discord logs or ox_lib logs. tags in discord. Example: {'<@%roleid>', '@everyone'}. ox_lib logs: tags for datadog and grafana loki
+---@field tags? string[] Discord logs only. tags in discord. Example: {'<@%roleid>', '@everyone'}
+---@field oxLibTags? string[] -- Tags for ox_lib logger
 
 ---Logs using ox_lib if ox_lib logging is configured. Additionally logs to discord if a web hook is passed.
 ---@param log Log
@@ -146,7 +147,7 @@ local function createLog(log)
         ---@diagnostic disable-next-line: param-type-mismatch
         discordLog(log)
     end
-    lib.logger(log.source, log.event, log.message, log.tags) -- support for ox_lib datadog and grafana loki logging
+    lib.logger(log.source, log.event, log.message, log.oxLibTags) -- support for ox_lib datadog and grafana loki logging
 end
 
 return {


### PR DESCRIPTION
## Description

This pull request adds an additional field to the logger function for tagging logs to be sent to ox_lib for API POST requests.  This allows people to have finer log control by being able to assign their own KV pairs to their logs, further enabling searching and querying.  See [lib.logger](https://overextended.dev/ox_lib/Modules/Logger/Server#liblogger) documentation in regards to the `vararg`.

## Checklist

- [x] I have personally loaded this code into an updated Qbox project and checked all of its functionality.
- [x] My pull request fits the contribution guidelines & code conventions.
