### PR TITLE
Fix drawText2d/drawText3d not working without color attribute.

### DIFF
--- a/modules/lib.lua
+++ b/modules/lib.lua
@@ -292,7 +292,7 @@ else
 
         SetTextScale(scale, scale)
         SetTextFont(font)
-        SetTextColour(color.r, color.g, color.b, color.a)
+        SetTextColour(color.x, color.y, color.z, color.w)
         SetTextDropShadow()
         SetTextOutline()
         SetTextCentre(true)
@@ -316,7 +316,7 @@ else
 
         SetTextScale(scale, scale)
         SetTextFont(font)
-        SetTextColour(color.r, color.g, color.b, color.a)
+        SetTextColour(color.x, color.y, color.z, color.w)
         SetTextCentre(true)
         BeginTextCommandDisplayText('STRING')
         AddTextComponentSubstringPlayerName(text)


### PR DESCRIPTION
## Description

Game-breaking issue breaking the lib.drawText2d and lib.drawText3d functionality. Prevents the use of evidence lockers, prisonbreak, teleports, vehiclepush and hotwiring.

This issue originated as you attempted to access r, g, b, a on a vector4 which only has x, y, z, w attributes.

## Checklist

<!-- Put an x inside the [ ] to check an item, like so: [x] -->

- [X] I have personally loaded this code into an updated Qbox project and checked all of its functionality.
- [X] My pull request fits the contribution guidelines & code conventions.
