### PR TITLE
fix(modules/lib): convert vector rgba values to integers in drawtext

### DIFF
--- a/modules/lib.lua
+++ b/modules/lib.lua
@@ -292,7 +292,7 @@ else
 
         SetTextScale(scale, scale)
         SetTextFont(font)
-        SetTextColour(color.r, color.g, color.b, color.a)
+        SetTextColour(math.floor(color.r), math.floor(color.g), math.floor(color.b), math.floor(color.a))
         SetTextDropShadow()
         SetTextOutline()
         SetTextCentre(true)
@@ -316,7 +316,7 @@ else
 
         SetTextScale(scale, scale)
         SetTextFont(font)
-        SetTextColour(color.r, color.g, color.b, color.a)
+        SetTextColour(math.floor(color.r), math.floor(color.g), math.floor(color.b), math.floor(color.a))
         SetTextCentre(true)
         BeginTextCommandDisplayText('STRING')
         AddTextComponentSubstringPlayerName(text)


### PR DESCRIPTION
## Description

<!-- What does your pull request change? Why should it be merged? Does it fix an issue? -->

Convert the lib module's `lib.drawText2d` and `lib.drawText3d` rgba values from vector4 float values to integers, since [`SetTextColour`](https://docs.fivem.net/natives/?_0xBE6B23FFA53FB442) only accepts integers.

## Checklist

<!-- Put an x inside the [ ] to check an item, like so: [x] -->

- [x] I have personally loaded this code into an updated Qbox project and checked all of its functionality.
- [x] My pull request fits the contribution guidelines & code conventions.
