### PR TITLE
fix(server/player): add lib prefix to math function

### DIFF
--- a/server/player.lua
+++ b/server/player.lua
@@ -568,7 +568,7 @@ function CreatePlayer(playerData, Offline)
     function self.Functions.SetMetaData(meta, val)
         if not meta or type(meta) ~= 'string' then return end
         if meta == 'hunger' or meta == 'thirst' or meta == 'stress' then
-            Player(self.PlayerData.source).state:set(meta, math.clamp(val, 0, 100), true)
+            Player(self.PlayerData.source).state:set(meta, lib.math.clamp(val, 0, 100), true)
         end
 
         local oldVal = self.PlayerData.metadata[meta]


### PR DESCRIPTION
## Description

Adds the missing `lib.` prefix to the math function added in the statebag pr

## Checklist

- [ ] I have personally loaded this code into an updated Qbox project and checked all of its functionality.
- [ ] My pull request fits the contribution guidelines & code conventions.
