### PR TITLE
config(server): add letter to citizen id generator

### DIFF
--- a/config/server.lua
+++ b/config/server.lua
@@ -25,7 +25,7 @@ return {
         identifierTypes = {
             citizenid = {
                 valueFunction = function()
-                    return lib.string.random('........')
+                    return lib.string.random('A.......')
                 end,
             },
             AccountNumber = {


### PR DESCRIPTION
## Description

It adds a letter to the first character of the `citizenid`. This presents problems in some functions such as `GetPlayerByCitizenId(cid)`.

![image](https://github.com/Qbox-project/qbx_core/assets/58707473/811cc927-c835-488a-9124-af727f8e24c8)
![image](https://github.com/Qbox-project/qbx_core/assets/58707473/26cf11c3-15fa-4291-8deb-1b93f88edc34)

Statistically, this is an extreme edge case, but the RNG has dealt its cards among one of my players and this is the issue after further review. Maybe this would be better suited to enforce string conversion in the functions that accepts CID... but this at least stops the problem at the source.

## Checklist

<!-- Put an x inside the [ ] to check an item, like so: [x] -->

- [ ] I have personally loaded this code into an updated Qbox project and checked all of its functionality.
- [x] My pull request fits the contribution guidelines & code conventions.
