### PR TITLE
fix(modules/lib): spawn temp vehicle under map

### DIFF
--- a/modules/lib.lua
+++ b/modules/lib.lua
@@ -247,7 +247,7 @@ if isServer then
             coords = vec4(pedCoords.x, pedCoords.y, pedCoords.z, GetEntityHeading(source))
         end
 
-        local tempVehicle = CreateVehicle(model, 0, 0, 0, 0, true, true)
+        local tempVehicle = CreateVehicle(model, 0, 0, -200, 0, true, true)
         while not DoesEntityExist(tempVehicle) do Wait(0) end
 
         local vehicleType = GetVehicleType(tempVehicle)


### PR DESCRIPTION
## Description

<!-- What does your pull request change? Why should it be merged? Does it fix an issue? -->
When spawning vehicles serverside we need to create a temporary vehicle to get the vehicle type. For most vehicles this is okay but some can explode when being spawned at 0,0,0. this pushes the spawn under the map so that they don't go boom


## Checklist

<!-- Put an x inside the [ ] to check an item, like so: [x] -->

- [x] I have personally loaded this code into an updated Qbox project and checked all of its functionality.
- [x] My pull request fits the contribution guidelines & code conventions.
