### PR TITLE
fix(server/player): only set state when possible

### DIFF
--- a/server/player.lua
+++ b/server/player.lua
@@ -346,9 +346,11 @@ function CheckPlayerData(source, playerData)
     playerData.metadata.hunger = playerData.metadata.hunger or 100
     playerData.metadata.thirst = playerData.metadata.thirst or 100
     playerData.metadata.stress = playerData.metadata.stress or 0
-    playerState:set('hunger', playerData.metadata.hunger, true)
-    playerState:set('thirst', playerData.metadata.thirst, true)
-    playerState:set('stress', playerData.metadata.stress, true)
+    if playerState then
+        playerState:set('hunger', playerData.metadata.hunger, true)
+        playerState:set('thirst', playerData.metadata.thirst, true)
+        playerState:set('stress', playerData.metadata.stress, true)
+    end
 
     playerData.metadata.isdead = playerData.metadata.isdead or false
     playerData.metadata.inlaststand = playerData.metadata.inlaststand or false

--- a/server/player.lua
+++ b/server/player.lua
@@ -566,7 +566,7 @@ function CreatePlayer(playerData, Offline)
     ---@param val any
     function self.Functions.SetMetaData(meta, val)
         if not meta or type(meta) ~= 'string' then return end
-        if meta == 'hunger' or meta == 'thirst' or meta == 'stress' then
+        if (meta == 'hunger' or meta == 'thirst' or meta == 'stress') and self.PlayerData.source then
             Player(self.PlayerData.source).state:set(meta, lib.math.clamp(val, 0, 100), true)
         end
 


### PR DESCRIPTION
## Description

<!-- What does your pull request change? Why should it be merged? Does it fix an issue? -->
Trying to set a statebag when the player is offline probably ain't gonna work. This moves these set events into a conditional that should correct issues with offline player data management

## Checklist

<!-- Put an x inside the [ ] to check an item, like so: [x] -->

- [ ] I have personally loaded this code into an updated Qbox project and checked all of its functionality.
- [x] My pull request fits the contribution guidelines & code conventions.
