### PR TITLE
fix(bridge): qb commands with implied arguments

### DIFF
--- a/bridge/qb/server/commands.lua
+++ b/bridge/qb/server/commands.lua
@@ -18,8 +18,12 @@ function commands.Add(name, help, arguments, argsrequired, callback, permission)
     end
     lib.addCommand(name, properties, function(source, args, raw)
         local _args = {}
-        for i = 1, #arguments do
-            _args[i] = args[arguments[i].name]
+        if #args > 0 then
+            _args = args
+        else
+            for i = 1, #arguments do
+                _args[i] = args[arguments[i].name]
+            end
         end
         callback(source, _args, raw)
     end)


### PR DESCRIPTION
## Description

Fixes bridge commands in cases where the arguments are not explicitly declared in the function. Observed in the wild that scripts were not declaring the help text, but still using the passed through arguments.

Fixes #437 

## Checklist

- [x] I have personally loaded this code into an updated Qbox project and checked all of its functionality.
- [x] My pull request fits the contribution guidelines & code conventions.
