### PR TITLE
refactor(client/server): Reintroduce Bucketing and Release streamingRequest

### DIFF
--- a/client/character.lua
+++ b/client/character.lua
@@ -268,7 +268,8 @@ local function chooseCharacter()
     Wait(1000)
     SetEntityCoords(cache.ped, randomLocation.pedCoords.x, randomLocation.pedCoords.y, randomLocation.pedCoords.z, false, false, false, false)
     SetEntityHeading(cache.ped, randomLocation.pedCoords.w)
-    if not lib.callback.await('qbx_core:server:characterBucket', false) then return chooseCharacter() end
+    ---@diagnostic disable-next-line: missing-parameter
+    lib.callback('qbx_core:server:setCharBucket', false)
     Wait(1500)
     ShutdownLoadingScreen()
     ShutdownLoadingScreenNui()

--- a/client/character.lua
+++ b/client/character.lua
@@ -268,6 +268,7 @@ local function chooseCharacter()
     Wait(1000)
     SetEntityCoords(cache.ped, randomLocation.pedCoords.x, randomLocation.pedCoords.y, randomLocation.pedCoords.z, false, false, false, false)
     SetEntityHeading(cache.ped, randomLocation.pedCoords.w)
+    if not lib.callback.await('qbx_core:server:characterBucket', false) then return chooseCharacter() end
     Wait(1500)
     ShutdownLoadingScreen()
     ShutdownLoadingScreenNui()

--- a/client/character.lua
+++ b/client/character.lua
@@ -402,6 +402,7 @@ CreateThread(function()
             Wait(250)
             lib.requestModel(model, config.loadingModelsTimeout)
             SetPlayerModel(cache.playerId, model)
+            SetModelAsNoLongerNeeded(model)
             chooseCharacter()
             break
         end

--- a/server/character.lua
+++ b/server/character.lua
@@ -47,7 +47,7 @@ lib.callback.register('qbx_core:server:loadCharacter', function(source, citizenI
     local success = Login(source, citizenId)
     if not success then return end
 
-    SetPlayerRoutingBucket(source, 0)
+    SetPlayerBucket(source, 0)
     logger.log({
         source = 'qbx_core',
         webhook = config.logging.webhook['joinleave'],

--- a/server/character.lua
+++ b/server/character.lua
@@ -76,9 +76,9 @@ lib.callback.register('qbx_core:server:createCharacter', function(source, data)
     return newData
 end)
 
-lib.callback.register('qbx_core:server:characterBucket', function (source)
+lib.callback.register('qbx_core:server:setCharBucket', function(source)
     SetPlayerBucket(source, source)
-    return GetPlayerRoutingBucket(source) == source
+    assert(GetPlayerRoutingBucket(source) == source, 'Multicharacter bucket not set.')
 end)
 
 RegisterNetEvent('qbx_core:server:deleteCharacter', function(citizenId)

--- a/server/character.lua
+++ b/server/character.lua
@@ -69,7 +69,7 @@ lib.callback.register('qbx_core:server:createCharacter', function(source, data)
 
     giveStarterItems(source)
     if GetResourceState('qbx_spawn') == 'missing' then
-        SetPlayerRoutingBucket(source, 0)
+        SetPlayerBucket(source, 0)
     end
 
     lib.print.info(('%s has created a character'):format(GetPlayerName(source)))

--- a/server/character.lua
+++ b/server/character.lua
@@ -76,6 +76,11 @@ lib.callback.register('qbx_core:server:createCharacter', function(source, data)
     return newData
 end)
 
+lib.callback.register('qbx_core:server:characterBucket', function (source)
+    SetPlayerBucket(source, source)
+    return GetPlayerRoutingBucket(source) == source
+end)
+
 RegisterNetEvent('qbx_core:server:deleteCharacter', function(citizenId)
     local src = source
     DeleteCharacter(src --[[@as number]], citizenId)


### PR DESCRIPTION
## Description

This adds back in bucketing to internal multicharacter, creating a callback to change player bucket. Refactors the use of bucket native to use internal SetPlayerBucket function. Finally releases a model request not being released after use.

#226

## Checklist

<!-- Put an x inside the [ ] to check an item, like so: [x] -->

- [x] I have personally loaded this code into an updated Qbox project and checked all of its functionality.
- [x] My pull request fits the contribution guidelines & code conventions.
