### PR TITLE
fix(server/player): status desync

### DIFF
--- a/server/player.lua
+++ b/server/player.lua
@@ -530,7 +530,8 @@ function CreatePlayer(playerData, Offline)
     function self.Functions.SetMetaData(meta, val)
         if not meta or type(meta) ~= 'string' then return end
         if (meta == 'hunger' or meta == 'thirst' or meta == 'stress') and self.PlayerData.source then
-            Player(self.PlayerData.source).state:set(meta, lib.math.clamp(val, 0, 100), true)
+            val = lib.math.clamp(val, 0, 100)
+            Player(self.PlayerData.source).state:set(meta, val, true)
         end
 
         local oldVal = self.PlayerData.metadata[meta]


### PR DESCRIPTION
## Description

This fixes an issue where the statebag statuses were clamped to 0-100 while the meta statuses wcould go over 100. causing them to become desynced. this would cause huds that use metadata values to say that players had more hunger/thirst than they really had and they would start dying for no apparent reason. it will now clamp both to 100.

repro here in issue #457 

## Checklist

<!-- Put an x inside the [ ] to check an item, like so: [x] -->

- [x ] I have personally loaded this code into an updated Qbox project and checked all of its functionality.
- [ x] My pull request fits the contribution guidelines & code conventions.
