### PR TITLE
feat(modules/lib): getVehicleModName and getVehicleLiveryName

### DIFF
--- a/modules/lib.lua
+++ b/modules/lib.lua
@@ -395,6 +395,23 @@ else
         return GetLabelText(GetMakeNameFromVehicleModel(GetEntityModel(vehicle)))
     end
 
+    ---Returns the mod type name of the given vehicle.
+    ---@param vehicle integer
+    ---@param modType integer
+    ---@param modIndex integer
+    ---@return string
+    function qbx.getVehicleModName(vehicle, modType, modIndex)
+        return GetLabelText(GetModTextLabel(vehicle, modType, modIndex))
+    end
+
+    ---Returns the livery name of the given vehicle.
+    ---@param vehicle integer
+    ---@param liveryIndex integer
+    ---@return string
+    function qbx.getVehicleLiveryName(vehicle, liveryIndex)
+        return GetLabelText(GetLiveryName(vehicle, liveryIndex))
+    end
+
     ---Returns the street name and cross section name at the given coords.
     ---@param coords vector3
     ---@return { main: string, cross: string }


### PR DESCRIPTION
## Description

Adds a function to get the vehicle mod name and vehicle livery name. Came across a use for it and realized we didn't have it in our lib so I figured I'd toss it in here. Not sure what everyone else's options on it are. 

## Checklist

- [ ] I have personally loaded this code into an updated Qbox project and checked all of its functionality.
- [x] My pull request fits the contribution guidelines & code conventions.
