### PR TITLE
fix(server/player): removing player from gang

### DIFF
--- a/server/player.lua
+++ b/server/player.lua
@@ -249,7 +249,7 @@ local function removePlayerFromGang(citizenid, gangName)
         local gang = GetGang('none')
         assert(gang ~= nil, 'cannot find none gang. Does it exist in shared/gangs.lua?')
         player.PlayerData.gang = {
-            name = gangName,
+            name = 'none',
             label = gang.label,
             isboss = false,
             grade = {


### PR DESCRIPTION
## Description

Fix an issue where when firing a gang member, it doesn't fully fire them as reported in https://github.com/Qbox-project/qbx_management/issues/58

## Checklist

- [x] I have personally loaded this code into an updated Qbox project and checked all of its functionality.
- [x] My pull request fits the contribution guidelines & code conventions.
