### PR TITLE
revert: changing character deletion tables to be an array

### DIFF
--- a/config/server.lua
+++ b/config/server.lua
@@ -56,31 +56,25 @@ return {
         }
     },
 
+
     ---@alias TableName string
     ---@alias ColumnName string
-    ---@type [TableName, ColumnName][]
+    ---@type table<TableName, ColumnName>
     characterDataTables = {
-        {'properties', 'owner'},
-        {'apartments', 'citizenid'},
-        {'bank_accounts_new', 'id'},
-        {'crypto_transactions', 'citizenid'},
-        {'phone_invoices', 'citizenid'},
-        {'phone_messages', 'citizenid'},
-        {'playerskins', 'citizenid'},
-        {'player_contacts', 'citizenid'},
-        {'player_houses', 'citizenid'},
-        {'player_mails', 'citizenid'},
-        {'player_outfits', 'citizenid'},
-        {'player_vehicles', 'citizenid'},
-        {'players', 'citizenid'},
-        {'npwd_calls', 'identifier'},
-        {'npwd_darkchat_channel_members', 'user_identifier'},
-        {'npwd_marketplace_listings', 'identifier'},
-        {'npwd_messages_participants', 'participant'},
-        {'npwd_notes', 'identifier'},
-        {'npwd_phone_contacts', 'identifier'},
-        {'npwd_phone_gallery', 'identifier'},
+        players = 'citizenid',
+        apartments = 'citizenid',
+        bank_accounts_new = 'id',
+        crypto_transactions = 'citizenid',
+        phone_invoices = 'citizenid',
+        phone_messages = 'citizenid',
+        playerskins = 'citizenid',
+        player_contacts = 'citizenid',
+        player_houses = 'citizenid',
+        player_mails = 'citizenid',
+        player_outfits = 'citizenid',
+        player_vehicles = 'citizenid',
     }, -- Rows to be deleted when the character is deleted
+
 
     server = {
         pvp = true, -- Enable or disable pvp on the server (Ability to shoot other players)

--- a/config/server.lua
+++ b/config/server.lua
@@ -73,6 +73,14 @@ return {
         player_mails = 'citizenid',
         player_outfits = 'citizenid',
         player_vehicles = 'citizenid',
+        properties = 'owner',
+        npwd_calls = 'identifier',
+        npwd_darkchat_channel_members = 'user_identifier',
+        npwd_marketplace_listings = 'identifier',
+        npwd_messages_participants = 'participant',
+        npwd_notes = 'identifier',
+        npwd_phone_contacts = 'identifier',
+        npwd_phone_gallery = 'identifier',
     }, -- Rows to be deleted when the character is deleted
 
 

--- a/server/storage/players.lua
+++ b/server/storage/players.lua
@@ -241,10 +241,7 @@ local function deletePlayer(citizenId)
     local query = 'DELETE FROM %s WHERE %s = ?'
     local queries = {}
 
-    for i = 1, #characterDataTables do
-        local data = characterDataTables[i]
-        local tableName = data[1]
-        local columnName = data[2]
+    for tableName, columnName in pairs(characterDataTables) do
         if doesTableExist(tableName) then
             queries[#queries + 1] = {
                 query = query:format(tableName, columnName),
@@ -362,8 +359,7 @@ RegisterCommand('convertjobs', function(source)
 end, true)
 
 CreateThread(function()
-    for _, data in pairs(characterDataTables) do
-        local tableName = data[1]
+    for tableName in pairs(characterDataTables) do
         if not doesTableExist(tableName) then
             warn(('Table \'%s\' does not exist in database, please remove it from qbx_core/config/server.lua or create the table'):format(tableName))
         end


### PR DESCRIPTION
- This causes warnings on startup as the index of the array is assumed to be the table name
- order shouldn't matter since all the statements are executed in a transaction