### PR TITLE
feat: accessor functions in lieu of exposing tables

### DIFF
--- a/client/groups.lua
+++ b/client/groups.lua
@@ -1,20 +1,35 @@
 local jobs = require 'shared.jobs'
 local gangs = require 'shared.gangs'
 
----@return table<string, Job>
-function GetJobs()
-    return jobs
+---@param name string?
+---@return table?
+function GetJobs(name)
+    if not name then return jobs end
+
+    if type(name) ~= 'string' then return end
+
+    name = name:lower()
+
+    return jobs[name]
 end
 
 exports('GetJobs', GetJobs)
 
----@return table<string, Gang>
-function GetGangs()
-    return gangs
+---@param name string?
+---@return table?
+function GetGangs(name)
+    if not name then return gangs end
+
+    if type(name) ~= 'string' then return end
+
+    name = name:lower()
+
+    return gangs[name]
 end
 
 exports('GetGangs', GetGangs)
 
+---@deprecated use the GetJobs function instead
 ---@param name string
 ---@return Job?
 function GetJob(name)
@@ -23,6 +38,7 @@ end
 
 exports('GetJob', GetJob)
 
+---@deprecated use the GetGangs function instead
 ---@param name string
 ---@return Gang?
 function GetGang(name)

--- a/client/groups.lua
+++ b/client/groups.lua
@@ -33,6 +33,8 @@ exports('GetGangs', GetGangs)
 ---@param name string
 ---@return Job?
 function GetJob(name)
+    lib.print.verbose('deprecated function GetJob invoked. use GetJobs instead')
+
     return jobs[name]
 end
 
@@ -42,6 +44,8 @@ exports('GetJob', GetJob)
 ---@param name string
 ---@return Gang?
 function GetGang(name)
+    lib.print.verbose('deprecated function GetGang invoked. use GetGangs instead')
+
     return gangs[name]
 end
 

--- a/client/main.lua
+++ b/client/main.lua
@@ -20,6 +20,8 @@ exports('GetVehicles', GetVehicles)
 ---@deprecated use the GetVehicles function instead
 ---@return table<string, Vehicle>
 function GetVehiclesByName()
+    lib.print.verbose('deprecated function GetVehiclesByName invoked. use GetVehicles instead')
+
     return QBX.Shared.Vehicles
 end
 

--- a/client/main.lua
+++ b/client/main.lua
@@ -3,6 +3,21 @@ QBX.PlayerData = {}
 QBX.Shared = require 'shared.main'
 QBX.IsLoggedIn = false
 
+---@param name string?
+---@return table?
+function GetVehicles(name)
+    if not name then return QBX.Shared.Vehicles end
+
+    if type(name) ~= 'string' then return end
+
+    name = name:lower()
+
+    return QBX.Shared.Vehicles[name]
+end
+
+exports('GetVehicles', GetVehicles)
+
+---@deprecated use the GetVehicles function instead
 ---@return table<string, Vehicle>
 function GetVehiclesByName()
     return QBX.Shared.Vehicles
@@ -24,16 +39,30 @@ end
 
 exports('GetVehiclesByCategory', GetVehiclesByCategory)
 
----@return table<number, Weapon>
-function GetWeapons()
-    return QBX.Shared.Weapons
+---@param name string?
+---@return table?
+function GetWeapons(name)
+    if not name then return QBX.Shared.Weapons end
+
+    if type(name) ~= 'string' then return end
+
+    name = name:lower()
+
+    return QBX.Shared.Weapons[name]
 end
 
 exports('GetWeapons', GetWeapons)
 
----@return table<string, vector4>
-function GetLocations()
-    return QBX.Shared.Locations
+---@param name string?
+---@return table?
+function GetLocations(name)
+    if not name then return QBX.Shared.Locations end
+
+    if type(name) ~= 'string' then return end
+
+    name = name:lower()
+
+    return QBX.Shared.Locations[name]
 end
 
 exports('GetLocations', GetLocations)

--- a/server/groups.lua
+++ b/server/groups.lua
@@ -103,20 +103,35 @@ end
 
 exports('RemoveGang', RemoveGang)
 
----@return table<string, Job>
-function GetJobs()
-    return jobs
+---@param name string?
+---@return table?
+function GetJobs(name)
+    if not name then return jobs end
+
+    if type(name) ~= 'string' then return end
+
+    name = name:lower()
+
+    return jobs[name]
 end
 
 exports('GetJobs', GetJobs)
 
----@return table<string, Gang>
-function GetGangs()
-    return gangs
+---@param name string?
+---@return table?
+function GetGangs(name)
+    if not name then return gangs end
+
+    if type(name) ~= 'string' then return end
+
+    name = name:lower()
+
+    return gangs[name]
 end
 
 exports('GetGangs', GetGangs)
 
+---@deprecated use the GetJobs function instead
 ---@param name string
 ---@return Job?
 function GetJob(name)
@@ -125,6 +140,7 @@ end
 
 exports('GetJob', GetJob)
 
+---@deprecated use the GetGangs function instead
 ---@param name string
 ---@return Gang?
 function GetGang(name)

--- a/server/groups.lua
+++ b/server/groups.lua
@@ -135,6 +135,8 @@ exports('GetGangs', GetGangs)
 ---@param name string
 ---@return Job?
 function GetJob(name)
+    lib.print.verbose('deprecated function GetJob invoked. use GetJobs instead')
+
     return jobs[name]
 end
 
@@ -144,6 +146,8 @@ exports('GetJob', GetJob)
 ---@param name string
 ---@return Gang?
 function GetGang(name)
+    lib.print.verbose('deprecated function GetGang invoked. use GetGangs instead')
+
     return gangs[name]
 end
 

--- a/server/main.lua
+++ b/server/main.lua
@@ -35,6 +35,8 @@ exports('GetVehicles', GetVehicles)
 ---@deprecated use the GetVehicles function instead
 ---@return table<string, Vehicle>
 function GetVehiclesByName()
+    lib.print.verbose('deprecated function GetVehiclesByName invoked. use GetVehicles instead')
+
     return QBX.Shared.Vehicles
 end
 

--- a/server/main.lua
+++ b/server/main.lua
@@ -18,6 +18,21 @@ QBX.Player_Buckets = {}
 QBX.Entity_Buckets = {}
 QBX.UsableItems = {}
 
+---@param name string?
+---@return table?
+function GetVehicles(name)
+    if not name then return QBX.Shared.Vehicles end
+
+    if type(name) ~= 'string' then return end
+
+    name = name:lower()
+
+    return QBX.Shared.Vehicles[name]
+end
+
+exports('GetVehicles', GetVehicles)
+
+---@deprecated use the GetVehicles function instead
 ---@return table<string, Vehicle>
 function GetVehiclesByName()
     return QBX.Shared.Vehicles
@@ -39,16 +54,30 @@ end
 
 exports('GetVehiclesByCategory', GetVehiclesByCategory)
 
----@return table<number, Weapon>
-function GetWeapons()
-    return QBX.Shared.Weapons
+---@param name string?
+---@return table?
+function GetWeapons(name)
+    if not name then return QBX.Shared.Weapons end
+
+    if type(name) ~= 'string' then return end
+
+    name = name:lower()
+
+    return QBX.Shared.Weapons[name]
 end
 
 exports('GetWeapons', GetWeapons)
 
----@return table<string, vector4>
-function GetLocations()
-    return QBX.Shared.Locations
+---@param name string?
+---@return table?
+function GetLocations(name)
+    if not name then return QBX.Shared.Locations end
+
+    if type(name) ~= 'string' then return end
+
+    name = name:lower()
+
+    return QBX.Shared.Locations[name]
 end
 
 exports('GetLocations', GetLocations)


### PR DESCRIPTION
## Description

Switches to the use of accessor functions instead of directly exposing the tables which has shown to be less performant and is generally just a bad habit. Added verbose messages which will be escalated to warnings at a later date

## Checklist

- [ ] I have personally loaded this code into an updated Qbox project and checked all of its functionality.
- [x] My pull request fits the contribution guidelines & code conventions.
