### PR TITLE
feat(bridge/qb/server) assertions for deprecated qb-inventory functions

### DIFF
--- a/bridge/qb/server/functions.lua
+++ b/bridge/qb/server/functions.lua
@@ -60,9 +60,8 @@ end
 ---@deprecated No replacement. See https://overextended.dev/ox_inventory/Functions/Client#useitem
 ---@param source Source
 ---@param item string name
-function functions.UseItem(source, item)
-    if GetResourceState('qb-inventory') == 'missing' then return end
-    exports['qb-inventory']:UseItem(source, item)
+function functions.UseItem(source, item) -- luacheck: ignore
+    assert(GetResourceState('qb-inventory') ~= 'started', 'qb-inventory is not compatible with qbx_core. use ox_inventory instead')
 end
 
 local discordLink = GetConvar('qbx:discordlink', 'discord.gg/qbox')

--- a/bridge/qb/server/player.lua
+++ b/bridge/qb/server/player.lua
@@ -23,42 +23,37 @@ local playerObj = {}
 
 ---@deprecated ox_inventory automatically saves
 ---@param source Source
-function playerObj.SaveInventory(source)
-    if GetResourceState('qb-inventory') == 'missing' then return end
-    exports['qb-inventory']:SaveInventory(source, false)
+function playerObj.SaveInventory(source) -- luacheck: ignore
+    assert(GetResourceState('qb-inventory') ~= 'started', 'qb-inventory is not compatible with qbx_core. use ox_inventory instead')
 end
 
 ---@deprecated ox_inventory automatically saves
 ---@param playerData PlayerData
-function playerObj.SaveOfflineInventory(playerData)
-    if GetResourceState('qb-inventory') == 'missing' then return end
-    exports['qb-inventory']:SaveInventory(playerData, true)
+function playerObj.SaveOfflineInventory(playerData) -- luacheck: ignore
+    assert(GetResourceState('qb-inventory') ~= 'started', 'qb-inventory is not compatible with qbx_core. use ox_inventory instead')
 end
 
 ---@deprecated call ox_inventory exports directly
 ---@param items any[]
 ---@return number?
-function playerObj.GetTotalWeight(items)
-    if GetResourceState('qb-inventory') == 'missing' then return end
-    return exports['qb-inventory']:GetTotalWeight(items)
+function playerObj.GetTotalWeight(items) -- luacheck: ignore
+    assert(GetResourceState('qb-inventory') ~= 'started', 'qb-inventory is not compatible with qbx_core. use ox_inventory instead')
 end
 
 ---@deprecated call ox_inventory exports directly
 ---@param items any[]
 ---@param itemName string
 ---@return integer[]? slots
-function playerObj.GetSlotsByItem(items, itemName)
-    if GetResourceState('qb-inventory') == 'missing' then return end
-    return exports['qb-inventory']:GetSlotsByItem(items, itemName)
+function playerObj.GetSlotsByItem(items, itemName) -- luacheck: ignore
+    assert(GetResourceState('qb-inventory') ~= 'started', 'qb-inventory is not compatible with qbx_core. use ox_inventory instead')
 end
 
 ---@deprecated call ox_inventory exports directly
 ---@param items any[]
 ---@param itemName string
 ---@return integer? slot
-function playerObj.GetFirstSlotByItem(items, itemName)
-    if GetResourceState('qb-inventory') == 'missing' then return end
-    return exports['qb-inventory']:GetFirstSlotByItem(items, itemName)
+function playerObj.GetFirstSlotByItem(items, itemName) -- luacheck: ignore
+    assert(GetResourceState('qb-inventory') ~= 'started', 'qb-inventory is not compatible with qbx_core. use ox_inventory instead')
 end
 
 ---@param source Source

--- a/server/player.lua
+++ b/server/player.lua
@@ -538,8 +538,6 @@ function CheckPlayerData(source, playerData)
     }
     playerData.gangs = gangs or {}
     playerData.position = playerData.position or defaultSpawn
-
-    assert(GetResourceState('qb-inventory') ~= 'started', 'qb-inventory is not compatible with qbx_core. use ox_inventory instead')
     playerData.items = {}
     return CreatePlayer(playerData --[[@as PlayerData]], Offline)
 end

--- a/server/player.lua
+++ b/server/player.lua
@@ -538,7 +538,9 @@ function CheckPlayerData(source, playerData)
     }
     playerData.gangs = gangs or {}
     playerData.position = playerData.position or defaultSpawn
-    playerData.items = GetResourceState('qb-inventory') ~= 'missing' and exports['qb-inventory']:LoadInventory(playerData.source, playerData.citizenid) or {}
+
+    assert(GetResourceState('qb-inventory') ~= 'started', 'qb-inventory is not compatible with qbx_core. use ox_inventory instead')
+    playerData.items = {}
     return CreatePlayer(playerData --[[@as PlayerData]], Offline)
 end
 
@@ -938,7 +940,7 @@ function Save(source)
             position = pcoords,
         })
     end)
-    if GetResourceState('qb-inventory') ~= 'missing' then exports['qb-inventory']:SaveInventory(source) end
+    assert(GetResourceState('qb-inventory') ~= 'started', 'qb-inventory is not compatible with qbx_core. use ox_inventory instead')
     lib.print.verbose(('%s PLAYER SAVED!'):format(playerData.name))
 end
 
@@ -957,7 +959,7 @@ function SaveOffline(playerData)
             position = playerData.position.xyz
         })
     end)
-    if GetResourceState('qb-inventory') ~= 'missing' then exports['qb-inventory']:SaveInventory(playerData, true) end
+    assert(GetResourceState('qb-inventory') ~= 'started', 'qb-inventory is not compatible with qbx_core. use ox_inventory instead')
     lib.print.verbose(('%s OFFLINE PLAYER SAVED!'):format(playerData.name))
 end
 


### PR DESCRIPTION
## Description

Assert that qbx_core will not work with qb-inventory and that the user should utilize ox_inventory instead.

## Checklist

- [ ] I have personally loaded this code into an updated Qbox project and checked all of its functionality.
- [ ] My pull request fits the contribution guidelines & code conventions.
