### PR TITLE
revert: "refactor(character): Remove callback and use tutorial native."

### DIFF
--- a/client/character.lua
+++ b/client/character.lua
@@ -374,7 +374,7 @@ local function chooseCharacter()
     SetEntityCoords(cache.ped, randomLocation.pedCoords.x, randomLocation.pedCoords.y, randomLocation.pedCoords.z, false, false, false, false)
     SetEntityHeading(cache.ped, randomLocation.pedCoords.w)
     ---@diagnostic disable-next-line: missing-parameter
-    lib.callback('qbx_core:server:setCharBucket', false)
+    lib.callback.await('qbx_core:server:setCharBucket')
     Wait(1500)
     ShutdownLoadingScreen()
     ShutdownLoadingScreenNui()

--- a/client/character.lua
+++ b/client/character.lua
@@ -269,8 +269,6 @@ local function spawnDefault() -- We use a callback to make the server wait on th
         Wait(0)
     end
 
-    NetworkEndTutorialSession()
-
     destroyPreviewCam()
 
     pcall(function() exports.spawnmanager:spawnPlayer({
@@ -297,8 +295,6 @@ local function spawnLastLocation()
     while not IsScreenFadedOut() do
         Wait(0)
     end
-
-    NetworkEndTutorialSession()
 
     destroyPreviewCam()
 
@@ -377,7 +373,8 @@ local function chooseCharacter()
     Wait(1000)
     SetEntityCoords(cache.ped, randomLocation.pedCoords.x, randomLocation.pedCoords.y, randomLocation.pedCoords.z, false, false, false, false)
     SetEntityHeading(cache.ped, randomLocation.pedCoords.w)
-    NetworkStartSoloTutorialSession()
+    ---@diagnostic disable-next-line: missing-parameter
+    lib.callback('qbx_core:server:setCharBucket', false)
     Wait(1500)
     ShutdownLoadingScreen()
     ShutdownLoadingScreenNui()
@@ -488,7 +485,6 @@ RegisterNetEvent('qbx_core:client:spawnNoApartments', function() -- This event i
     Wait(500)
     destroyPreviewCam()
     SetEntityVisible(cache.ped, true, false)
-    NetworkEndTutorialSession()
     Wait(500)
     DoScreenFadeIn(250)
     TriggerServerEvent('QBCore:Server:OnPlayerLoaded')

--- a/server/character.lua
+++ b/server/character.lua
@@ -47,6 +47,7 @@ lib.callback.register('qbx_core:server:loadCharacter', function(source, citizenI
     local success = Login(source, citizenId)
     if not success then return end
 
+    SetPlayerBucket(source, 0)
     logger.log({
         source = 'qbx_core',
         webhook = config.logging.webhook['joinleave'],
@@ -67,9 +68,17 @@ lib.callback.register('qbx_core:server:createCharacter', function(source, data)
     if not success then return end
 
     giveStarterItems(source)
+    if GetResourceState('qbx_spawn') == 'missing' then
+        SetPlayerBucket(source, 0)
+    end
 
     lib.print.info(('%s has created a character'):format(GetPlayerName(source)))
     return newData
+end)
+
+lib.callback.register('qbx_core:server:setCharBucket', function(source)
+    SetPlayerBucket(source, source)
+    assert(GetPlayerRoutingBucket(source) == source, 'Multicharacter bucket not set.')
 end)
 
 RegisterNetEvent('qbx_core:server:deleteCharacter', function(citizenId)


### PR DESCRIPTION
Reverts Qbox-project/qbx_core#473

This causes a bug where players are invisible to other players. Not a clean revert. Changed the original code to await the callback to fix the original issue of not having a callback function for the async callback.