### PR TITLE
fix(client/events): server sets isLoggedIn state

### DIFF
--- a/client/events.lua
+++ b/client/events.lua
@@ -1,7 +1,6 @@
 -- Player load and unload handling
 RegisterNetEvent('QBCore:Client:OnPlayerLoaded', function()
     ShutdownLoadingScreenNui()
-    LocalPlayer.state:set('isLoggedIn', true, false)
     QBX.IsLoggedIn = true
 
     if GlobalState.PVPEnabled then


### PR DESCRIPTION
## Description

<!-- What does your pull request change? Why should it be merged? Does it fix an issue? -->
Apparently we set this twice cause it's cool. This fixes that and lets the server set it so no shenanigans.

## Checklist

<!-- Put an x inside the [ ] to check an item, like so: [x] -->

- [ ] I have personally loaded this code into an updated Qbox project and checked all of its functionality.
- [x] My pull request fits the contribution guidelines & code conventions.
