### PR TITLE
fix(bridge/qb/shared/main): context check for requiring server file

### DIFF
--- a/bridge/qb/shared/main.lua
+++ b/bridge/qb/shared/main.lua
@@ -1,6 +1,6 @@
 local qbShared = require 'shared.main'
 
-if lib.context == 'server' then
+if IsDuplicityVersion() then
     local starterItems = require 'config.server'.starterItems
     ---@deprecated use starterItems in config/server.lua
     qbShared.StarterItems = {}

--- a/bridge/qb/shared/main.lua
+++ b/bridge/qb/shared/main.lua
@@ -1,16 +1,17 @@
 local qbShared = require 'shared.main'
 
-local starterItems = require 'config.shared'.starterItems or {}
----@deprecated use starterItems in config/server.lua
+local starterItems = require 'config.shared'.starterItems
+---@deprecated use starterItems in config/shared.lua
 qbShared.StarterItems = {}
 
-assert(next(starterItems), 'starterItems is missing or incorrect in shared/config.lua')
-for i = 1, #starterItems do
-    local item = starterItems[i]
-    qbShared.StarterItems[item.name] = {
-        amount = item.amount,
-        item = item.name,
-    }
+if type(starterItems) == 'table' then
+    for i = 1, #starterItems do
+        local item = starterItems[i]
+        qbShared.StarterItems[item.name] = {
+            amount = item.amount,
+            item = item.name,
+        }
+    end
 end
 
 ---@deprecated use lib.math.groupdigits from ox_lib

--- a/bridge/qb/shared/main.lua
+++ b/bridge/qb/shared/main.lua
@@ -1,15 +1,17 @@
-local starterItems = require 'config.server'.starterItems
 local qbShared = require 'shared.main'
 
----@deprecated use starterItems in config/server.lua
-qbShared.StarterItems = {}
+if lib.context == 'server' then
+    local starterItems = require 'config.server'.starterItems
+    ---@deprecated use starterItems in config/server.lua
+    qbShared.StarterItems = {}
 
-for i = 1, #starterItems do
-    local item = starterItems[i]
-    qbShared.StarterItems[item.name] = {
-        amount = item.amount,
-        item = item.name,
-    }
+    for i = 1, #starterItems do
+        local item = starterItems[i]
+        qbShared.StarterItems[item.name] = {
+            amount = item.amount,
+            item = item.name,
+        }
+    end
 end
 
 ---@deprecated use lib.math.groupdigits from ox_lib

--- a/bridge/qb/shared/main.lua
+++ b/bridge/qb/shared/main.lua
@@ -1,17 +1,16 @@
 local qbShared = require 'shared.main'
 
-if IsDuplicityVersion() then
-    local starterItems = require 'config.server'.starterItems
-    ---@deprecated use starterItems in config/server.lua
-    qbShared.StarterItems = {}
+local starterItems = require 'config.shared'.starterItems or {}
+---@deprecated use starterItems in config/server.lua
+qbShared.StarterItems = {}
 
-    for i = 1, #starterItems do
-        local item = starterItems[i]
-        qbShared.StarterItems[item.name] = {
-            amount = item.amount,
-            item = item.name,
-        }
-    end
+assert(next(starterItems), 'starterItems is missing or incorrect in shared/config.lua')
+for i = 1, #starterItems do
+    local item = starterItems[i]
+    qbShared.StarterItems[item.name] = {
+        amount = item.amount,
+        item = item.name,
+    }
 end
 
 ---@deprecated use lib.math.groupdigits from ox_lib

--- a/config/server.lua
+++ b/config/server.lua
@@ -98,21 +98,6 @@ return {
         defaultNumberOfCharacters = 3, -- Define maximum amount of default characters (maximum 3 characters defined by default)
     },
 
-    ---@type { name: string, amount: integer, metadata: fun(source: number): table }[]
-    starterItems = { -- Character starting items
-        { name = 'phone', amount = 1 },
-        { name = 'id_card', amount = 1, metadata = function(source)
-                assert(GetResourceState('qbx_idcard') == 'started', 'qbx_idcard resource not found. Required to give an id_card as a starting item')
-                return exports.qbx_idcard:GetMetaLicense(source, {'id_card'})
-            end
-        },
-        { name = 'driver_license', amount = 1, metadata = function(source)
-                assert(GetResourceState('qbx_idcard') == 'started', 'qbx_idcard resource not found. Required to give an id_card as a starting item')
-                return exports.qbx_idcard:GetMetaLicense(source, {'driver_license'})
-            end
-        },
-    },
-
     -- this configuration is for core events only. putting other webhooks here will have no effect
     logging = {
         webhook = {

--- a/config/shared.lua
+++ b/config/shared.lua
@@ -2,22 +2,18 @@ return {
     serverName = 'Server',
     defaultSpawn = vec4(-540.58, -212.02, 37.65, 208.88),
     notifyPosition = 'top-right', -- 'top' | 'top-right' | 'top-left' | 'bottom' | 'bottom-right' | 'bottom-left'
-    starterItems = function()
-        ---@type { name: string, amount: integer, metadata: fun(source: number): table }[]
-        local starterItemTable = { -- Character starting items
-            { name = 'phone', amount = 1 },
-            { name = 'id_card', amount = 1, metadata = function(source)
-                    assert(GetResourceState('qbx_idcard') == 'started', 'qbx_idcard resource not found. Required to give an id_card as a starting item')
-                    return exports.qbx_idcard:GetMetaLicense(source, {'id_card'})
-                end
-            },
-            { name = 'driver_license', amount = 1, metadata = function(source)
-                    assert(GetResourceState('qbx_idcard') == 'started', 'qbx_idcard resource not found. Required to give an id_card as a starting item')
-                    return exports.qbx_idcard:GetMetaLicense(source, {'driver_license'})
-                end
-            },
-        }
-        assert(next(starterItemTable), 'starterItems is missing or incorrect in shared/config.lua')
-        return starterItemTable
-    end
+    ---@type { name: string, amount: integer, metadata: fun(source: number): table }[]
+    starterItems = { -- Character starting items
+        { name = 'phone', amount = 1 },
+        { name = 'id_card', amount = 1, metadata = function(source)
+                assert(GetResourceState('qbx_idcard') == 'started', 'qbx_idcard resource not found. Required to give an id_card as a starting item')
+                return exports.qbx_idcard:GetMetaLicense(source, {'id_card'})
+            end
+        },
+        { name = 'driver_license', amount = 1, metadata = function(source)
+                assert(GetResourceState('qbx_idcard') == 'started', 'qbx_idcard resource not found. Required to give an id_card as a starting item')
+                return exports.qbx_idcard:GetMetaLicense(source, {'driver_license'})
+            end
+        },
+    }
 }

--- a/config/shared.lua
+++ b/config/shared.lua
@@ -1,5 +1,20 @@
 return {
     serverName = 'Server',
     defaultSpawn = vec4(-540.58, -212.02, 37.65, 208.88),
-    notifyPosition = 'top-right' -- 'top' | 'top-right' | 'top-left' | 'bottom' | 'bottom-right' | 'bottom-left'
+    notifyPosition = 'top-right', -- 'top' | 'top-right' | 'top-left' | 'bottom' | 'bottom-right' | 'bottom-left'
+
+    ---@type { name: string, amount: integer, metadata: fun(source: number): table }[]
+    starterItems = { -- Character starting items
+        { name = 'phone', amount = 1 },
+        { name = 'id_card', amount = 1, metadata = function(source)
+                assert(GetResourceState('qbx_idcard') == 'started', 'qbx_idcard resource not found. Required to give an id_card as a starting item')
+                return exports.qbx_idcard:GetMetaLicense(source, {'id_card'})
+            end
+        },
+        { name = 'driver_license', amount = 1, metadata = function(source)
+                assert(GetResourceState('qbx_idcard') == 'started', 'qbx_idcard resource not found. Required to give an id_card as a starting item')
+                return exports.qbx_idcard:GetMetaLicense(source, {'driver_license'})
+            end
+        },
+    },
 }

--- a/config/shared.lua
+++ b/config/shared.lua
@@ -2,19 +2,22 @@ return {
     serverName = 'Server',
     defaultSpawn = vec4(-540.58, -212.02, 37.65, 208.88),
     notifyPosition = 'top-right', -- 'top' | 'top-right' | 'top-left' | 'bottom' | 'bottom-right' | 'bottom-left'
-
-    ---@type { name: string, amount: integer, metadata: fun(source: number): table }[]
-    starterItems = { -- Character starting items
-        { name = 'phone', amount = 1 },
-        { name = 'id_card', amount = 1, metadata = function(source)
-                assert(GetResourceState('qbx_idcard') == 'started', 'qbx_idcard resource not found. Required to give an id_card as a starting item')
-                return exports.qbx_idcard:GetMetaLicense(source, {'id_card'})
-            end
-        },
-        { name = 'driver_license', amount = 1, metadata = function(source)
-                assert(GetResourceState('qbx_idcard') == 'started', 'qbx_idcard resource not found. Required to give an id_card as a starting item')
-                return exports.qbx_idcard:GetMetaLicense(source, {'driver_license'})
-            end
-        },
-    },
+    starterItems = function()
+        ---@type { name: string, amount: integer, metadata: fun(source: number): table }[]
+        local starterItemTable = { -- Character starting items
+            { name = 'phone', amount = 1 },
+            { name = 'id_card', amount = 1, metadata = function(source)
+                    assert(GetResourceState('qbx_idcard') == 'started', 'qbx_idcard resource not found. Required to give an id_card as a starting item')
+                    return exports.qbx_idcard:GetMetaLicense(source, {'id_card'})
+                end
+            },
+            { name = 'driver_license', amount = 1, metadata = function(source)
+                    assert(GetResourceState('qbx_idcard') == 'started', 'qbx_idcard resource not found. Required to give an id_card as a starting item')
+                    return exports.qbx_idcard:GetMetaLicense(source, {'driver_license'})
+                end
+            },
+        }
+        assert(next(starterItemTable), 'starterItems is missing or incorrect in shared/config.lua')
+        return starterItemTable
+    end
 }

--- a/server/character.lua
+++ b/server/character.lua
@@ -1,6 +1,7 @@
 local config = require 'config.server'
 local logger = require 'modules.logger'
 local storage = require 'server.storage.main'
+local starterItems = require 'config.shared'.starterItems
 
 ---@param license2 string
 ---@param license? string
@@ -14,8 +15,8 @@ local function giveStarterItems(source)
     while not exports.ox_inventory:GetInventory(source) do
         Wait(100)
     end
-    for i = 1, #config.starterItems do
-        local item = config.starterItems[i]
+    for i = 1, #starterItems do
+        local item = starterItems[i]
         if item.metadata and type(item.metadata) == 'function' then
             exports.ox_inventory:AddItem(source, item.name, item.amount, item.metadata(source))
         else


### PR DESCRIPTION
since this is a shared file, the client copy of the file errors out immediately on script start since its trying to require a file thats not available to the client.