### PR TITLE
refactor(server/players.lua): Explicitly select columns in SQL queries

### DIFF
--- a/server/storage/players.lua
+++ b/server/storage/players.lua
@@ -61,7 +61,7 @@ end
 ---@return BanEntity?
 local function fetchBan(request)
     local column, value = getBanId(request)
-    local result = MySQL.single.await('SELECT * FROM bans WHERE ' ..column.. ' = ?', { value })
+    local result = MySQL.single.await('SELECT expire, reason FROM bans WHERE ' ..column.. ' = ?', { value })
     return result and {
         expire = result.expire,
         reason = result.reason,
@@ -198,7 +198,7 @@ local function fetchAllPlayerEntities(license2, license)
     ---@type PlayerEntity[]
     local chars = {}
     ---@type PlayerEntityDatabase[]
-    local result = MySQL.query.await('SELECT *, UNIX_TIMESTAMP(last_logged_out) AS lastLoggedOutUnix FROM players WHERE license = ? OR license = ?', {license, license2})
+    local result = MySQL.query.await('SELECT charinfo, money, job, gang, position, metadata, UNIX_TIMESTAMP(last_logged_out) AS lastLoggedOutUnix FROM players WHERE license = ? OR license = ?', {license, license2})
     for i = 1, #result do
         chars[i] = result[i]
         chars[i].charinfo = json.decode(result[i].charinfo)
@@ -217,15 +217,15 @@ end
 ---@return PlayerEntity?
 local function fetchPlayerEntity(citizenId)
     ---@type PlayerEntityDatabase
-    local player = MySQL.single.await('SELECT *, UNIX_TIMESTAMP(last_logged_out) AS lastLoggedOutUnix FROM players where citizenid = ?', { citizenId })
+    local player = MySQL.single.await('SELECT citizenid, license, name, charinfo, money, job, gang, position, metadata, UNIX_TIMESTAMP(last_logged_out) AS lastLoggedOutUnix FROM players WHERE citizenid = ?', { citizenId })
     local charinfo = json.decode(player.charinfo)
     return player and {
         citizenid = player.citizenid,
-        cid = charinfo.cid,
         license = player.license,
         name = player.name,
         money = json.decode(player.money),
         charinfo = charinfo,
+        cid = charinfo.cid,
         job = player.job and json.decode(player.job),
         gang = player.gang and json.decode(player.gang),
         position = convertPosition(player.position),


### PR DESCRIPTION
## Description

This is a refactor of the SQL queries in the `server/players.lua` file to explicitly select only the necessary columns, improving query performance and database efficiency. 

Previously, the fetchBan function used a query like this:

```sql
SELECT * FROM bans WHERE ...
```
This query selects all columns (*) from the bans table, regardless of whether they are actually needed by the function.
However, the fetchBan function only returns two properties in the result object:

```lua
return result and {
    expire = result.expire,
    reason = result.reason,
}
```
It only uses the expire and reason columns from the query result.
To optimize the query and select only the necessary columns, we can update the fetchBan function to use a query like this:

```sql
SELECT expire, reason FROM bans WHERE ...
```
Now, the query explicitly selects only the expire and reason columns, which are the ones actually used by the function. The same reasoning was applied to the functions: _fetchAllPlayerEntities_ & _fetchPlayerEntity_, where the latter function would also retrieve data from the inventory & phone_number columns despite not being used by the functions.
## Checklist

<!-- Put an x inside the [ ] to check an item, like so: [x] -->

- [ ] I have personally loaded this code into an updated Qbox project and checked all of its functionality.
- [x] My pull request fits the contribution guidelines & code conventions.
