### PR TITLE
feat: HasGroup export

### DIFF
--- a/client/functions.lua
+++ b/client/functions.lua
@@ -43,3 +43,72 @@ function GetPlayerData()
 end
 
 exports('GetPlayerData', GetPlayerData)
+
+--- HasPlayerGotGroup function borrowed from ox_target: https://github.com/overextended/ox_target/blob/aefc464d01da9b7aa3565e79161dd0a489945b90/client/framework/qb.lua#L41
+
+-- MIT License
+
+-- Copyright (c) 2022 Overextended
+
+-- Permission is hereby granted, free of charge, to any person obtaining a copy
+-- of this software and associated documentation files (the "Software"), to deal
+-- in the Software without restriction, including without limitation the rights
+-- to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+-- copies of the Software, and to permit persons to whom the Software is
+-- furnished to do so, subject to the following conditions:
+
+-- The above copyright notice and this permission notice shall be included in all
+-- copies or substantial portions of the Software.
+
+-- THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+-- IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+-- FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+-- AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+-- LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+-- OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+-- SOFTWARE.
+
+---@param filter string | string[] | table<string, number>
+---@return boolean
+function HasGroup(filter)
+    if not filter then return false end
+    local _type = type(filter)
+
+    if _type == 'string' then
+        local job = QBX.PlayerData.job.name == filter
+        local gang = QBX.PlayerData.gang.name == filter
+        local citizenId = QBX.PlayerData.citizenid == filter
+
+        if job or gang or citizenId then
+            return true
+        end
+    elseif _type == 'table' then
+        local tabletype = table.type(filter)
+
+        if tabletype == 'hash' then
+            for name, grade in pairs(filter) do
+                local job = QBX.PlayerData.job.name == name
+                local gang = QBX.PlayerData.gang.name == name
+                local citizenId = QBX.PlayerData.citizenid == name
+
+                if job and grade <= QBX.PlayerData.job.grade.level or gang and grade <= QBX.PlayerData.gang.grade.level or citizenId then
+                    return true
+                end
+            end
+        elseif tabletype == 'array' then
+            for i = 1, #filter do
+                local name = filter[i]
+                local job = QBX.PlayerData.job.name == name
+                local gang = QBX.PlayerData.gang.name == name
+                local citizenId = QBX.PlayerData.citizenid == name
+
+                if job or gang or citizenId then
+                    return true
+                end
+            end
+        end
+    end
+    return false
+end
+
+exports('HasGroup', HasGroup)

--- a/client/functions.lua
+++ b/client/functions.lua
@@ -44,71 +44,10 @@ end
 
 exports('GetPlayerData', GetPlayerData)
 
---- HasPlayerGotGroup function borrowed from ox_target: https://github.com/overextended/ox_target/blob/aefc464d01da9b7aa3565e79161dd0a489945b90/client/framework/qb.lua#L41
-
--- MIT License
-
--- Copyright (c) 2022 Overextended
-
--- Permission is hereby granted, free of charge, to any person obtaining a copy
--- of this software and associated documentation files (the "Software"), to deal
--- in the Software without restriction, including without limitation the rights
--- to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
--- copies of the Software, and to permit persons to whom the Software is
--- furnished to do so, subject to the following conditions:
-
--- The above copyright notice and this permission notice shall be included in all
--- copies or substantial portions of the Software.
-
--- THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
--- IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
--- FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
--- AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
--- LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
--- OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
--- SOFTWARE.
-
 ---@param filter string | string[] | table<string, number>
 ---@return boolean
-function HasGroup(filter)
-    if not filter then return false end
-    local _type = type(filter)
-
-    if _type == 'string' then
-        local job = QBX.PlayerData.job.name == filter
-        local gang = QBX.PlayerData.gang.name == filter
-        local citizenId = QBX.PlayerData.citizenid == filter
-
-        if job or gang or citizenId then
-            return true
-        end
-    elseif _type == 'table' then
-        local tabletype = table.type(filter)
-
-        if tabletype == 'hash' then
-            for name, grade in pairs(filter) do
-                local job = QBX.PlayerData.job.name == name
-                local gang = QBX.PlayerData.gang.name == name
-                local citizenId = QBX.PlayerData.citizenid == name
-
-                if job and grade <= QBX.PlayerData.job.grade.level or gang and grade <= QBX.PlayerData.gang.grade.level or citizenId then
-                    return true
-                end
-            end
-        elseif tabletype == 'array' then
-            for i = 1, #filter do
-                local name = filter[i]
-                local job = QBX.PlayerData.job.name == name
-                local gang = QBX.PlayerData.gang.name == name
-                local citizenId = QBX.PlayerData.citizenid == name
-
-                if job or gang or citizenId then
-                    return true
-                end
-            end
-        end
-    end
-    return false
+function HasPrimaryGroup(filter)
+    return HasPlayerGotGroup(filter, QBX.PlayerData)
 end
 
-exports('HasGroup', HasGroup)
+exports('HasPrimaryGroup', HasPrimaryGroup)

--- a/fxmanifest.lua
+++ b/fxmanifest.lua
@@ -11,6 +11,7 @@ shared_scripts {
     '@ox_lib/init.lua',
     'modules/lib.lua',
     'shared/locale.lua',
+    'shared/functions.lua',
 }
 
 client_scripts {

--- a/server/functions.lua
+++ b/server/functions.lua
@@ -423,73 +423,12 @@ end
 
 exports('ExploitBan', ExploitBan)
 
---- HasPlayerGotGroup function borrowed from ox_target: https://github.com/overextended/ox_target/blob/aefc464d01da9b7aa3565e79161dd0a489945b90/client/framework/qb.lua#L41
-
--- MIT License
-
--- Copyright (c) 2022 Overextended
-
--- Permission is hereby granted, free of charge, to any person obtaining a copy
--- of this software and associated documentation files (the "Software"), to deal
--- in the Software without restriction, including without limitation the rights
--- to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
--- copies of the Software, and to permit persons to whom the Software is
--- furnished to do so, subject to the following conditions:
-
--- The above copyright notice and this permission notice shall be included in all
--- copies or substantial portions of the Software.
-
--- THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
--- IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
--- FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
--- AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
--- LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
--- OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
--- SOFTWARE.
-
 ---@param source Source
 ---@param filter string | string[] | table<string, number>
 ---@return boolean
-function HasGroup(source, filter)
+function HasPrimaryGroup(source, filter)
     local playerData = QBX.Players[source].PlayerData
-    if not filter then return false end
-    local _type = type(filter)
-
-    if _type == 'string' then
-        local job = playerData.job.name == filter
-        local gang = playerData.gang.name == filter
-        local citizenId = playerData.citizenid == filter
-
-        if job or gang or citizenId then
-            return true
-        end
-    elseif _type == 'table' then
-        local tabletype = table.type(filter)
-
-        if tabletype == 'hash' then
-            for name, grade in pairs(filter) do
-                local job = playerData.job.name == name
-                local gang = playerData.gang.name == name
-                local citizenId = playerData.citizenid == name
-
-                if job and grade <= playerData.job.grade.level or gang and grade <= playerData.gang.grade.level or citizenId then
-                    return true
-                end
-            end
-        elseif tabletype == 'array' then
-            for i = 1, #filter do
-                local name = filter[i]
-                local job = playerData.job.name == name
-                local gang = playerData.gang.name == name
-                local citizenId = playerData.citizenid == name
-
-                if job or gang or citizenId then
-                    return true
-                end
-            end
-        end
-    end
-    return false
+    return HasPlayerGotGroup(filter, playerData)
 end
 
-exports('HasGroup', HasGroup)
+exports('HasPrimaryGroup', HasPrimaryGroup)

--- a/server/functions.lua
+++ b/server/functions.lua
@@ -422,3 +422,74 @@ local function ExploitBan(playerId, origin)
 end
 
 exports('ExploitBan', ExploitBan)
+
+--- HasPlayerGotGroup function borrowed from ox_target: https://github.com/overextended/ox_target/blob/aefc464d01da9b7aa3565e79161dd0a489945b90/client/framework/qb.lua#L41
+
+-- MIT License
+
+-- Copyright (c) 2022 Overextended
+
+-- Permission is hereby granted, free of charge, to any person obtaining a copy
+-- of this software and associated documentation files (the "Software"), to deal
+-- in the Software without restriction, including without limitation the rights
+-- to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+-- copies of the Software, and to permit persons to whom the Software is
+-- furnished to do so, subject to the following conditions:
+
+-- The above copyright notice and this permission notice shall be included in all
+-- copies or substantial portions of the Software.
+
+-- THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+-- IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+-- FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+-- AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+-- LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+-- OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+-- SOFTWARE.
+
+---@param source Source
+---@param filter string | string[] | table<string, number>
+---@return boolean
+function HasGroup(source, filter)
+    local playerData = QBX.Players[source].PlayerData
+    if not filter then return false end
+    local _type = type(filter)
+
+    if _type == 'string' then
+        local job = playerData.job.name == filter
+        local gang = playerData.gang.name == filter
+        local citizenId = playerData.citizenid == filter
+
+        if job or gang or citizenId then
+            return true
+        end
+    elseif _type == 'table' then
+        local tabletype = table.type(filter)
+
+        if tabletype == 'hash' then
+            for name, grade in pairs(filter) do
+                local job = playerData.job.name == name
+                local gang = playerData.gang.name == name
+                local citizenId = playerData.citizenid == name
+
+                if job and grade <= playerData.job.grade.level or gang and grade <= playerData.gang.grade.level or citizenId then
+                    return true
+                end
+            end
+        elseif tabletype == 'array' then
+            for i = 1, #filter do
+                local name = filter[i]
+                local job = playerData.job.name == name
+                local gang = playerData.gang.name == name
+                local citizenId = playerData.citizenid == name
+
+                if job or gang or citizenId then
+                    return true
+                end
+            end
+        end
+    end
+    return false
+end
+
+exports('HasGroup', HasGroup)

--- a/shared/functions.lua
+++ b/shared/functions.lua
@@ -1,0 +1,67 @@
+--- HasPlayerGotGroup function borrowed from ox_target: https://github.com/overextended/ox_target/blob/aefc464d01da9b7aa3565e79161dd0a489945b90/client/framework/qb.lua#L41
+
+-- MIT License
+
+-- Copyright (c) 2022 Overextended
+
+-- Permission is hereby granted, free of charge, to any person obtaining a copy
+-- of this software and associated documentation files (the "Software"), to deal
+-- in the Software without restriction, including without limitation the rights
+-- to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+-- copies of the Software, and to permit persons to whom the Software is
+-- furnished to do so, subject to the following conditions:
+
+-- The above copyright notice and this permission notice shall be included in all
+-- copies or substantial portions of the Software.
+
+-- THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+-- IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+-- FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+-- AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+-- LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+-- OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+-- SOFTWARE.
+
+---@param filter string | string[] | table<string, number>
+---@param playerData table
+---@return boolean
+function HasPlayerGotGroup(filter, playerData)
+    if not filter then return false end
+    local _type = type(filter)
+
+    if _type == 'string' then
+        local job = playerData.job.name == filter
+        local gang = playerData.gang.name == filter
+        local citizenId = playerData.citizenid == filter
+
+        if job or gang or citizenId then
+            return true
+        end
+    elseif _type == 'table' then
+        local tabletype = table.type(filter)
+
+        if tabletype == 'hash' then
+            for name, grade in pairs(filter) do
+                local job = playerData.job.name == name
+                local gang = playerData.gang.name == name
+                local citizenId = playerData.citizenid == name
+
+                if job and grade <= playerData.job.grade.level or gang and grade <= playerData.gang.grade.level or citizenId then
+                    return true
+                end
+            end
+        elseif tabletype == 'array' then
+            for i = 1, #filter do
+                local name = filter[i]
+                local job = playerData.job.name == name
+                local gang = playerData.gang.name == name
+                local citizenId = playerData.citizenid == name
+
+                if job or gang or citizenId then
+                    return true
+                end
+            end
+        end
+    end
+    return false
+end


### PR DESCRIPTION
## Description

<!-- What does your pull request change? Why should it be merged? Does it fix an issue? -->

This adds a utility export that allows for a string/table of job/gang/citizenId to be passed against a function and quickly return if the condition matches. Utilizes ox_target code for group/citizenId matching.

## Checklist

<!-- Put an x inside the [ ] to check an item, like so: [x] -->

- [ ] I have personally loaded this code into an updated Qbox project and checked all of its functionality.
- [x] My pull request fits the contribution guidelines & code conventions.
