### PR TITLE
fix(config/server): Add missing rows to be deleted

### DIFF
--- a/config/server.lua
+++ b/config/server.lua
@@ -76,6 +76,8 @@ return {
         {'npwd_notes', 'identifier'},
         {'npwd_phone_contacts', 'identifier'},
         {'npwd_phone_gallery', 'identifier'},
+        {'npwd_twitter_profiles', 'identifier'},
+        {'npwd_match_profiles', 'identifier'},
     }, -- Rows to be deleted when the character is deleted
 
     server = {


### PR DESCRIPTION
## Description

Added two missing data table entries from npwd, these two entries will make sure that all rows from npwd are being properly deleted from the database when deleting a character.

## Checklist

- [x] I have personally loaded this code into an updated Qbox project and checked all of its functionality.
- [x] My pull request fits the contribution guidelines & code conventions.
