### PR TITLE
fix: propagate errors for job/gang commands

### DIFF
--- a/server/commands.lua
+++ b/server/commands.lua
@@ -254,7 +254,8 @@ lib.addCommand('setjob', {
         return
     end
 
-    player.Functions.SetJob(args[locale('command.setjob.params.job.name')], args[locale('command.setjob.params.grade.name')] or 0)
+    local success, errorResult = player.Functions.SetJob(args[locale('command.setjob.params.job.name')], args[locale('command.setjob.params.grade.name')] or 0)
+    assert(success, errorResult)
 end)
 
 --- ADMIN COMMAND
@@ -273,7 +274,8 @@ lib.addCommand('changejob', {
         return
     end
 
-    SetPlayerPrimaryJob(player.PlayerData.citizenid, args[locale('command.changejob.params.job.name')])
+    local success, errorResult = SetPlayerPrimaryJob(player.PlayerData.citizenid, args[locale('command.changejob.params.job.name')])
+    assert(success, errorResult)
 end)
 
 lib.addCommand('addjob', {
@@ -291,7 +293,8 @@ lib.addCommand('addjob', {
         return
     end
 
-    AddPlayerToJob(player.PlayerData.citizenid, args[locale('command.addjob.params.job.name')], args[locale('command.addjob.params.grade.name')] or 0)
+    local success, errorResult = AddPlayerToJob(player.PlayerData.citizenid, args[locale('command.addjob.params.job.name')], args[locale('command.addjob.params.grade.name')] or 0)
+    assert(success, errorResult)
 end)
 
 lib.addCommand('removejob', {
@@ -308,7 +311,8 @@ lib.addCommand('removejob', {
         return
     end
 
-    RemovePlayerFromJob(player.PlayerData.citizenid, args[locale('command.removejob.params.job.name')])
+    local success, errorResult = RemovePlayerFromJob(player.PlayerData.citizenid, args[locale('command.removejob.params.job.name')])
+    assert(success, errorResult)
 end)
 
 -- Gang
@@ -335,7 +339,8 @@ lib.addCommand('setgang', {
         return
     end
 
-    player.Functions.SetGang(args[locale('command.setgang.params.gang.name')], args[locale('command.setgang.params.grade.name')] or 0)
+    local success, errorResult = player.Functions.SetGang(args[locale('command.setgang.params.gang.name')], args[locale('command.setgang.params.grade.name')] or 0)
+    assert(success, errorResult)
 end)
 
 -- Out of Character Chat

--- a/server/player.lua
+++ b/server/player.lua
@@ -610,6 +610,7 @@ function CreatePlayer(playerData, Offline)
     ---@param jobName string name
     ---@param grade? integer defaults to 0
     ---@return boolean success if job was set
+    ---@return ErrorResult? errorResult
     function self.Functions.SetJob(jobName, grade)
         jobName = jobName:lower()
         grade = grade or 0
@@ -625,8 +626,10 @@ function CreatePlayer(playerData, Offline)
         if setJobReplaces then
             RemovePlayerFromJob(self.PlayerData.citizenid, self.PlayerData.job.name)
         end
-        AddPlayerToJob(self.PlayerData.citizenid, jobName, grade)
-        SetPlayerPrimaryJob(self.PlayerData.citizenid, jobName)
+        local success, errorResult = AddPlayerToJob(self.PlayerData.citizenid, jobName, grade)
+        if not success then return false, errorResult end
+        success, errorResult = SetPlayerPrimaryJob(self.PlayerData.citizenid, jobName)
+        if not success then return false, errorResult end
         return true
     end
 
@@ -634,6 +637,7 @@ function CreatePlayer(playerData, Offline)
     ---@param gangName string name
     ---@param grade? integer defaults to 0
     ---@return boolean success if gang was set
+    ---@return ErrorResult? errorResult
     function self.Functions.SetGang(gangName, grade)
         gangName = gangName:lower()
         grade = grade or 0
@@ -647,10 +651,13 @@ function CreatePlayer(playerData, Offline)
             return false
         end
         if setGangReplaces then
-            removePlayerFromGang(self.PlayerData.citizenid, self.PlayerData.gang.name)
+            local success, errorResult = removePlayerFromGang(self.PlayerData.citizenid, self.PlayerData.gang.name)
+            if not success then return false, errorResult end
         end
-        AddPlayerToGang(self.PlayerData.citizenid, gangName, grade)
-        setPlayerPrimaryGang(self.PlayerData.citizenid, gangName)
+        local success, errorResult = AddPlayerToGang(self.PlayerData.citizenid, gangName, grade)
+        if not success then return false, errorResult end
+        success, errorResult = setPlayerPrimaryGang(self.PlayerData.citizenid, gangName)
+        if not success then return false, errorResult end
         return true
     end
 


### PR DESCRIPTION
Asserting that all the commands for job/gang modification are successful so that the error is printed in console if it fails