### PR TITLE
fix(config/server): remove player_groups row on delete when foreign key constraint is missing

### DIFF
--- a/config/server.lua
+++ b/config/server.lua
@@ -68,6 +68,7 @@ return {
         {'player_mails', 'citizenid'},
         {'player_outfits', 'citizenid'},
         {'player_vehicles', 'citizenid'},
+        {'player_groups', 'citizenid'},
         {'players', 'citizenid'},
         {'npwd_calls', 'identifier'},
         {'npwd_darkchat_channel_members', 'user_identifier'},


### PR DESCRIPTION
When deleting characters this table needs to have rows removed if there is not a FK constraint

## Description

<!-- What does your pull request change? Why should it be merged? Does it fix an issue? -->

## Checklist

<!-- Put an x inside the [ ] to check an item, like so: [x] -->

- [ ] I have personally loaded this code into an updated Qbox project and checked all of its functionality.
- [x] My pull request fits the contribution guidelines & code conventions.
