### PR TITLE
feat(client/events): add handler for triggering hud updates

### DIFF
--- a/bridge/qb/client/events.lua
+++ b/bridge/qb/client/events.lua
@@ -23,3 +23,15 @@ RegisterNetEvent('QBCore:Client:VehicleInfo', function(info)
 
     TriggerEvent('QBCore:Client:'..info.event..'Vehicle', data)
 end)
+
+AddStateBagChangeHandler('hunger', ('player:%s'):format(cache.serverId), function(_, _, value)
+    TriggerEvent('hud:client:UpdateNeeds', value, LocalPlayer.state.thirst)
+end)
+
+AddStateBagChangeHandler('thirst', ('player:%s'):format(cache.serverId), function(_, _, value)
+    TriggerEvent('hud:client:UpdateNeeds', LocalPlayer.state.hunger, value)
+end)
+
+AddStateBagChangeHandler('stress', ('player:%s'):format(cache.serverId), function(_, _, value)
+    TriggerEvent('hud:client:UpdateStress', value)
+end)

--- a/client/events.lua
+++ b/client/events.lua
@@ -247,3 +247,15 @@ qbx.entityStateHandler('initVehicle', function(vehicle, _, init)
         state:set('initVehicle', nil, true)
     end)
 end)
+
+AddStateBagChangeHandler('hunger', ('player:%s'):format(cache.serverId), function(_, _, value)
+    TriggerEvent('hud:client:UpdateNeeds', value, LocalPlayer.state.thirst)
+end)
+
+AddStateBagChangeHandler('thirst', ('player:%s'):format(cache.serverId), function(_, _, value)
+    TriggerEvent('hud:client:UpdateNeeds', LocalPlayer.state.hunger, value)
+end)
+
+AddStateBagChangeHandler('stress', ('player:%s'):format(cache.serverId), function(_, _, value)
+    TriggerEvent('hud:client:UpdateStress', value)
+end)

--- a/client/events.lua
+++ b/client/events.lua
@@ -247,15 +247,3 @@ qbx.entityStateHandler('initVehicle', function(vehicle, _, init)
         state:set('initVehicle', nil, true)
     end)
 end)
-
-AddStateBagChangeHandler('hunger', ('player:%s'):format(cache.serverId), function(_, _, value)
-    TriggerEvent('hud:client:UpdateNeeds', value, LocalPlayer.state.thirst)
-end)
-
-AddStateBagChangeHandler('thirst', ('player:%s'):format(cache.serverId), function(_, _, value)
-    TriggerEvent('hud:client:UpdateNeeds', LocalPlayer.state.hunger, value)
-end)
-
-AddStateBagChangeHandler('stress', ('player:%s'):format(cache.serverId), function(_, _, value)
-    TriggerEvent('hud:client:UpdateStress', value)
-end)

--- a/server/loops.lua
+++ b/server/loops.lua
@@ -9,7 +9,6 @@ local function removeHungerAndThirst(src, player)
     player.Functions.SetMetaData('thirst', math.max(0, newThirst))
     player.Functions.SetMetaData('hunger', math.max(0, newHunger))
 
-    TriggerClientEvent('hud:client:UpdateNeeds', src, newHunger, newThirst)
     player.Functions.Save()
 end
 


### PR DESCRIPTION
## Description

<!-- What does your pull request change? Why should it be merged? Does it fix an issue? -->
Adds statebag handlers to trigger hud updates for compatibility. Not required for qbx_hud but other huds that listen to the legacy NetEvents need these

## Checklist

<!-- Put an x inside the [ ] to check an item, like so: [x] -->

- [x] I have personally loaded this code into an updated Qbox project and checked all of its functionality.
- [x] My pull request fits the contribution guidelines & code conventions.
