### PR TITLE
chore(server/commands): remove unnecessary comments

### DIFF
--- a/server/commands.lua
+++ b/server/commands.lua
@@ -3,7 +3,6 @@ local logger = require 'modules.logger'
 
 GlobalState.PVPEnabled = config.server.pvp
 
--- Teleport
 lib.addCommand('tp', {
     help = locale('command.tp.help'),
     params = {
@@ -52,8 +51,6 @@ lib.addCommand('togglepvp', {
     GlobalState.PVPEnabled = config.server.pvp
 end)
 
--- Permissions
-
 lib.addCommand('addpermission', {
     help = locale('command.addpermission.help'),
     params = {
@@ -90,8 +87,6 @@ lib.addCommand('removepermission', {
     RemovePermission(player.PlayerData.source, permission)
 end)
 
--- Open & Close Server
-
 lib.addCommand('openserver', {
     help = locale('command.openserver.help'),
     restricted = 'group.admin'
@@ -127,7 +122,7 @@ lib.addCommand('closeserver', {
         config.server.closedReason = reason
         for k in pairs(QBX.Players) do
             if not IsPlayerAceAllowed(k --[[@as string]], config.server.whitelistPermission) then
-                DropPlayer(k, reason)
+                DropPlayer(k --[[@as string]], reason)
             end
         end
 
@@ -136,8 +131,6 @@ lib.addCommand('closeserver', {
         DropPlayer(source, locale('error.no_permission'))
     end
 end)
-
--- Vehicle
 
 lib.addCommand('car', {
     help = locale('command.car.help'),
@@ -193,8 +186,6 @@ lib.addCommand('dv', {
     end
 end)
 
--- Money
-
 lib.addCommand('givemoney', {
     help = locale('command.givemoney.help'),
     params = {
@@ -231,7 +222,6 @@ lib.addCommand('setmoney', {
     player.Functions.SetMoney(args[locale('command.setmoney.params.moneytype.name')], args[locale('command.setmoney.params.amount.name')])
 end)
 
--- Job
 lib.addCommand('job', {
     help = locale('command.job.help')
 }, function(source)
@@ -257,8 +247,6 @@ lib.addCommand('setjob', {
     local success, errorResult = player.Functions.SetJob(args[locale('command.setjob.params.job.name')], args[locale('command.setjob.params.grade.name')] or 0)
     assert(success, errorResult)
 end)
-
---- ADMIN COMMAND
 
 lib.addCommand('changejob', {
     help = locale('command.changejob.help'),
@@ -315,8 +303,6 @@ lib.addCommand('removejob', {
     assert(success, errorResult)
 end)
 
--- Gang
-
 lib.addCommand('gang', {
     help = locale('command.gang.help')
 }, function(source)
@@ -342,8 +328,6 @@ lib.addCommand('setgang', {
     local success, errorResult = player.Functions.SetGang(args[locale('command.setgang.params.gang.name')], args[locale('command.setgang.params.grade.name')] or 0)
     assert(success, errorResult)
 end)
-
--- Out of Character Chat
 
 lib.addCommand('ooc', {
     help = locale('command.ooc.help')
@@ -387,8 +371,6 @@ lib.addCommand('ooc', {
     end
 end)
 
--- Me command
-
 lib.addCommand('me', {
     help = locale('command.me.help'),
     params = {
@@ -406,13 +388,9 @@ lib.addCommand('me', {
     playerState:set('me', nil, true)
 end)
 
--- ID command
-
 lib.addCommand('id', {help = locale('info.check_id')}, function(source)
     Notify(source, 'ID: ' .. source)
 end)
-
--- Character commands
 
 lib.addCommand('logout', {
     help = locale('info.logout_command_help'),


### PR DESCRIPTION
## Description

Removed the unnecessary comments above the commands and sets a type to string.

## Checklist

- [ ] I have personally loaded this code into an updated Qbox project and checked all of its functionality.
- [x] My pull request fits the contribution guidelines & code conventions.
