### PR TITLE
fix(server/character): return number index for multicharacter

### DIFF
--- a/server/character.lua
+++ b/server/character.lua
@@ -32,7 +32,7 @@ lib.callback.register('qbx_core:server:getCharacters', function(source)
     local sortedChars = {}
     for i = 1, #chars do
         local char = chars[i]
-        sortedChars[char.charinfo.cid] = char
+        sortedChars[tonumber(char.charinfo.cid)] = char
     end
     return sortedChars, allowedAmount
 end)


### PR DESCRIPTION
## Description

<!-- What does your pull request change? Why should it be merged? Does it fix an issue? -->
qb-core stores the charinfo.cid as a string. This won't work with the built in multicharacter due to using the cid as an index value. This fixes that.

## Checklist

<!-- Put an x inside the [ ] to check an item, like so: [x] -->

- [x] I have personally loaded this code into an updated Qbox project and checked all of its functionality.
- [x] My pull request fits the contribution guidelines & code conventions.
