### PR TITLE
fix(server/functions): ban checking edge case

### DIFF
--- a/server/functions.lua
+++ b/server/functions.lua
@@ -332,10 +332,18 @@ exports('ToggleOptin', ToggleOptin)
 ---@return boolean
 ---@return string? playerMessage
 function IsPlayerBanned(source)
-    local plicense = GetPlayerIdentifierByType(source --[[@as string]], 'license2') or GetPlayerIdentifierByType(source --[[@as string]], 'license')
+    local plicense = GetPlayerIdentifierByType(source --[[@as string]], 'license2')
     local result = storage.fetchBan({
         license = plicense
     })
+
+    if not result then
+        plicense = GetPlayerIdentifierByType(source --[[@as string]], 'license')
+        result = storage.fetchBan({
+            license = plicense
+        })
+    end
+
     if not result then return false end
     if os.time() < result.expire then
         local timeTable = os.date('*t', tonumber(result.expire))


### PR DESCRIPTION
## Description

There seems to be a weird edge case in ban checking which I believe is the issue in #463.

Currently we pull whichever license the player has (license2 first then license) and then check it against the bans table to see if the individual is banned. If you have an admin menu which bans by license but you have a license2, the check will give a false positive and allow the player through because it did not check by license. This fixes that by first checking by license2 and then by license to make sure we catch both cases.

Feel free to comment or start a discussion below. Idk if there's a better way we'd like to do this.

## Checklist

- [x] I have personally loaded this code into an updated Qbox project and checked all of its functionality.
- [x] My pull request fits the contribution guidelines & code conventions.
