### PR TITLE
fix(server/functions): exploitban yield until ids inserted

### DIFF
--- a/server/functions.lua
+++ b/server/functions.lua
@@ -424,7 +424,7 @@ local function ExploitBan(playerId, origin)
         event = 'Anti-Cheat',
         color = 'red',
         tags = loggingConfig.role,
-        message = ('%s has been banned for exploiting %s'):format(name, origin)
+        message = success and ('%s has been kicked and banned for exploiting %s'):format(name, origin) or ('%s has been kicked for exploiting %s, ban insert failed'):format(name, origin)
     })
 end
 

--- a/server/functions.lua
+++ b/server/functions.lua
@@ -406,8 +406,8 @@ exports('GetCoreVersion', GetCoreVersion)
 ---@param origin string reason
 local function ExploitBan(playerId, origin)
     local name = GetPlayerName(playerId)
-    CreateThread(function()
-        local success, errorResult = storage.insertBan({
+    local success, errorResult = pcall(
+        storage.insertBan({
             name = name,
             license = GetPlayerIdentifierByType(playerId --[[@as string]], 'license2') or GetPlayerIdentifierByType(playerId --[[@as string]], 'license'),
             discordId = GetPlayerIdentifierByType(playerId --[[@as string]], 'discord'),
@@ -415,9 +415,8 @@ local function ExploitBan(playerId, origin)
             reason = origin,
             expiration = 2147483647,
             bannedBy = 'Anti Cheat'
-        })
-        assert(success, json.encode(errorResult))
-    end)
+        }))
+    if not success then lib.print.error(errorResult) end
     DropPlayer(playerId --[[@as string]], locale('info.exploit_banned', serverConfig.discord))
     logger.log({
         source = 'qbx_core',


### PR DESCRIPTION
## Description

<!-- What does your pull request change? Why should it be merged? Does it fix an issue? -->
Spawning off a thread for the ban insert while functionally correct the natives could fail to return the identifiers preventing the ban from being inserted. This moves the insert into a pcall which will yield until the ban is inserted.

## Checklist

<!-- Put an x inside the [ ] to check an item, like so: [x] -->

- [ ] I have personally loaded this code into an updated Qbox project and checked all of its functionality.
- [x] My pull request fits the contribution guidelines & code conventions.
