### PR TITLE
refactor(server/storage): block non-existent groups from PlayerData

### DIFF
--- a/server/storage/players.lua
+++ b/server/storage/players.lua
@@ -325,7 +325,7 @@ local function fetchPlayerGroups(citizenid)
         local group = groups[i]
         if group.type == GroupType.JOB then
             jobs[group.group] = group.grade
-        else
+        elseif group.type == GroupType.GANG then
             gangs[group.group] = group.grade
         end
     end

--- a/server/storage/players.lua
+++ b/server/storage/players.lua
@@ -369,6 +369,23 @@ RegisterCommand('convertjobs', function(source)
     TriggerEvent('qbx_core:server:jobsconverted')
 end, true)
 
+RegisterCommand('cleanplayergroups', function(source)
+	if source ~= 0 then return warn('This command can only be executed using the server console.') end
+
+    local groups = MySQL.query.await('SELECT DISTINCT `group`, type FROM player_groups')
+    for i = 1, #groups do
+        local group = groups[i]
+        local validGroup = group.type == GroupType.JOB and GetJob(group.group) or GetGang(group.group)
+        if not validGroup then
+            MySQL.query.await('DELETE FROM player_groups WHERE `group` = ? AND type = ?', {group.group, group.type})
+            lib.print.info(('Remove invalid %s %s from player_groups table'):format(group.type, group.group))
+        end
+    end
+
+    lib.print.info('Removed invalid groups from player_groups table')
+    TriggerEvent('qbx_core:server:playergroupscleaned')
+end, true)
+
 CreateThread(function()
     for _, data in pairs(characterDataTables) do
         local tableName = data[1]

--- a/server/storage/players.lua
+++ b/server/storage/players.lua
@@ -375,6 +375,7 @@ RegisterCommand('convertjobs', function(source)
 end, true)
 
 ---Removes invalid groups from the player_groups table.
+local function cleanPlayerGroups()
     local groups = MySQL.query.await('SELECT DISTINCT `group`, type, grade FROM player_groups')
     for i = 1, #groups do
         local group = groups[i]
@@ -389,6 +390,11 @@ end, true)
     end
 
     lib.print.info('Removed invalid groups from player_groups table')
+end
+
+RegisterCommand('cleanplayergroups', function(source)
+	if source ~= 0 then return warn('This command can only be executed using the server console.') end
+    cleanPlayerGroups()
 end, true)
 
 CreateThread(function()

--- a/server/storage/players.lua
+++ b/server/storage/players.lua
@@ -387,7 +387,6 @@ RegisterCommand('cleanplayergroups', function(source)
     end
 
     lib.print.info('Removed invalid groups from player_groups table')
-    TriggerEvent('qbx_core:server:playergroupscleaned')
 end, true)
 
 CreateThread(function()

--- a/server/storage/players.lua
+++ b/server/storage/players.lua
@@ -404,6 +404,9 @@ CreateThread(function()
             warn(('Table \'%s\' does not exist in database, please remove it from qbx_core/config/server.lua or create the table'):format(tableName))
         end
     end
+    if GetConvar('qbx:cleanPlayerGroups', 'false') == 'true' then
+        cleanPlayerGroups()
+    end
 end)
 
 return {

--- a/server/storage/players.lua
+++ b/server/storage/players.lua
@@ -372,6 +372,7 @@ RegisterCommand('convertjobs', function(source)
     TriggerEvent('qbx_core:server:jobsconverted')
 end, true)
 
+---Removes invalid groups from the player_groups table.
 RegisterCommand('cleanplayergroups', function(source)
 	if source ~= 0 then return warn('This command can only be executed using the server console.') end
 

--- a/server/storage/players.lua
+++ b/server/storage/players.lua
@@ -323,7 +323,10 @@ local function fetchPlayerGroups(citizenid)
     local gangs = {}
     for i = 1, #groups do
         local group = groups[i]
-        if group.type == GroupType.JOB then
+        local validGroup = group.type == GroupType.JOB and GetJob(group.group) or GetGang(group.group)
+        if not validGroup then
+            lib.print.warn(('Invalid group %s found in player_groups table, Does it exist in shared/%ss.lua?'):format(group.group, group.type))
+        elseif group.type == GroupType.JOB then
             jobs[group.group] = group.grade
         elseif group.type == GroupType.GANG then
             gangs[group.group] = group.grade


### PR DESCRIPTION
## Description

<!-- What does your pull request change? Why should it be merged? Does it fix an issue? -->
Adds cleanplayergroups command to remove invalid groups from the player_groups table to prevent issues with PlayerData loading. Additionally checks for group validity during player load to block invalid groups from being inserted into the respective PlayerData.jobs/gangs tables. Fixes #526

## Checklist

<!-- Put an x inside the [ ] to check an item, like so: [x] -->

- [ ] I have personally loaded this code into an updated Qbox project and checked all of its functionality.
- [x] My pull request fits the contribution guidelines & code conventions.
