### PR TITLE
fix(server/storage/players): use correct check for group grade

### DIFF
--- a/server/storage/players.lua
+++ b/server/storage/players.lua
@@ -326,7 +326,7 @@ local function fetchPlayerGroups(citizenid)
         local validGroup = group.type == GroupType.JOB and GetJob(group.group) or GetGang(group.group)
         if not validGroup then
             lib.print.warn(('Invalid group %s found in player_groups table, Does it exist in shared/%ss.lua?'):format(group.group, group.type))
-        elseif not validGroup[group.grade] then
+        elseif not validGroup.grades[group.grade] then
             lib.print.warn(('Invalid grade %s found in player_groups table for %s %s, Does it exist in shared/%ss.lua?'):format(group.grade, group.type, group.group, group.type))
         elseif group.type == GroupType.JOB then
             jobs[group.group] = group.grade
@@ -383,7 +383,7 @@ local function cleanPlayerGroups()
         if not validGroup then
             MySQL.query.await('DELETE FROM player_groups WHERE `group` = ? AND type = ?', {group.group, group.type})
             lib.print.info(('Remove invalid %s %s from player_groups table'):format(group.type, group.group))
-        elseif not validGroup[group.grade] then
+        elseif not validGroup.grades[group.grade] then
             MySQL.query.await('DELETE FROM player_groups WHERE `group` = ? AND type = ? AND grade = ?', {group.group, group.type, group.grade})
             lib.print.info(('Remove invalid %s %s grade %s from player_groups table'):format(group.type, group.group, group.grade))
         end

--- a/server/storage/players.lua
+++ b/server/storage/players.lua
@@ -326,7 +326,7 @@ local function fetchPlayerGroups(citizenid)
         local validGroup = group.type == GroupType.JOB and GetJob(group.group) or GetGang(group.group)
         if not validGroup then
             lib.print.warn(('Invalid group %s found in player_groups table, Does it exist in shared/%ss.lua?'):format(group.group, group.type))
-        elseif not validGroup.grades[group.grade] then
+        elseif not validGroup.grades?[group.grade] then
             lib.print.warn(('Invalid grade %s found in player_groups table for %s %s, Does it exist in shared/%ss.lua?'):format(group.grade, group.type, group.group, group.type))
         elseif group.type == GroupType.JOB then
             jobs[group.group] = group.grade

--- a/server/storage/players.lua
+++ b/server/storage/players.lua
@@ -383,7 +383,7 @@ local function cleanPlayerGroups()
         if not validGroup then
             MySQL.query.await('DELETE FROM player_groups WHERE `group` = ? AND type = ?', {group.group, group.type})
             lib.print.info(('Remove invalid %s %s from player_groups table'):format(group.type, group.group))
-        elseif not validGroup.grades[group.grade] then
+        elseif not validGroup.grades?[group.grade] then
             MySQL.query.await('DELETE FROM player_groups WHERE `group` = ? AND type = ? AND grade = ?', {group.group, group.type, group.grade})
             lib.print.info(('Remove invalid %s %s grade %s from player_groups table'):format(group.type, group.group, group.grade))
         end


### PR DESCRIPTION
## Description

<!-- What does your pull request change? Why should it be merged? Does it fix an issue? -->
The grade check for valid groups would fail due to not looking in the grades table of a group. This corrects that.

## Checklist

<!-- Put an x inside the [ ] to check an item, like so: [x] -->

- [ ] I have personally loaded this code into an updated Qbox project and checked all of its functionality.
- [x] My pull request fits the contribution guidelines & code conventions.
