### PR TITLE
fix(server/character): use sql order by for character returns

### DIFF
--- a/server/character.lua
+++ b/server/character.lua
@@ -27,14 +27,7 @@ end
 
 lib.callback.register('qbx_core:server:getCharacters', function(source)
     local license2, license = GetPlayerIdentifierByType(source, 'license2'), GetPlayerIdentifierByType(source, 'license')
-    local chars = storage.fetchAllPlayerEntities(license2, license)
-    local allowedAmount = getAllowedAmountOfCharacters(license2, license)
-    local sortedChars = {}
-    for i = 1, #chars do
-        local char = chars[i]
-        sortedChars[tonumber(char.charinfo.cid)] = char
-    end
-    return sortedChars, allowedAmount
+    return storage.fetchAllPlayerEntities(license2, license), getAllowedAmountOfCharacters(license2, license)
 end)
 
 lib.callback.register('qbx_core:server:getPreviewPedData', function(_, citizenId)

--- a/server/storage/players.lua
+++ b/server/storage/players.lua
@@ -198,7 +198,7 @@ local function fetchAllPlayerEntities(license2, license)
     ---@type PlayerEntity[]
     local chars = {}
     ---@type PlayerEntityDatabase[]
-    local result = MySQL.query.await('SELECT citizenid, charinfo, money, job, gang, position, metadata, UNIX_TIMESTAMP(last_logged_out) AS lastLoggedOutUnix FROM players WHERE license = ? OR license = ?', {license, license2})
+    local result = MySQL.query.await('SELECT citizenid, charinfo, money, job, gang, position, metadata, UNIX_TIMESTAMP(last_logged_out) AS lastLoggedOutUnix FROM players WHERE license = ? OR license = ? ORDER BY cid', {license, license2})
     for i = 1, #result do
         chars[i] = result[i]
         chars[i].charinfo = json.decode(result[i].charinfo)


### PR DESCRIPTION
## Description

<!-- What does your pull request change? Why should it be merged? Does it fix an issue? -->
oxmysql returns results in the order returned by the sql server. This moves the sort to the SQL server eliminating an extra loop and localized variables as well as addressing an issue with old qbcore dbs being converted to qbox and not showing characters with the builtin multichar.

## Checklist

<!-- Put an x inside the [ ] to check an item, like so: [x] -->

- [x] I have personally loaded this code into an updated Qbox project and checked all of its functionality.
- [x] My pull request fits the contribution guidelines & code conventions.
