### PR TITLE
Fix Player Joining Error

### DIFF
--- a/server/storage/players.lua
+++ b/server/storage/players.lua
@@ -44,7 +44,7 @@ local function getBanId(request)
     elseif request.ip then
         return 'ip', request.ip
     else
-        error('no identifier provided', 2)
+        return nil, nil
     end
 end
 
@@ -61,6 +61,10 @@ end
 ---@return BanEntity?
 local function fetchBan(request)
     local column, value = getBanId(request)
+    if not column or not value then
+        return nil
+    end
+
     local result = MySQL.single.await('SELECT expire, reason FROM bans WHERE ' ..column.. ' = ?', { value })
     return result and {
         expire = result.expire,


### PR DESCRIPTION
## Description

Fixes the following error message when a player without a `license2` tries to join the server:

```
[ERROR] @qbx_core/server/storage/players.lua:63: no identifier provided
```

The root cause is: https://github.com/Qbox-project/qbx_core/pull/519. The issue here is that `fetchBan` expects a non-nil license, and since the PR introduces a check for two different licenses as opposed to either license, if a user is missing one of them it will not allow them to join the server and will have a failure message.

Alternate fix:
In `IsPlayerBanned` check if the license is valid before checking. If this approach is preferred let me know and I can quickly make that change.

## Checklist

<!-- Put an x inside the [ ] to check an item, like so: [x] -->

- [x] I have personally loaded this code into an updated Qbox project and checked all of its functionality.
- [x] My pull request fits the contribution guidelines & code conventions.
