### PR TITLE
fix(client/character): disable minimap when in char select

### DIFF
--- a/client/character.lua
+++ b/client/character.lua
@@ -4,7 +4,6 @@ local defaultSpawn = require 'config.shared'.defaultSpawn
 if config.characters.useExternalCharacters then return end
 
 local previewCam
-local charsOpen = false
 local randomLocation = config.characters.locations[math.random(1, #config.characters.locations)]
 
 local randomPeds = {
@@ -356,8 +355,6 @@ end
 local function chooseCharacter()
     randomLocation = config.characters.locations[math.random(1, #config.characters.locations)]
     SetFollowPedCamViewMode(2)
-
-    charsOpen = true
     DisplayRadar(false)
 
     DoScreenFadeOut(500)

--- a/client/character.lua
+++ b/client/character.lua
@@ -3,7 +3,8 @@ local defaultSpawn = require 'config.shared'.defaultSpawn
 
 if config.characters.useExternalCharacters then return end
 
-local previewCam = nil
+local previewCam
+local charsOpen = false
 local randomLocation = config.characters.locations[math.random(1, #config.characters.locations)]
 
 local randomPeds = {
@@ -140,6 +141,8 @@ local function destroyPreviewCam()
     DestroyCam(previewCam, true)
     RenderScriptCams(false, false, 1, true, true)
     FreezeEntityPosition(cache.ped, false)
+    DisplayRadar(true)
+    previewCam = nil
 end
 
 local function randomPed()
@@ -353,6 +356,9 @@ end
 local function chooseCharacter()
     randomLocation = config.characters.locations[math.random(1, #config.characters.locations)]
     SetFollowPedCamViewMode(2)
+
+    charsOpen = true
+    DisplayRadar(false)
 
     DoScreenFadeOut(500)
 


### PR DESCRIPTION
## Description

- Disables the minimap and health/armor bars when in character selection
- Resets `previewCam` when destroyed

## Checklist

- [x] I have personally loaded this code into an updated Qbox project and checked all of its functionality.
- [x] My pull request fits the contribution guidelines & code conventions.
