### PR TITLE
refactor: error conditions and bridge compat

### DIFF
--- a/bridge/qb/server/main.lua
+++ b/bridge/qb/server/main.lua
@@ -3,10 +3,8 @@ if GetConvar('qbx:enablebridge', 'true') == 'false' then return end
 require 'bridge.qb.server.debug'
 require 'bridge.qb.server.events'
 
-CreateThread(function()
-    local convertItems = require 'bridge.qb.shared.compat'.convertItems
-    convertItems(require '@ox_inventory.data.items', require 'shared.items')
-end)
+local convertItems = require 'bridge.qb.shared.compat'.convertItems
+convertItems(require '@ox_inventory.data.items', require 'shared.items')
 
 qbCoreCompat = {}
 

--- a/bridge/qb/shared/compat.lua
+++ b/bridge/qb/shared/compat.lua
@@ -91,8 +91,11 @@ return {
             file[fileSize+1] = '}'
 
             SaveResourceFile('ox_inventory', 'data/items.lua', table.concat(file), -1)
-            print('^2[warning]^7 '..count..' items have been added to ox_inventory')
-            print('^2[warning]^7 You MUST restart the resource to load the new items.')
+            CreateThread(function()
+                Wait(1000)
+                print('^2[warning]^7 '..count..' items have been added to ox_inventory')
+                print('^2[warning]^7 You MUST restart the resource to load the new items.')
+            end)
         end
     end
 }

--- a/server/main.lua
+++ b/server/main.lua
@@ -1,5 +1,15 @@
 lib.versionCheck('Qbox-project/qbx_core')
-assert(lib.checkDependency('ox_lib', '3.20.0', true))
+local startupErrors, errorMessage = lib.checkDependency('ox_lib', '3.20.0', true), 'ox_lib version 3.20.0 or higher is required'
+startupErrors, errorMessage = not startupErrors and lib.checkDependency('ox_inventory', '2.42.0', true), 'ox_inventory version 2.42.0 or higher is required'
+startupErrors, errorMessage = not startupErrors and GetConvar('inventory:framework', '') == 'qbx' and true, 'inventory:framework must be set to "qbx" in order to use qbx_core'
+if not startupErrors then
+    lib.print.error('Startup errors detected, shutting down server...')
+    ExecuteCommand('quit immediately')
+    for _ = 1, 100 do
+        lib.print.error(errorMessage)
+    end
+    error(errorMessage)
+end
 
 ---@type 'strict'|'relaxed'|'inactive'
 local bucketLockDownMode = GetConvar('qbx:bucketlockdownmode', 'inactive')

--- a/server/main.lua
+++ b/server/main.lua
@@ -1,6 +1,6 @@
 lib.versionCheck('Qbox-project/qbx_core')
-local startupErrors, errorMessage = lib.checkDependency('ox_lib', '3.20.0', true), 'ox_lib version 3.20.0 or higher is required'
-startupErrors, errorMessage = not startupErrors and lib.checkDependency('ox_inventory', '2.42.0', true), 'ox_inventory version 2.42.0 or higher is required'
+local startupErrors, errorMessage = lib.checkDependency('ox_lib', '3.20.0', true), 'ox_lib version 3.20.0 or higher is required' -- luacheck: ignore
+startupErrors, errorMessage = not startupErrors and lib.checkDependency('ox_inventory', '2.42.0', true), 'ox_inventory version 2.42.0 or higher is required' -- luacheck: ignore
 startupErrors, errorMessage = not startupErrors and GetConvar('inventory:framework', '') == 'qbx' and true, 'inventory:framework must be set to "qbx" in order to use qbx_core'
 if not startupErrors then
     lib.print.error('Startup errors detected, shutting down server...')

--- a/server/main.lua
+++ b/server/main.lua
@@ -1,8 +1,13 @@
 lib.versionCheck('Qbox-project/qbx_core')
-local startupErrors, errorMessage = lib.checkDependency('ox_lib', '3.20.0', true), 'ox_lib version 3.20.0 or higher is required' -- luacheck: ignore
-startupErrors, errorMessage = not startupErrors and lib.checkDependency('ox_inventory', '2.42.0', true), 'ox_inventory version 2.42.0 or higher is required' -- luacheck: ignore
-startupErrors, errorMessage = not startupErrors and GetConvar('inventory:framework', '') == 'qbx' and true, 'inventory:framework must be set to "qbx" in order to use qbx_core'
-if not startupErrors then
+local startupErrors, errorMessage
+if not lib.checkDependency('ox_lib', '3.20.0', true) then
+    startupErrors, errorMessage = true, 'ox_lib version 3.20.0 or higher is required'
+elseif not lib.checkDependency('ox_inventory', '2.42.0', true) then
+    startupErrors, errorMessage = true, 'ox_inventory version 2.42.0 or higher is required'
+elseif GetConvar('inventory:framework', '') ~= 'qbx' then
+    startupErrors, errorMessage = true, 'inventory:framework must be set to "qbx" in order to use qbx_core'
+end
+if startupErrors then
     lib.print.error('Startup errors detected, shutting down server...')
     ExecuteCommand('quit immediately')
     for _ = 1, 100 do


### PR DESCRIPTION
## Description

<!-- What does your pull request change? Why should it be merged? Does it fix an issue? -->
Next core release is a breaking release that requires external dependencies to be updated. Failing to complete these dependencies should throw loud and obvious warnings to prevent users from connecting to a server in a bad state. This accomplishes that along with moving the print message for item conversion to a thread to print at end of server load.

## Checklist

<!-- Put an x inside the [ ] to check an item, like so: [x] -->

- [x] I have personally loaded this code into an updated Qbox project and checked all of its functionality.
- [x] My pull request fits the contribution guidelines & code conventions.
