### PR TITLE
refactor(server/main): make error conditions very obvious

### DIFF
--- a/server/player.lua
+++ b/server/player.lua
@@ -670,7 +670,7 @@ function CreatePlayer(playerData, Offline)
             Player(self.PlayerData.source).state:set(meta, val, true)
         end
         if (meta == 'dead' or meta == 'inlaststand') and self.PlayerData.source then
-            Player(self.PlayerData.source).state:set('canUseWeapons', val, true)
+            Player(self.PlayerData.source).state:set('canUseWeapons', not val, true)
         end
 
         local oldVal = self.PlayerData.metadata[meta]


### PR DESCRIPTION
Dead people shouldn't use weapons while living people can use weapons

## Description

<!-- What does your pull request change? Why should it be merged? Does it fix an issue? -->
canUseWeapons should be inverted from inlaststand and dead metas otherwise you get zombies with guns.

## Checklist

<!-- Put an x inside the [ ] to check an item, like so: [x] -->

- [x] I have personally loaded this code into an updated Qbox project and checked all of its functionality.
- [x] My pull request fits the contribution guidelines & code conventions.
