### PR TITLE
fix(server/events): statebag handler for hunger/stress/thirst

### DIFF
--- a/server/events.lua
+++ b/server/events.lua
@@ -195,3 +195,29 @@ RegisterNetEvent('QBCore:ToggleDuty', function()
         Notify(src, locale('info.on_duty'))
     end
 end)
+
+---Syncs the player's hunger, thirst, and stress levels with the statebags
+---@param bagName string
+---@param meta 'hunger' | 'thirst' | 'stress'
+---@param value number
+local function playerStateBagCheck(bagName, meta, value)
+    if not value then return end
+    local plySrc = GetPlayerFromStateBagName(bagName)
+    if not plySrc then return end
+    local player = QBX.Players[plySrc]
+    if not player then return end
+    if player.PlayerData.metadata[meta] == value then return end
+    player.Functions.SetMetaData(meta, value)
+end
+
+AddStateBagChangeHandler('hunger', nil, function(bagName, _, value)
+    playerStateBagCheck(bagName, 'hunger', value)
+end)
+
+AddStateBagChangeHandler('thirst', nil, function(bagName, _, value)
+    playerStateBagCheck(bagName, 'thirst', value)
+end)
+
+AddStateBagChangeHandler('stress', nil, function(bagName, _, value)
+    playerStateBagCheck(bagName, 'stress', value)
+end)

--- a/server/events.lua
+++ b/server/events.lua
@@ -206,7 +206,7 @@ local function playerStateBagCheck(bagName, meta, value)
     if not plySrc then return end
     local player = QBX.Players[plySrc]
     if not player then return end
-    if player.PlayerData.metadata[meta] == value then return end
+    if player.PlayerData.metadata[meta] == value or Player(plySrc).state[meta] == value then return end
     player.Functions.SetMetaData(meta, value)
 end
 

--- a/server/events.lua
+++ b/server/events.lua
@@ -204,10 +204,12 @@ local function playerStateBagCheck(bagName, meta, value)
     if not value then return end
     local plySrc = GetPlayerFromStateBagName(bagName)
     if not plySrc then return end
-    local player = QBX.Players[plySrc]
-    if not player then return end
-    if player.PlayerData.metadata[meta] == value or Player(plySrc).state[meta] == value then return end
-    player.Functions.SetMetaData(meta, value)
+    CreateThread(function()
+        local player = QBX.Players[plySrc]
+        if not player then return end
+        if player.PlayerData.metadata[meta] == value and Player(plySrc).state[meta] == value then return end
+        player.Functions.SetMetaData(meta, value)
+    end)
 end
 
 AddStateBagChangeHandler('hunger', nil, function(bagName, _, value)


### PR DESCRIPTION
## Description

<!-- What does your pull request change? Why should it be merged? Does it fix an issue? -->
Setting the statebags outside of the core never actually updates the metadata values which other resources may depend on. This corrects that with a guard check to prevent infinite recursion.

## Checklist

<!-- Put an x inside the [ ] to check an item, like so: [x] -->

- [ ] I have personally loaded this code into an updated Qbox project and checked all of its functionality.
- [x] My pull request fits the contribution guidelines & code conventions.
