### PR TITLE
fix(server/player): convert grade to number

### DIFF
--- a/server/player.lua
+++ b/server/player.lua
@@ -592,7 +592,7 @@ function CreatePlayer(playerData, Offline)
     ---@return ErrorResult? errorResult
     function self.Functions.SetJob(jobName, grade)
         jobName = jobName:lower()
-        grade = grade or 0
+        grade = tonumber(grade or 0)
         local job = GetJob(jobName)
         if not job then
             lib.print.error(('cannot set job. Job %s does not exist'):format(jobName))
@@ -622,7 +622,7 @@ function CreatePlayer(playerData, Offline)
     ---@return ErrorResult? errorResult
     function self.Functions.SetGang(gangName, grade)
         gangName = gangName:lower()
-        grade = grade or 0
+        grade = tonumber(grade or 0)
         local gang = GetGang(gangName)
         if not gang then
             lib.print.error(('cannot set gang. Gang %s does not exist'):format(gangName))


### PR DESCRIPTION
## Description

<!-- What does your pull request change? Why should it be merged? Does it fix an issue? -->
Some older admin resources may pass the grade as a string. We don't use strings for grades so this covers that case and converts them properly

## Checklist

<!-- Put an x inside the [ ] to check an item, like so: [x] -->

- [ ] I have personally loaded this code into an updated Qbox project and checked all of its functionality.
- [x] My pull request fits the contribution guidelines & code conventions.
