### PR TITLE
feat: currentPropertyId metadata

### DIFF
--- a/server/player.lua
+++ b/server/player.lua
@@ -472,7 +472,6 @@ function CheckPlayerData(source, playerData)
     playerData.metadata.dealerrep = playerData.metadata.dealerrep or 0
     playerData.metadata.craftingrep = playerData.metadata.craftingrep or 0
     playerData.metadata.attachmentcraftingrep = playerData.metadata.attachmentcraftingrep or 0
-    playerData.metadata.currentapartment = playerData.metadata.currentapartment or nil
     playerData.metadata.jobrep = playerData.metadata.jobrep or {}
     playerData.metadata.jobrep.tow = playerData.metadata.jobrep.tow or 0
     playerData.metadata.jobrep.trucker = playerData.metadata.jobrep.trucker or 0
@@ -490,6 +489,7 @@ function CheckPlayerData(source, playerData)
         driver = true,
         weapon = false,
     }
+    ---@deprecated
     playerData.metadata.inside = playerData.metadata.inside or {
         house = nil,
         apartment = {
@@ -497,6 +497,7 @@ function CheckPlayerData(source, playerData)
             apartmentId = nil,
         }
     }
+    playerData.metadata.currentPropertyId = playerData.metadata.currentPropertyId or nil
     playerData.metadata.phonedata = playerData.metadata.phonedata or {
         SerialNumber = GenerateUniqueIdentifier('SerialNumber'),
         InstalledApps = {},

--- a/types.lua
+++ b/types.lua
@@ -172,14 +172,14 @@
 ---@field dealerrep number
 ---@field craftingrep number
 ---@field attachmentcraftingrep number
----@field currentapartment? integer apartmentId
 ---@field jobrep {tow: number, trucker: number, taxi: number, hotdog: number}
 ---@field callsign string
 ---@field fingerprint string
 ---@field walletid string
 ---@field criminalrecord {hasRecord: boolean, date?: table} TODO: date is os.date(), create better type than table
 ---@field licences {id: boolean, driver: boolean, weapon: boolean}
----@field inside {house?: any, apartment: {apartmentType?: any, apartmentId?: integer}} TODO: expand
+---@field inside {house?: any, apartment: {apartmentType?: any, apartmentId?: integer}} deprecated, use currentPropertyId with qbx_properties
+---@field currentPropertyId number?
 ---@field phonedata {SerialNumber: string, InstalledApps: table} TODO: expand
 
 ---@class PlayerJob


### PR DESCRIPTION
## Description

This add the currentPropertyId metadata for use with qbx_properties. This is to ensure you can use last location inside a property.

## Checklist

- [x] I have personally loaded this code into an updated Qbox project and checked all of its functionality.
- [x] My pull request fits the contribution guidelines & code conventions.
