### PR TITLE
fix(sql): correct column for unicode enforcement

### DIFF
--- a/qbx_core.sql
+++ b/qbx_core.sql
@@ -1,6 +1,6 @@
 CREATE TABLE IF NOT EXISTS `players` (
   `id` int(11) NOT NULL AUTO_INCREMENT,
-  `citizenid` varchar(50) NOT NULL COLLATE utf8mb4_unicode_ci,
+  `citizenid` varchar(50) NOT NULL,
   `cid` int(11) DEFAULT NULL,
   `license` varchar(255) NOT NULL,
   `name` varchar(255) NOT NULL,
@@ -19,9 +19,9 @@ CREATE TABLE IF NOT EXISTS `players` (
   KEY `license` (`license`)
 ) ENGINE=InnoDB AUTO_INCREMENT=1 DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
 
-ALTER TABLE `players` 
+ALTER TABLE `players`
 ADD IF NOT EXISTS `last_logged_out` timestamp NULL DEFAULT NULL AFTER `last_updated`,
-MODIFY COLUMN `citizenid` varchar(50) NOT NULL COLLATE utf8mb4_unicode_ci;
+MODIFY COLUMN `name` varchar(50) NOT NULL COLLATE utf8mb4_unicode_ci;
 
 CREATE TABLE IF NOT EXISTS `bans` (
   `id` int(11) NOT NULL AUTO_INCREMENT,


### PR DESCRIPTION
## Description

<!-- What does your pull request change? Why should it be merged? Does it fix an issue? -->
CitizenID is a generated field that has a charset of A-Z 0-9. Forcing this to a certain collation is counterintuitive as it doesn't support unicode characters. The issue that was supposed to be resolved by this is for the `name` field being unpopulated due to players with unicode characters in their name within the fivem client. This corrects that issue as well as streamlining qb-core users migrating to qbx_core.

## Checklist

<!-- Put an x inside the [ ] to check an item, like so: [x] -->

- [x] I have personally loaded this code into an updated Qbox project and checked all of its functionality.
- [x] My pull request fits the contribution guidelines & code conventions.
