### PR TITLE
fix(server/queue): get max players via convar for better reliability

### DIFF
--- a/server/queue.lua
+++ b/server/queue.lua
@@ -18,7 +18,7 @@ end
 -- Queue code
 
 local config = require 'config.queue'
-local maxPlayers = GlobalState.MaxPlayers
+local maxPlayers = GetConvarInt('sv_maxclients', 48)
 
 -- destructure frequently used config options
 local waitingEmojis = config.waitingEmojis


### PR DESCRIPTION
## Description

<!-- What does your pull request change? Why should it be merged? Does it fix an issue? -->

For some reason `GlobalState.MaxPlayers` isn't completely reliable and can sometimes be `nil`, so this gets the convar directly instead.

## Checklist

<!-- Put an x inside the [ ] to check an item, like so: [x] -->

- [ ] I have personally loaded this code into an updated Qbox project and checked all of its functionality.
- [x] My pull request fits the contribution guidelines & code conventions.
