### PR TITLE
feat: motd

### DIFF
--- a/client/events.lua
+++ b/client/events.lua
@@ -7,6 +7,11 @@ RegisterNetEvent('QBCore:Client:OnPlayerLoaded', function()
         SetCanAttackFriendly(cache.ped, true, false)
         NetworkSetFriendlyFireOption(true)
     end
+
+    local motd = GetConvar('qbx:motd', '')
+    if motd ~= '' then
+        exports.chat:addMessage({ template = motd })
+    end
 end)
 
 ---@param val PlayerData

--- a/fxmanifest.lua
+++ b/fxmanifest.lua
@@ -29,6 +29,7 @@ client_scripts {
 
 server_scripts {
     '@oxmysql/lib/MySQL.lua',
+    'server/motd.lua',
     'server/main.lua',
     'server/groups.lua',
     'server/functions.lua',

--- a/server/motd.lua
+++ b/server/motd.lua
@@ -1,0 +1,96 @@
+local acknowledged = GetConvar('qbx:acknowledge', 'false') == 'true'
+local messagesUrl = GetConvar('qbx:serviceMessagesUrl', 'https://raw.githubusercontent.com/Qbox-project/txAdminRecipe/refs/heads/main/service-messages.json')
+local resourceVersion = GetResourceMetadata(cache.resource, 'version', 0)
+
+---@param str string
+---@param prefix string
+---@return boolean
+local function startsWith(str, prefix)
+    return str:sub(1, prefix:len()) == prefix
+end
+
+---Returns whether the given version prefix or exact version matches the resource's version.
+---@return boolean
+local function isResourceVersion(version)
+    if type(version) == 'string' then
+        -- if we don't have a dot at the end, check for an exact version match
+        if version:sub(-1) ~= '.' then
+            return resourceVersion == version
+        end
+
+        -- otherwise treat `version` as a prefix
+        return startsWith(resourceVersion, version)
+    end
+
+    if type(version) == 'table' then
+        for i = 1, #version do
+            local currentVersion = version[i]
+            if isResourceVersion(currentVersion) then
+                return true
+            end
+        end
+
+        return false
+    end
+
+    return not version
+end
+
+---Returns the given content stringified, or concatenated with a newline separator if given a table.
+---@return string
+local function validateContent(content)
+    if type(content) == 'table' then
+        local concat = ''
+
+        for i = 1, #content do
+            concat = concat .. (i == 1 and '' or '\n') .. tostring(content[i])
+        end
+
+        return concat
+    end
+
+    return tostring(content)
+end
+
+CreateThread(function()
+    Wait(500) -- wait until after the Nucleus message
+    local messages = {}
+
+    if not acknowledged then
+        messages[#messages + 1] = [[^7
+^4Welcome to ^3Qbox^4!
+To learn more, please check out the documentation at ^5https://docs.qbox.re/^4.
+To turn this message off, add ^3set qbx:acknowledge true^4 to your cfg files.^7]]
+    end
+
+    local requestPromise = promise:new()
+    PerformHttpRequest(messagesUrl, function(_, body)
+        requestPromise:resolve(body)
+    end, 'GET')
+
+    local serviceMessages = json.decode(Citizen.Await(requestPromise))
+    if type(serviceMessages) == 'table' then
+        local hasServiceMessage = false
+
+        for i = 1, #serviceMessages do
+            local message = serviceMessages[i]
+
+            if type(message) == 'table' and message.content and isResourceVersion(message.version) then
+                if not hasServiceMessage then
+                    hasServiceMessage = true
+                    messages[#messages + 1] = '\n^5Qbox service messages:^7'
+                end
+
+                local content = validateContent(message.content)
+                if content then
+                    messages[#messages + 1] = '    ' .. content
+                end
+            end
+        end
+    end
+
+    if #messages == 0 then return end
+    messages[#messages + 1] = '^7'
+
+    print(table.concat(messages, '\n'))
+end)


### PR DESCRIPTION
## Description

<!-- What does your pull request change? Why should it be merged? Does it fix an issue? -->

To improve the onboarding of newbies to Qbox, this PR adds:
- Client MOTD sent in the chat after the player loads in; can be configured.
- Server MOTD printed to the console after the server starts; can be disabled.
- Service messages taken from the `txAdminRecipe`, repo printed to the console after the server starts; can be disabled.

Server MOTD example:
![image](https://github.com/user-attachments/assets/f46d76fb-8d60-496f-9fa0-3fd7157030aa)

See client MOTD and service message examples here: Qbox-project/txAdminRecipe#86

## Checklist

<!-- Put an x inside the [ ] to check an item, like so: [x] -->

- [x] I have personally loaded this code into an updated Qbox project and checked all of its functionality.
- [x] My pull request fits the contribution guidelines & code conventions.
