### PR TITLE
feat(bridge/qb): add warnings and disabling of overridden functions

### DIFF
--- a/bridge/qb/server/functions.lua
+++ b/bridge/qb/server/functions.lua
@@ -2,8 +2,8 @@ require 'server.functions'
 require 'bridge.qb.server.player'
 local functions = {}
 
-local allowMethodOverrides = GetConvarInt('qbx:allowMethodOverrides', 1) == 1
-local disableMethodOverrideWarning = GetConvarInt('qbx:disableMethodOverrideWarning', 0) == 1
+local allowMethodOverrides = GetConvarInt('qbx:allowmethodoverrides', 1) == 1
+local disableMethodOverrideWarning = GetConvarInt('qbx:disableoverridewarning', 0) == 1
 
 local createQbExport = require 'bridge.qb.shared.export-function'
 

--- a/bridge/qb/server/functions.lua
+++ b/bridge/qb/server/functions.lua
@@ -2,8 +2,8 @@ require 'server.functions'
 require 'bridge.qb.server.player'
 local functions = {}
 
-local allowMethodOverrides = GetConvarInt('qbx:allowmethodoverrides', 1) == 1
-local disableMethodOverrideWarning = GetConvarInt('qbx:disableoverridewarning', 0) == 1
+local allowMethodOverrides = GetConvar('qbx:allowmethodoverrides', 'true') == 'true'
+local disableMethodOverrideWarning = GetConvar('qbx:disableoverridewarning', 'false') == 'true'
 
 local createQbExport = require 'bridge.qb.shared.export-function'
 

--- a/bridge/qb/server/functions.lua
+++ b/bridge/qb/server/functions.lua
@@ -397,7 +397,7 @@ createQbExport('RemoveGang', RemoveGang)
 local function checkExistingMethod(method, methodName)
     local methodType = type(method)
     if methodType == 'function' then
-        local warnMessage = allowMethodOverrides and 'Method %s already exists in player class. Overriding it. Disable this warning by setting convar qbx:disableoverridewarning to true' or 'Method %s already exists in player class. This can cause unexpected behavior. Disable this warning by setting convar qbx:disableoverridewarning to true'
+        local warnMessage = allowMethodOverrides and 'A resource is overriding method %s in player class. This can cause unexpected behavior. Disable this warning by setting convar qbx:disableoverridewarning to true' or 'A resource attempted to override method %s in player object and was blocked. Disable this warning by setting convar qbx:disableoverridewarning to true'
         if not disableMethodOverrideWarning then
             lib.print.warn(warnMessage:format(methodName))
         end


### PR DESCRIPTION
QBCore offered a method to modify player object functions at runtime which can lead to interesting side effects depending on implementation. This adds warnings for when this occurs and adds options to block the behavior as well as disabling the warning in either case.

## Description

<!-- What does your pull request change? Why should it be merged? Does it fix an issue? -->
In cases where resources override existing functions such as https://github.com/Qbox-project/qbx_core/issues/559 we should throw a warning to advise the user that unintended behavior may occur. We can also provide a convar to selectively disable this behavior as well as the warning.

## Checklist

<!-- Put an x inside the [ ] to check an item, like so: [x] -->

- [x] I have personally loaded this code into an updated Qbox project and checked all of its functionality.
- [x] My pull request fits the contribution guidelines & code conventions.
