### PR TITLE
feat(server/groups.lua): adds error print if a group name contains capital letters

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@
 .vscode/*
 !.vscode/extensions.json
 !.vscode/settings.json
+.DS_Store

--- a/server/groups.lua
+++ b/server/groups.lua
@@ -10,6 +10,18 @@ local jobs = require 'shared.jobs'
 ---@type table<string, Gang>
 local gangs = require 'shared.gangs'
 
+for name in pairs(jobs) do
+    if name ~= name:lower() then
+        lib.print.error(('jobs.lua contains a job name with capital letters: %s'):format(name))
+    end
+end
+
+for name in pairs(gangs) do
+    if name ~= name:lower() then
+        lib.print.error(('gangs.lua contains a gang name with capital letters: %s'):format(name))
+    end
+end
+
 ---Adds or overwrites jobs in shared/jobs.lua
 ---@param newJobs table<string, Job>
 function CreateJobs(newJobs)

--- a/shared/gangs.lua
+++ b/shared/gangs.lua
@@ -1,3 +1,4 @@
+---Gang names must be lower case (top level table key)
 ---@type table<string, Gang>
 return {
 	['none'] = {

--- a/shared/jobs.lua
+++ b/shared/jobs.lua
@@ -1,3 +1,4 @@
+---Job names must be lower case (top level table key)
 ---@type table<string, Job>
 return {
 	['unemployed'] = {


### PR DESCRIPTION
A core assumption of jobs/gangs is that they will be named all lower case.

- Adds comments in the config file explaining this
- Adds a server side check on server start to add console error prints if a group name is invalid.