### PR TITLE
feat: persistent player vehicles

### DIFF
--- a/client/vehicle-persistence.lua
+++ b/client/vehicle-persistence.lua
@@ -42,6 +42,7 @@ local function calculateDiff(tbl1, tbl2)
 end
 
 local function sendPropsDiff()
+    if not Entity(vehicle).state.persisted then return end
     local newProps = lib.getVehicleProperties(vehicle)
     if not cachedProps then
         cachedProps = newProps

--- a/client/vehicle-persistence.lua
+++ b/client/vehicle-persistence.lua
@@ -1,0 +1,73 @@
+if GetConvar('qbx:enable_vehicle_persistence', 'true') == 'false' then return end
+
+local cachedProps
+local netId
+local vehicle
+local seat
+
+local watchedKeys = {
+    'bodyHealth',
+    'engineHealth',
+    'tankHealth',
+    'fuelLevel',
+    'oilLevel',
+    'dirtLevel',
+    'windows',
+    'doors',
+    'tyres',
+}
+
+---Calculates the difference in values of two tables for the watched keys.
+---If the second table does not have a value that the first table has, it will be marked 'deleted'.
+---@param tbl1 table
+---@param tbl2 table
+---@return table diff
+---@return boolean hasChanged if diff table is not empty
+local function calculateDiff(tbl1, tbl2)
+    local diff = {}
+    local hasChanged = false
+
+    for i = 1, #watchedKeys do
+        local key = watchedKeys[i]
+        local val1 = tbl1[key]
+        local val2 = tbl2[key]
+
+        if val1 ~= val2 then
+            diff[key] = val2 == nil and 'deleted' or val2
+            hasChanged = true
+        end
+    end
+
+    return diff, hasChanged
+end
+
+local function sendPropsDiff()
+    local newProps = lib.getVehicleProperties(vehicle)
+    if not cachedProps then
+        cachedProps = newProps
+        return
+    end
+    local diff, hasChanged = calculateDiff(cachedProps, newProps)
+    cachedProps = newProps
+    if not hasChanged then return end
+    TriggerServerEvent('qbx_core:server:vehiclePropsChanged', netId, diff)
+end
+
+lib.onCache('seat', function(newSeat)
+    if newSeat == -1 then
+        seat = -1
+        vehicle = cache.vehicle
+        netId = NetworkGetNetworkIdFromEntity(vehicle)
+        CreateThread(function()
+            while seat == -1 do
+                sendPropsDiff()
+                Wait(10000)
+            end
+        end)
+    else
+        seat = nil
+        sendPropsDiff()
+        vehicle = nil
+        netId = nil
+    end
+end)

--- a/client/vehicle-persistence.lua
+++ b/client/vehicle-persistence.lua
@@ -64,7 +64,7 @@ lib.onCache('seat', function(newSeat)
                 Wait(10000)
             end
         end)
-    else
+    elseif seat == -1 then
         seat = nil
         sendPropsDiff()
         vehicle = nil

--- a/client/vehicle-persistence.lua
+++ b/client/vehicle-persistence.lua
@@ -1,4 +1,4 @@
-if GetConvar('qbx:enable_vehicle_persistence', 'true') == 'false' then return end
+if GetConvar('qbx:enableVehiclePersistence', 'false') == 'false' then return end
 
 local cachedProps
 local netId

--- a/fxmanifest.lua
+++ b/fxmanifest.lua
@@ -65,7 +65,6 @@ dependencies {
     '/onesync',
     'ox_lib',
     'oxmysql',
-    'qbx_vehicles',
 }
 
 provide 'qb-core'

--- a/fxmanifest.lua
+++ b/fxmanifest.lua
@@ -23,6 +23,7 @@ client_scripts {
     'client/events.lua',
     'client/character.lua',
     'client/discord.lua',
+    'client/vehicle-persistence.lua',
     'bridge/qb/client/main.lua',
 }
 
@@ -36,6 +37,7 @@ server_scripts {
     'server/commands.lua',
     'server/loops.lua',
     'server/character.lua',
+    'server/vehicle-persistence.lua',
     'bridge/qb/server/main.lua',
 }
 
@@ -63,6 +65,7 @@ dependencies {
     '/onesync',
     'ox_lib',
     'oxmysql',
+    'qbx_vehicles',
 }
 
 provide 'qb-core'

--- a/modules/lib.lua
+++ b/modules/lib.lua
@@ -419,6 +419,7 @@ else
     end
 
     ---Deletes the specified vehicle and returns whether it was successful.
+    ---@deprecated use exports.qbx_core:DeleteVehicle(vehicle) instead
     ---@param vehicle integer
     ---@return boolean deleted
     function qbx.deleteVehicle(vehicle)

--- a/modules/lib.lua
+++ b/modules/lib.lua
@@ -419,7 +419,6 @@ else
     end
 
     ---Deletes the specified vehicle and returns whether it was successful.
-    ---@deprecated use exports.qbx_core:DeleteVehicle(vehicle) instead
     ---@param vehicle integer
     ---@return boolean deleted
     function qbx.deleteVehicle(vehicle)

--- a/modules/lib.lua
+++ b/modules/lib.lua
@@ -316,7 +316,7 @@ if isServer then
         end
 
         local netId = NetworkGetNetworkIdFromEntity(veh)
-        TriggerEvent('qbx_core:server:vehicleSpawned', veh)
+        exports.qbx_core:EnablePersistence(veh)
         return netId, veh
     end
 else

--- a/modules/lib.lua
+++ b/modules/lib.lua
@@ -316,7 +316,7 @@ if isServer then
         end
 
         local netId = NetworkGetNetworkIdFromEntity(veh)
-        TriggerServerEvent('qbx_core:server:vehicleSpawned', veh)
+        TriggerEvent('qbx_core:server:vehicleSpawned', veh)
         return netId, veh
     end
 else

--- a/modules/lib.lua
+++ b/modules/lib.lua
@@ -316,7 +316,7 @@ if isServer then
         end
 
         local netId = NetworkGetNetworkIdFromEntity(veh)
-
+        TriggerServerEvent('qbx_core:server:vehicleSpawned', veh)
         return netId, veh
     end
 else

--- a/server/commands.lua
+++ b/server/commands.lua
@@ -146,7 +146,7 @@ lib.addCommand('car', {
     local keepCurrentVehicle = args[locale('command.car.params.keepCurrentVehicle.name')]
     local currentVehicle = not keepCurrentVehicle and GetVehiclePedIsIn(ped, false)
     if currentVehicle and currentVehicle ~= 0 then
-        DeleteEntity(currentVehicle)
+        DeleteVehicle(currentVehicle)
     end
 
     local _, vehicle = qbx.spawnVehicle({
@@ -180,7 +180,7 @@ lib.addCommand('dv', {
         for i = 1, #pedCars do
             local pedCar = NetworkGetEntityFromNetworkId(pedCars[i])
             if pedCar and DoesEntityExist(pedCar) then
-                DeleteEntity(pedCar)
+                DeleteVehicle(pedCar)
             end
         end
     end

--- a/server/functions.lua
+++ b/server/functions.lua
@@ -488,9 +488,7 @@ exports('GetGroupMembers', getGroupMembers)
 ---Disables persistence before deleting a vehicle, then deletes it.
 ---@param vehicle number
 function DeleteVehicle(vehicle)
-    if DisablePersistence then
-        DisablePersistence(vehicle)
-    end
+    DisablePersistence(vehicle)
     if DoesEntityExist(vehicle) then
         DeleteEntity(vehicle)
     end

--- a/server/functions.lua
+++ b/server/functions.lua
@@ -484,3 +484,16 @@ local function getGroupMembers(group, type)
 end
 
 exports('GetGroupMembers', getGroupMembers)
+
+---Disables persistence before deleting a vehicle, then deletes it.
+---@param vehicle number
+local function deleteVehicle(vehicle)
+    if DisablePersistence then
+        DisablePersistence(vehicle)
+    end
+    if DoesEntityExist(vehicle) then
+        DeleteEntity(vehicle)
+    end
+end
+
+exports('DeleteVehicle', deleteVehicle)

--- a/server/functions.lua
+++ b/server/functions.lua
@@ -487,7 +487,7 @@ exports('GetGroupMembers', getGroupMembers)
 
 ---Disables persistence before deleting a vehicle, then deletes it.
 ---@param vehicle number
-local function deleteVehicle(vehicle)
+function DeleteVehicle(vehicle)
     if DisablePersistence then
         DisablePersistence(vehicle)
     end
@@ -496,4 +496,4 @@ local function deleteVehicle(vehicle)
     end
 end
 
-exports('DeleteVehicle', deleteVehicle)
+exports('DeleteVehicle', DeleteVehicle)

--- a/server/vehicle-persistence.lua
+++ b/server/vehicle-persistence.lua
@@ -93,9 +93,9 @@ AddEventHandler('entityRemoved', function(entity)
     local vehicleId = getVehicleId(entity)
     if not vehicleId then return end
     local playerVehicle = exports.qbx_vehicles:GetPlayerVehicle(vehicleId)
-    Entity(entity).state:set('persisted', nil, true)
 
     if DoesEntityExist(entity) then
+        Entity(entity).state:set('persisted', nil, true)
         DeleteVehicle(entity)
     end
 

--- a/server/vehicle-persistence.lua
+++ b/server/vehicle-persistence.lua
@@ -1,0 +1,96 @@
+if GetConvar('qbx:enable_vehicle_persistence', 'true') == 'false' then return end
+
+assert(lib.checkDependency('qbx_vehicles', '1.4.1', true))
+
+local function getVehicleId(vehicle)
+    return Entity(vehicle).state.vehicleid or exports.qbx_vehicles:GetVehicleByIdPlate(GetVehicleNumberPlateText(vehicle))
+end
+
+RegisterNetEvent('qbx_core:server:vehiclePropsChanged', function(netId, diff)
+    local vehicle = NetworkGetEntityFromNetworkId(netId)
+
+    local vehicleId = getVehicleId(vehicle)
+    if not vehicleId then return end
+
+    local props = exports.qbx_vehicles:GetPlayerVehicle(vehicleId)?.props
+    if not props then return end
+
+    if diff.bodyHealth then
+        props.bodyHealth = GetVehicleBodyHealth(vehicle)
+    end
+
+    if diff.engineHealth then
+        props.engineHealth = GetVehicleEngineHealth(vehicle)
+    end
+
+    if diff.tankHealth then
+        props.tankHealth = GetVehiclePetrolTankHealth(vehicle)
+    end
+
+    if diff.fuelLevel then
+        props.fuelLevel = diff.fuelLevel ~= 'deleted' and diff.fuelLevel or nil
+    end
+
+    if diff.oilLevel then
+        props.oilLevel = diff.oilLevel ~= 'deleted' and diff.oilLevel or nil
+    end
+
+    if diff.dirtLevel then
+        props.dirtLevel = GetVehicleDirtLevel(vehicle)
+    end
+
+    if diff.windows then
+        props.windows = diff.windows ~= 'deleted' and diff.windows or nil
+    end
+
+    if diff.doors then
+        local damage = {}
+        local numDoors = 0
+
+        for i = 0, 5 do
+            if IsVehicleDoorDamaged(vehicle, i) then
+                numDoors += 1
+                damage[numDoors] = i
+            end
+        end
+
+        props.doors = damage
+    end
+
+    if diff.tyres then
+        local damage = {}
+        for i = 0, 7 do
+            if IsVehicleTyreBurst(vehicle, i, false) then
+                damage[i] = IsVehicleTyreBurst(vehicle, i, true) and 2 or 1
+            end
+        end
+
+        props.tyres = damage
+    end
+
+    exports.qbx_vehicles:SaveVehicle(vehicle, {
+        props = props,
+    })
+end)
+
+AddEventHandler('entityRemoved', function(entity)
+    if not IsEntityAVehicle(entity) then return end
+    local coords = GetEntityCoords(entity)
+    local heading = GetEntityHeading(entity)
+    local bucket = GetEntityRoutingBucket(entity)
+
+    local vehicleId = getVehicleId(entity)
+    if not vehicleId then return end
+    local playerVehicle = exports.qbx_vehicles:GetPlayerVehicle(vehicleId)
+
+    if DoesEntityExist(entity) then
+        DeleteVehicle(entity)
+    end
+
+    qbx.spawnVehicle({
+        model = playerVehicle.props.model,
+        spawnSource = vec4(coords.x, coords.y, coords.z, heading),
+        bucket = bucket,
+        props = playerVehicle.props
+    })
+end)

--- a/server/vehicle-persistence.lua
+++ b/server/vehicle-persistence.lua
@@ -1,7 +1,3 @@
-if GetConvar('qbx:enable_vehicle_persistence', 'false') == 'false' then return end
-
-assert(lib.checkDependency('qbx_vehicles', '1.4.1', true))
-
 ---A persisted vehicle will respawn when deleted. Only works for player owned vehicles.
 ---Vehicles spawned using lib are automatically persisted
 ---@param vehicle number
@@ -18,6 +14,10 @@ function DisablePersistence(vehicle)
 end
 
 exports('DisablePersistence', DisablePersistence)
+
+if GetConvar('qbx:enable_vehicle_persistence', 'false') == 'false' then return end
+
+assert(lib.checkDependency('qbx_vehicles', '1.4.1', true))
 
 local function getVehicleId(vehicle)
     return Entity(vehicle).state.vehicleid or exports.qbx_vehicles:GetVehicleIdByPlate(GetVehicleNumberPlateText(vehicle))
@@ -78,10 +78,6 @@ RegisterNetEvent('qbx_core:server:vehiclePropsChanged', function(netId, diff)
     exports.qbx_vehicles:SaveVehicle(vehicle, {
         props = props,
     })
-end)
-
-AddEventHandler('qbx_core:server:vehicleSpawned', function(entity)
-    Entity(entity).state:set('persisted', true, true)
 end)
 
 local function getPedsInVehicleSeats(vehicle)

--- a/server/vehicle-persistence.lua
+++ b/server/vehicle-persistence.lua
@@ -1,4 +1,4 @@
-if GetConvar('qbx:enable_vehicle_persistence', 'true') == 'false' then return end
+if GetConvar('qbx:enable_vehicle_persistence', 'false') == 'false' then return end
 
 assert(lib.checkDependency('qbx_vehicles', '1.4.1', true))
 

--- a/server/vehicle-persistence.lua
+++ b/server/vehicle-persistence.lua
@@ -15,7 +15,7 @@ end
 
 exports('DisablePersistence', DisablePersistence)
 
-if GetConvar('qbx:enable_vehicle_persistence', 'false') == 'false' then return end
+if GetConvar('qbx:enableVehiclePersistence', 'false') == 'false' then return end
 
 assert(lib.checkDependency('qbx_vehicles', '1.4.1', true))
 

--- a/server/vehicle-persistence.lua
+++ b/server/vehicle-persistence.lua
@@ -20,7 +20,7 @@ end
 exports('DisablePersistence', DisablePersistence)
 
 local function getVehicleId(vehicle)
-    return Entity(vehicle).state.vehicleid or exports.qbx_vehicles:GetVehicleByIdPlate(GetVehicleNumberPlateText(vehicle))
+    return Entity(vehicle).state.vehicleid or exports.qbx_vehicles:GetVehicleIdByPlate(GetVehicleNumberPlateText(vehicle))
 end
 
 RegisterNetEvent('qbx_core:server:vehiclePropsChanged', function(netId, diff)

--- a/server/vehicle-persistence.lua
+++ b/server/vehicle-persistence.lua
@@ -44,17 +44,7 @@ RegisterNetEvent('qbx_core:server:vehiclePropsChanged', function(netId, diff)
     end
 
     if diff.doors then
-        local damage = {}
-        local numDoors = 0
-
-        for i = 0, 5 do
-            if IsVehicleDoorDamaged(vehicle, i) then
-                numDoors += 1
-                damage[numDoors] = i
-            end
-        end
-
-        props.doors = damage
+        props.doors = diff.doors ~= 'deleted' and diff.doors or nil
     end
 
     if diff.tyres then
@@ -74,7 +64,6 @@ RegisterNetEvent('qbx_core:server:vehiclePropsChanged', function(netId, diff)
 end)
 
 AddEventHandler('entityRemoved', function(entity)
-    if not IsEntityAVehicle(entity) then return end
     local coords = GetEntityCoords(entity)
     local heading = GetEntityHeading(entity)
     local bucket = GetEntityRoutingBucket(entity)


### PR DESCRIPTION
fixes #567 

Implements design as described in #567
- Tested
- persistence is disabled by default, requires convar to opt-in.
- Changed places where we delete a vehicle in core to use the new core export.
- We'll need to change other Qbox resources to use the DeleteVehicle export to delete vehicles. This export allows the vehicle to be deleted without being respawned by persistence and works even if persistence is disabled via convar.

Adds new exports
- EnablePersistence
- DisablePersistence
- DeleteVehicle