### PR TITLE
fix(locales/et): SetGang command broken for Estonian users

### DIFF
--- a/locales/et.json
+++ b/locales/et.json
@@ -154,7 +154,7 @@
             "help": "Määra mängija grupeeringu (ainult administraator)",
             "params": {
                 "id": { "name": "id", "help": "Player ID" },
-                "gang": { "name": "tase", "help": "Grupeeringu nimi" },
+                "gang": { "name": "jõuk", "help": "Grupeeringu nimi" },
                 "grade": { "name": "tase", "help": "Grupeeringu tase" }
             }
         },


### PR DESCRIPTION
- Arguments of a command cannot be named the same