### PR TITLE
fix(client/main): hash model names when passing classes to server

### DIFF
--- a/client/main.lua
+++ b/client/main.lua
@@ -70,7 +70,7 @@ lib.callback.register('qbx_core:client:getVehicleClasses', function()
     for i = 1, #models do
         local model = models[i]
         local class = GetVehicleClassFromName(model)
-        classes[model] = class
+        classes[joaat(model)] = class
     end
     return classes
 end)


### PR DESCRIPTION
## Description

<!-- What does your pull request change? Why should it be merged? Does it fix an issue? -->

Hashes the vehicle model name before adding it to the table of vehicle classes that will be passed to the server. This seems to be the intention as the server-side `GetVehicleClass` function is documented to take a number for a model, not a string.

## Checklist

<!-- Put an x inside the [ ] to check an item, like so: [x] -->

- [x] I have personally loaded this code into an updated Qbox project and checked all of its functionality.
- [x] My pull request fits the contribution guidelines & code conventions.
