### PR TITLE
fix(server/main): prevent multiple vehicle classes requests to client

### DIFF
--- a/server/main.lua
+++ b/server/main.lua
@@ -42,9 +42,9 @@ local vehicleClasses = nil
 local vehicleClassesPromise = nil
 
 ---Caches the vehicle classes the first time this is called by getting the data from a random client.
----Returns nil if there is no cache and no client is connected to get the data from.
+---Throws an error if there is no cache and no client is connected to get the data from.
 ---@param model number
----@return VehicleClass?
+---@return VehicleClass
 function GetVehicleClass(model)
     if not vehicleClasses then
         if vehicleClassesPromise then
@@ -64,11 +64,14 @@ function GetVehicleClass(model)
                 end)
             until vehicleClasses
 
+            if not vehicleClasses then
+                local message = 'no clients online'
+                vehicleClassesPromise:reject(message)
+                vehicleClassesPromise = nil
+                error(message)
+            end
+
             vehicleClassesPromise:resolve()
-        end
-        -- if it's still `nil` the callbacks must've failed and there are no players
-        if not vehicleClasses then
-            return
         end
     end
     return vehicleClasses[model]

--- a/server/main.lua
+++ b/server/main.lua
@@ -38,8 +38,8 @@ QBX.UsableItems = {}
 ---@alias Model number
 ---@alias VehicleClass integer see https://docs.fivem.net/natives/?_0x29439776AAA00A62
 ---@type table<Model, VehicleClass>
-local vehicleClasses = nil
-local vehicleClassesPromise = nil
+local vehicleClasses
+local vehicleClassesPromise
 
 ---Caches the vehicle classes the first time this is called by getting the data from a random client.
 ---Throws an error if there is no cache and no client is connected to get the data from.

--- a/server/main.lua
+++ b/server/main.lua
@@ -53,13 +53,16 @@ function GetVehicleClass(model)
             -- lib.callback.await is async, so let additional callers wait along instead of awaiting new callbacks
             vehicleClassesPromise = promise:new()
 
-            local players = GetPlayers()
-            if #players == 0 then return end
-            local playerId = players[math.random(#players)]
-            -- this *may* fail, but we still need to resolve our promise
-            pcall(function()
-                vehicleClasses = lib.callback.await('qbx_core:client:getVehicleClasses', playerId)
-            end)
+            -- keep asking different players until we get an answer or until there are no players
+            repeat
+                local players = GetPlayers()
+                if #players == 0 then break end
+                local playerId = players[math.random(#players)]
+                -- this *may* fail, but we still need to resolve our promise
+                pcall(function()
+                    vehicleClasses = lib.callback.await('qbx_core:client:getVehicleClasses', playerId)
+                end)
+            until vehicleClasses
 
             vehicleClassesPromise:resolve()
         end

--- a/server/main.lua
+++ b/server/main.lua
@@ -63,6 +63,10 @@ function GetVehicleClass(model)
 
             vehicleClassesPromise:resolve()
         end
+        -- if it's still `nil` the callbacks must've failed and there are no players
+        if not vehicleClasses then
+            return
+        end
     end
     return vehicleClasses[model]
 end


### PR DESCRIPTION
## Description

<!-- What does your pull request change? Why should it be merged? Does it fix an issue? -->

This fixes 3 issues:
- Calls to this function would *always* send a new client callback for vehicle classes, since non-array tables don't have a length. Fixed by assigning `nil` at first and checking for that.
- `lib.callback.await` is async. This gives potential for multiple callbacks when vehicle classes aren't available, but are still being waited on by other callers. Fixed by creating a new promise, and resolving it when the callback is done.
- If the callback failed for one player, other players may still be available. Fixed by asking different players continuously until there's no players to ask.

Might need more of a discussion on the 2nd point. What should happen if the client can't answer for some reason and the callback times out? Should we return `nil` like in the current solution or throw an error?

## Checklist

<!-- Put an x inside the [ ] to check an item, like so: [x] -->

- [x] I have personally loaded this code into an updated Qbox project and checked all of its functionality.
- [x] My pull request fits the contribution guidelines & code conventions.
