### PR TITLE
feat: entity session id

### DIFF
--- a/server/main.lua
+++ b/server/main.lua
@@ -41,23 +41,16 @@ QBX.UsableItems = {}
 local vehicleClasses
 local vehicleClassesPromise
 
-local currentSessionId = 1
-local sessionIdLock = false
+local currentSessionId = 0
 
 ---Sets a unique sessionId statebag on the entity.
 ---@param entity number
 ---@return integer sessionId
 local function createSessionId(entity)
-    if sessionIdLock then
-        lib.waitFor(function()
-            if not sessionIdLock then return true end
-        end, 'timed out acquiring sessionId lock')
-    end
-    sessionIdLock = true
-    Entity(entity).state:set('sessionId', currentSessionId, true)
     currentSessionId += 1
-    sessionIdLock = false
-    return currentSessionId - 1
+    local sessionId = currentSessionId
+    Entity(entity).state:set('sessionId', sessionId, true)
+    return sessionId
 end
 
 exports('CreateSessionId', createSessionId)

--- a/server/main.lua
+++ b/server/main.lua
@@ -47,7 +47,7 @@ local sessionIdLock = false
 ---Sets a unique sessionId statebag on the entity.
 ---@param entity number
 ---@return integer sessionId
-local function setSessionId(entity)
+local function createSessionId(entity)
     if sessionIdLock then
         lib.waitFor(function()
             if not sessionIdLock then return true end
@@ -60,7 +60,7 @@ local function setSessionId(entity)
     return currentSessionId - 1
 end
 
-exports('SetSessionId', setSessionId)
+exports('CreateSessionId', createSessionId)
 
 ---Caches the vehicle classes the first time this is called by getting the data from a random client.
 ---Throws an error if there is no cache and no client is connected to get the data from.

--- a/server/main.lua
+++ b/server/main.lua
@@ -41,26 +41,26 @@ QBX.UsableItems = {}
 local vehicleClasses
 local vehicleClassesPromise
 
-local currentVehicleSessionId = 1
-local vehicleSessionIdLock = false
+local currentSessionId = 1
+local sessionIdLock = false
 
----Sets a unique vehicleSessionId statebag on the vehicle entity. This will follow the vehicle if it is recreated by persistence.
----@param vehicle number
----@return integer vehicleSessionId
-local function setVehicleSessionId(vehicle)
-    if vehicleSessionIdLock then
+---Sets a unique sessionId statebag on the entity.
+---@param entity number
+---@return integer sessionId
+local function setSessionId(entity)
+    if sessionIdLock then
         lib.waitFor(function()
-            if not vehicleSessionIdLock then return true end
-        end, 'timed out acquiring vehicleSessionIdLock')
+            if not sessionIdLock then return true end
+        end, 'timed out acquiring sessionId lock')
     end
-    vehicleSessionIdLock = true
-    Entity(vehicle).state:set('vehicleSessionId', currentVehicleSessionId, true)
-    currentVehicleSessionId += 1
-    vehicleSessionIdLock = false
-    return currentVehicleSessionId - 1
+    sessionIdLock = true
+    Entity(entity).state:set('sessionId', currentSessionId, true)
+    currentSessionId += 1
+    sessionIdLock = false
+    return currentSessionId - 1
 end
 
-exports('SetVehicleSessionId', setVehicleSessionId)
+exports('SetSessionId', setSessionId)
 
 ---Caches the vehicle classes the first time this is called by getting the data from a random client.
 ---Throws an error if there is no cache and no client is connected to get the data from.

--- a/server/main.lua
+++ b/server/main.lua
@@ -42,10 +42,21 @@ local vehicleClasses
 local vehicleClassesPromise
 
 local currentVehicleSessionId = 1
+local vehicleSessionIdLock = false
 
+---Sets a unique vehicleSessionId statebag on the vehicle entity. This will follow the vehicle if it is recreated by persistence.
+---@param vehicle number
+---@return integer vehicleSessionId
 local function setVehicleSessionId(vehicle)
+    if vehicleSessionIdLock then
+        lib.waitFor(function()
+            if not vehicleSessionIdLock then return true end
+        end, 'timed out acquiring vehicleSessionIdLock')
+    end
+    vehicleSessionIdLock = true
     Entity(vehicle).state:set('vehicleSessionId', currentVehicleSessionId, true)
     currentVehicleSessionId += 1
+    vehicleSessionIdLock = false
     return currentVehicleSessionId - 1
 end
 

--- a/server/main.lua
+++ b/server/main.lua
@@ -41,6 +41,16 @@ QBX.UsableItems = {}
 local vehicleClasses
 local vehicleClassesPromise
 
+local currentVehicleSessionId = 1
+
+local function setVehicleSessionId(vehicle)
+    Entity(vehicle).state:set('vehicleSessionId', currentVehicleSessionId, true)
+    currentVehicleSessionId += 1
+    return currentVehicleSessionId - 1
+end
+
+exports('SetVehicleSessionId', setVehicleSessionId)
+
 ---Caches the vehicle classes the first time this is called by getting the data from a random client.
 ---Throws an error if there is no cache and no client is connected to get the data from.
 ---@param model number

--- a/server/vehicle-persistence.lua
+++ b/server/vehicle-persistence.lua
@@ -106,7 +106,7 @@ AddEventHandler('entityRemoved', function(entity)
     local vehicleId = getVehicleId(entity)
     if not vehicleId then return end
 
-    local vehicleSessionId = Entity(entity).state.vehicleSessionId
+    local sessionId = Entity(entity).state.sessionId
     local playerVehicle = exports.qbx_vehicles:GetPlayerVehicle(vehicleId)
 
     if DoesEntityExist(entity) then
@@ -121,7 +121,7 @@ AddEventHandler('entityRemoved', function(entity)
         props = playerVehicle.props
     })
 
-    Entity(veh).state:set('vehicleSessionId', vehicleSessionId, true)
+    Entity(veh).state:set('sessionId', sessionId, true)
     Entity(veh).state:set('vehicleid', vehicleId, false)
 
     for i = 1, #passengers do

--- a/server/vehicle-persistence.lua
+++ b/server/vehicle-persistence.lua
@@ -105,6 +105,8 @@ AddEventHandler('entityRemoved', function(entity)
 
     local vehicleId = getVehicleId(entity)
     if not vehicleId then return end
+
+    local vehicleSessionId = Entity(entity).state.vehicleSessionId
     local playerVehicle = exports.qbx_vehicles:GetPlayerVehicle(vehicleId)
 
     if DoesEntityExist(entity) then
@@ -118,6 +120,9 @@ AddEventHandler('entityRemoved', function(entity)
         bucket = bucket,
         props = playerVehicle.props
     })
+
+    Entity(veh).state:set('vehicleSessionId', vehicleSessionId, true)
+    Entity(veh).state:set('vehicleid', vehicleId, false)
 
     for i = 1, #passengers do
         local passenger = passengers[i]


### PR DESCRIPTION
We need a stable vehicle identifier that works for both NPC and player owned vehicles. vehicleid already represents player owned vehicles, so overloading it could cause issues with scripts relying on this behavior. netId would not be stable for persisted vehicles, which have their entities deleted and spawned.

Therefore this PR is introducing a sessionId, which will be incremented starting by 1 to guarantee uniqueness. This will be set via a new export CreateSessionId on the vehicle's state bag, which acquires a lock to guarantee that no two vehicles are assigned the same id. This will be persisted during vehicle persistence.

Also sneaking in a fix to persist vehicleid during vehicle persistence as I realize we never did that before.

While this is being introduced for vehicles, it is being introduced as a generic feature that could be used for any entity. This may prove useful for other applications which want a unique id to reference when those entities may be deleted and re-created.