### PR TITLE
fix: make calling createSessionId for the same entity return the same id

### DIFF
--- a/server/main.lua
+++ b/server/main.lua
@@ -43,10 +43,14 @@ local vehicleClassesPromise
 
 local currentSessionId = 0
 
----Sets a unique sessionId statebag on the entity.
+---Sets a unique sessionId statebag on the entity. If the entity already has a sessionId, this will return it.
 ---@param entity number
 ---@return integer sessionId
 local function createSessionId(entity)
+    local existingSessionId = Entity(entity).state.sessionId
+    if existingSessionId then
+        return existingSessionId
+    end
     currentSessionId += 1
     local sessionId = currentSessionId
     Entity(entity).state:set('sessionId', sessionId, true)

--- a/server/main.lua
+++ b/server/main.lua
@@ -43,7 +43,8 @@ local vehicleClassesPromise
 
 local currentSessionId = 0
 
----Sets a unique sessionId statebag on the entity. If the entity already has a sessionId, this will return it.
+---Sets a unique sessionId statebag on the entity.
+---If the entity already has a sessionId, this will return it rather than overwrite.
 ---@param entity number
 ---@return integer sessionId
 local function createSessionId(entity)


### PR DESCRIPTION
Current behavior is that it will overwrite. This just saves callers from needing to check if a sessionId already exists before creating one and adds some protection to bugs that would be caused by doing so.