### PR TITLE
fix(server/loops): correctly skip if society is too low

### DIFF
--- a/server/loops.lua
+++ b/server/loops.lua
@@ -32,7 +32,7 @@ local function pay(player)
         return
     end
     local account = config.getSocietyAccount(job.name)
-    if not account or account == 0 then -- Checks if player is employed by a society
+    if not account then -- Checks if player is employed by a society
         config.sendPaycheck(player, payment)
         return
     end


### PR DESCRIPTION

## Description

<!-- What does your pull request change? Why should it be merged? Does it fix an issue? -->

Fixes erroneous issue where if society account has zero dollars it will still issue a paycheck

## Checklist

<!-- Put an x inside the [ ] to check an item, like so: [x] -->

- [ ] I have personally loaded this code into an updated Qbox project and checked all of its functionality.
- [x] My pull request fits the contribution guidelines & code conventions.
