### PR TITLE
fix(storage/players): Avoid json decoding error when a citizenid doesn't exist

### DIFF
--- a/server/storage/players.lua
+++ b/server/storage/players.lua
@@ -112,7 +112,7 @@ end
 local function fetchPlayerEntity(citizenId)
     ---@type PlayerEntityDatabase
     local player = MySQL.single.await('SELECT citizenid, license, name, charinfo, money, job, gang, position, metadata, UNIX_TIMESTAMP(last_logged_out) AS lastLoggedOutUnix FROM players WHERE citizenid = ?', { citizenId })
-    local charinfo = json.decode(player.charinfo)
+    local charinfo = player and json.decode(player.charinfo)
     return player and {
         citizenid = player.citizenid,
         license = player.license,


### PR DESCRIPTION
## Description
Fixes an issue where a JSON decoding error is thrown when a `citizenid` isn't present in the `players` table when attempting to fetch a player entity.

## Checklist

<!-- Put an x inside the [ ] to check an item, like so: [x] -->

- [x] I have personally loaded this code into an updated Qbox project and checked all of its functionality.
- [x] My pull request fits the contribution guidelines & code conventions.
