### PR TITLE
feat(client): Display player's first character ped...

### DIFF
--- a/client/character.lua
+++ b/client/character.lua
@@ -105,11 +105,9 @@ local randomPeds = {
 local nationalities = {}
 
 if config.characters.limitNationalities then
-    local nationalityList = lib.load('data.nationalities')
-
     CreateThread(function()
-        for i = 1, #nationalityList do
-            nationalities[#nationalities + 1] = { value = nationalityList[i] }
+        for i = 1, #config.characters.nationalities do
+            nationalities[#nationalities + 1] = {value = config.characters.nationalities[i]}
         end
     end)
 end
@@ -153,9 +151,11 @@ local function randomPed()
     pcall(function() exports['illenium-appearance']:setPedAppearance(PlayerPedId(), ped) end)
     SetModelAsNoLongerNeeded(ped.model)
 end
-
 ---@param citizenId? string
 local function previewPed(citizenId)
+    local citizenId = citizenId
+    local characters, amount = lib.callback.await('qbx_core:server:getCharacters')
+    if characters[1] and not citizenId then citizenId = characters[1].citizenid end
     if not citizenId then randomPed() return end
 
     local clothing, model = lib.callback.await('qbx_core:server:getPreviewPedData', false, citizenId)
@@ -496,6 +496,7 @@ end)
 
 RegisterNetEvent('qbx_core:client:playerLoggedOut', function()
     if GetInvokingResource() then return end -- Make sure this can only be triggered from the server
+    previewPed()
     chooseCharacter()
 end)
 
@@ -505,7 +506,7 @@ CreateThread(function()
         if NetworkIsSessionStarted() then
             pcall(function() exports.spawnmanager:setAutoSpawn(false) end)
             Wait(250)
-            randomPed()
+            previewPed()
             chooseCharacter()
             break
         end

--- a/client/character.lua
+++ b/client/character.lua
@@ -1,6 +1,6 @@
 local config = require 'config.client'
 local defaultSpawn = require 'config.shared'.defaultSpawn
-
+local characters, amount = nil, nil
 if config.characters.useExternalCharacters then return end
 
 local previewCam
@@ -153,8 +153,7 @@ local function randomPed()
 end
 ---@param citizenId? string
 local function previewPed(citizenId)
-    local characters = lib.callback.await('qbx_core:server:getCharacters')
-    if characters[1] and not citizenId then citizenId = characters[1].citizenid end
+    if not citizenId and characters[1] then citizenId = characters[1].citizenid end
     if not citizenId then randomPed() return end
 
     local clothing, model = lib.callback.await('qbx_core:server:getPreviewPedData', false, citizenId)
@@ -379,7 +378,7 @@ local function chooseCharacter()
     setupPreviewCam()
 
     ---@type PlayerEntity[], integer
-    local characters, amount = lib.callback.await('qbx_core:server:getCharacters')
+    characters, amount = lib.callback.await('qbx_core:server:getCharacters')
     local options = {}
     for i = 1, amount do
         local character = characters[i]
@@ -495,8 +494,8 @@ end)
 
 RegisterNetEvent('qbx_core:client:playerLoggedOut', function()
     if GetInvokingResource() then return end -- Make sure this can only be triggered from the server
-    previewPed()
     chooseCharacter()
+    previewPed()
 end)
 
 CreateThread(function()
@@ -505,8 +504,8 @@ CreateThread(function()
         if NetworkIsSessionStarted() then
             pcall(function() exports.spawnmanager:setAutoSpawn(false) end)
             Wait(250)
-            previewPed()
             chooseCharacter()
+            previewPed()
             break
         end
     end

--- a/client/character.lua
+++ b/client/character.lua
@@ -1,6 +1,5 @@
 local config = require 'config.client'
 local defaultSpawn = require 'config.shared'.defaultSpawn
-local characters, amount = lib.callback.await('qbx_core:server:getCharacters')
 
 if config.characters.useExternalCharacters then return end
 
@@ -155,6 +154,7 @@ end
 ---@param citizenId? string
 local function previewPed(citizenId)
     local cID = citizenId
+    local characters = lib.callback.await('qbx_core:server:getCharacters')
     if characters[1] and not cID then cID = characters[1].citizenid end
     if not cID then randomPed() return end
 
@@ -380,6 +380,7 @@ local function chooseCharacter()
     setupPreviewCam()
 
     ---@type PlayerEntity[], integer
+    local characters, amount = lib.callback.await('qbx_core:server:getCharacters')
     local options = {}
     for i = 1, amount do
         local character = characters[i]

--- a/client/character.lua
+++ b/client/character.lua
@@ -153,12 +153,11 @@ local function randomPed()
 end
 ---@param citizenId? string
 local function previewPed(citizenId)
-    local cID = citizenId
     local characters = lib.callback.await('qbx_core:server:getCharacters')
-    if characters[1] and not cID then cID = characters[1].citizenid end
-    if not cID then randomPed() return end
+    if characters[1] and not citizenId then citizenId = characters[1].citizenid end
+    if not citizenId then randomPed() return end
 
-    local clothing, model = lib.callback.await('qbx_core:server:getPreviewPedData', false, cID)
+    local clothing, model = lib.callback.await('qbx_core:server:getPreviewPedData', false, citizenId)
     if model and clothing then
         lib.requestModel(model, config.loadingModelsTimeout)
         SetPlayerModel(cache.playerId, model)

--- a/client/character.lua
+++ b/client/character.lua
@@ -105,9 +105,10 @@ local randomPeds = {
 local nationalities = {}
 
 if config.characters.limitNationalities then
+    local nationalityList = lib.load('data.nationalities')
     CreateThread(function()
-        for i = 1, #config.characters.nationalities do
-            nationalities[#nationalities + 1] = {value = config.characters.nationalities[i]}
+        for i = 1, #nationalityList do
+            nationalities[#nationalities + 1] = { value = nationalityList[i] }
         end
     end)
 end

--- a/client/character.lua
+++ b/client/character.lua
@@ -1,5 +1,6 @@
 local config = require 'config.client'
 local defaultSpawn = require 'config.shared'.defaultSpawn
+local characters, amount = lib.callback.await('qbx_core:server:getCharacters')
 
 if config.characters.useExternalCharacters then return end
 
@@ -154,7 +155,6 @@ end
 ---@param citizenId? string
 local function previewPed(citizenId)
     local cID = citizenId
-    local characters = lib.callback.await('qbx_core:server:getCharacters')
     if characters[1] and not cID then cID = characters[1].citizenid end
     if not cID then randomPed() return end
 
@@ -380,7 +380,6 @@ local function chooseCharacter()
     setupPreviewCam()
 
     ---@type PlayerEntity[], integer
-    local characters, amount = lib.callback.await('qbx_core:server:getCharacters')
     local options = {}
     for i = 1, amount do
         local character = characters[i]

--- a/client/character.lua
+++ b/client/character.lua
@@ -153,12 +153,12 @@ local function randomPed()
 end
 ---@param citizenId? string
 local function previewPed(citizenId)
-    local citizenId = citizenId
-    local characters, amount = lib.callback.await('qbx_core:server:getCharacters')
-    if characters[1] and not citizenId then citizenId = characters[1].citizenid end
-    if not citizenId then randomPed() return end
+    local cID = citizenId
+    local characters = lib.callback.await('qbx_core:server:getCharacters')
+    if characters[1] and not cID then cID = characters[1].citizenid end
+    if not cID then randomPed() return end
 
-    local clothing, model = lib.callback.await('qbx_core:server:getPreviewPedData', false, citizenId)
+    local clothing, model = lib.callback.await('qbx_core:server:getPreviewPedData', false, cID)
     if model and clothing then
         lib.requestModel(model, config.loadingModelsTimeout)
         SetPlayerModel(cache.playerId, model)


### PR DESCRIPTION

## Description

Display's the player's first character -if it exists- instead of a random ped. If there is no characters, it displays a random Ped as the default does.
The video: [in discord](https://discord.com/channels/1012753553418354748/1031968831595352085/1296531683612557313)
## Checklist


- [ x ] I have personally loaded this code into an updated Qbox project and checked all of its functionality.
- [ x ] My pull request fits the contribution guidelines & code conventions.
