### PR TITLE
Update qbx_core.sql

### DIFF
--- a/qbx_core.sql
+++ b/qbx_core.sql
@@ -20,7 +20,7 @@ CREATE TABLE IF NOT EXISTS `players` (
 ) ENGINE=InnoDB AUTO_INCREMENT=1 DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
 
 ALTER TABLE `players`
-ADD IF NOT EXISTS `last_logged_out` timestamp NULL DEFAULT NULL AFTER `last_updated`,
+ADD `last_logged_out` timestamp NULL DEFAULT NULL AFTER `last_updated`,
 MODIFY COLUMN `name` varchar(50) NOT NULL COLLATE utf8mb4_unicode_ci;
 
 CREATE TABLE IF NOT EXISTS `bans` (


### PR DESCRIPTION
ADD IF NOT EXISTS is invalid syntax, the IF NOT EXISTS is not needed. This line currently breaks the DB from being setup properly during install.

## Description

Currently the code attempted to use ADD IF NOT EXISTS to add a row to the user table. However, this syntax is not valid and causes an error during the installation when it sets up the database using the TXAdmin recipe.

## Checklist

<!-- Put an x inside the [ ] to check an item, like so: [x] -->

- [ ] I have personally loaded this code into an updated Qbox project and checked all of its functionality.
- [x ] My pull request fits the contribution guidelines & code conventions.
