### PR TITLE
ADD IF NOT EXISTS syntax error during installation from TXAdmin Recipe

### DIFF
--- a/qbx_core.sql
+++ b/qbx_core.sql
@@ -20,7 +20,7 @@ CREATE TABLE IF NOT EXISTS `players` (
 ) ENGINE=InnoDB AUTO_INCREMENT=1 DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
 
 ALTER TABLE `players`
-ADD IF NOT EXISTS `last_logged_out` timestamp NULL DEFAULT NULL AFTER `last_updated`,
+ADD `last_logged_out` timestamp NULL DEFAULT NULL AFTER `last_updated`,
 MODIFY COLUMN `name` varchar(50) NOT NULL COLLATE utf8mb4_unicode_ci;
 
 CREATE TABLE IF NOT EXISTS `bans` (


### PR DESCRIPTION
## Description

Fixes a syntax error preventing proper database setup during installation from TXAdmin recipe. IF NOT EXISTS is improper syntax after ADD you only need the ADD and then the row you wish to add.

## Checklist

<!-- Put an x inside the [ ] to check an item, like so: [x] -->

- [x ] I have personally loaded this code into an updated Qbox project and checked all of its functionality.
- [x ] My pull request fits the contribution guidelines & code conventions.
