### PR TITLE
feat: Adding player ID to player load log output

### DIFF
--- a/server/character.lua
+++ b/server/character.lua
@@ -49,7 +49,7 @@ lib.callback.register('qbx_core:server:loadCharacter', function(source, citizenI
         color = 'green',
         message = ('**%s** (%s |  ||%s|| | %s | %s | %s) loaded'):format(GetPlayerName(source), GetPlayerIdentifierByType(source, 'discord') or 'undefined', GetPlayerIdentifierByType(source, 'ip') or 'undefined', GetPlayerIdentifierByType(source, 'license2') or GetPlayerIdentifierByType(source, 'license') or 'undefined', citizenId, source)
     })
-    lib.print.info(('%s (Citizen ID: %s) has successfully loaded!'):format(GetPlayerName(source), citizenId))
+    lib.print.info(('%s (Citizen ID: %s ID: %s) has successfully loaded!'):format(GetPlayerName(source), citizenId, source))
 end)
 
 ---@param data unknown


### PR DESCRIPTION

## Description

<!-- What does your pull request change? Why should it be merged? Does it fix an issue? -->
What: Added the player's CID to the join log. 
Why: Useful for administrative tasks and debugging.
Does it fix an issue: No

## Checklist

<!-- Put an x inside the [ ] to check an item, like so: [x] -->

- [X] I have personally loaded this code into an updated Qbox project and checked all of its functionality.

![image](https://github.com/user-attachments/assets/712b16d2-3885-445e-933c-9c34d694c4e6)

- [X] My pull request fits the contribution guidelines & code conventions.
