### PR TITLE
fix(client/config): adjust to match ox_lib

### DIFF
--- a/config/client.lua
+++ b/config/client.lua
@@ -1,6 +1,6 @@
 return {
     statusIntervalSeconds = 5, -- how often to check hunger/thirst status to remove health if 0.
-    loadingModelsTimeout = 10000, -- Waiting time for ox_lib to load the models before throws an error, for low specs pc
+    loadingModelsTimeout = 30000, -- Waiting time for ox_lib to load the models before throws an error, for low specs pc
 
     pauseMapText = 'Powered by Qbox', -- Text shown above the map when ESC is pressed. If left empty 'FiveM' will appear
 


### PR DESCRIPTION
## Description

With the new default timeout being increased to 30 seconds in ox_lib, our core config option should reflect that.

I'm also of the opinion that it can now be removed but that's up to yall.

## Checklist

- [ ] I have personally loaded this code into an updated Qbox project and checked all of its functionality.
- [x] My pull request fits the contribution guidelines & code conventions.
