### PR TITLE
fix: Add guard clause to fetchPlayerEntity

### DIFF
--- a/server/character.lua
+++ b/server/character.lua
@@ -49,7 +49,7 @@ lib.callback.register('qbx_core:server:loadCharacter', function(source, citizenI
         color = 'green',
         message = ('**%s** (%s |  ||%s|| | %s | %s | %s) loaded'):format(GetPlayerName(source), GetPlayerIdentifierByType(source, 'discord') or 'undefined', GetPlayerIdentifierByType(source, 'ip') or 'undefined', GetPlayerIdentifierByType(source, 'license2') or GetPlayerIdentifierByType(source, 'license') or 'undefined', citizenId, source)
     })
-    lib.print.info(('%s (Citizen ID: %s) has successfully loaded!'):format(GetPlayerName(source), citizenId))
+    lib.print.info(('%s (Citizen ID: %s ID: %s) has successfully loaded!'):format(GetPlayerName(source), citizenId, source))
 end)
 
 ---@param data unknown

--- a/server/storage/players.lua
+++ b/server/storage/players.lua
@@ -112,6 +112,7 @@ end
 local function fetchPlayerEntity(citizenId)
     ---@type PlayerEntityDatabase
     local player = MySQL.single.await('SELECT citizenid, license, name, charinfo, money, job, gang, position, metadata, UNIX_TIMESTAMP(last_logged_out) AS lastLoggedOutUnix FROM players WHERE citizenid = ?', { citizenId })
+    if not player then return nil end
     local charinfo = player and json.decode(player.charinfo)
     return player and {
         citizenid = player.citizenid,


### PR DESCRIPTION
## Description

<!-- What does your pull request change? Why should it be merged? Does it fix an issue? -->

Added guard clause to fetchPlayerEntity
This should be merged because when given an incorrect citizenid the function wouldn't fail gracefully and would cause a runtime error. Now nil will be returned which can be handled.

Yes, it fixes an issue.

## Checklist

<!-- Put an x inside the [ ] to check an item, like so: [x] -->

- [X] I have personally loaded this code into an updated Qbox project and checked all of its functionality.
- [X] My pull request fits the contribution guidelines & code conventions.
