### PR TITLE
fix(server/player) sanitize player name & limit to 50 chars for db constraints

### DIFF
--- a/server/player.lua
+++ b/server/player.lua
@@ -425,7 +425,7 @@ function CheckPlayerData(source, playerData)
     if source then
         playerData.source = source
         playerData.license = playerData.license or GetPlayerIdentifierByType(source --[[@as string]], 'license2') or GetPlayerIdentifierByType(source --[[@as string]], 'license')
-        playerData.name = GetPlayerName(source)
+        playerData.name = string.sub(GetPlayerName(source):gsub('[^%w%s]', ''), 1, 50)
         Offline = false
     end
 


### PR DESCRIPTION
fix(server/player) sanitize player name, limit to 50 chars for db constraints

## Description

- Fixes when players with super long names join and try to create a character, the name would be too long for the name column in the players table and cause errors. 
- Added basic string sanitization to remove any non A-Z 0-9 characters. 

Added a

## Checklist

- [x] I have personally loaded this code into an updated Qbox project and checked all of its functionality.
- [x] My pull request fits the contribution guidelines & code conventions.
