### PR TITLE
fix(vehicle-persistence): use diff provided tyres changes

### DIFF
--- a/server/vehicle-persistence.lua
+++ b/server/vehicle-persistence.lua
@@ -65,14 +65,7 @@ RegisterNetEvent('qbx_core:server:vehiclePropsChanged', function(netId, diff)
     end
 
     if diff.tyres then
-        local damage = {}
-        for i = 0, 7 do
-            if IsVehicleTyreBurst(vehicle, i, false) then
-                damage[i] = IsVehicleTyreBurst(vehicle, i, true) and 2 or 1
-            end
-        end
-
-        props.tyres = damage
+        props.tyres = diff.tyres ~= 'deleted' and diff.tyres or nil
     end
 
     exports.qbx_vehicles:SaveVehicle(vehicle, {


### PR DESCRIPTION
IsVehicleTyreBurst throws an error if the tire index does not exist and there is no server side native to check if the tire exists.
This handles tire damage the same way as windows and doors; getting the data from the client.