### PR TITLE
fix(lib): vehicle spawning reliability

### DIFF
--- a/client/events.lua
+++ b/client/events.lua
@@ -206,29 +206,24 @@ RegisterNetEvent('QBCore:Client:OnSharedUpdateMultiple', function(tableName, val
 end)
 
 -- Set vehicle props
----@param vehicle number
+---@param netId number
 ---@param props table<any, any>
-qbx.entityStateHandler('setVehicleProperties', function(vehicle, _, props)
+RegisterNetEvent('qbx_core:client:setVehicleProperties', function(netId, props)
     if not props then return end
-
-    SetTimeout(0, function()
-        local state = Entity(vehicle).state
-
-        local timeOut = GetGameTimer() + 10000
-
-        while state.setVehicleProperties do
-            if NetworkGetEntityOwner(vehicle) == cache.playerId then
-                if lib.setVehicleProperties(vehicle, props) then
-                    state:set('setVehicleProperties', nil, true)
-                end
+    local timeOut = GetGameTimer() + 1000
+    local vehicle = NetworkGetEntityFromNetworkId(netId)
+    while true do
+        if NetworkGetEntityOwner(vehicle) == cache.playerId then
+            if lib.setVehicleProperties(vehicle, props) then
+                return
             end
-            if GetGameTimer() > timeOut then
-                break
-            end
-
-            Wait(50)
         end
-    end)
+        if GetGameTimer() > timeOut then
+            return
+        end
+
+        Wait(50)
+    end
 end)
 
 -- Clear vehicle peds


### PR DESCRIPTION
## Description

After turning off ped warping, I noticed reliability issues with setting vehicle properties on spawned vehicles. This PR aims to improve this reliability and has been tested in Popcorn RP for the past week with no issues. Here are the changes:

**Consistent Ownership**: When a player is put into the driver seat of a vehicle, they become the vehicle owner, and will stay the owner, which prevents race conditions in the async communication of client/server for entity ownership. This acts as a sort of lock on entity ownership. To also have a lock on entity ownership, we assert that the entity owner does not change during prop setting. Asserting this is needed as through debugging prints I observed that multiple clients thought themselves the owner at the same time and attempted to set properties. Since we guarantee the owner is the same at the start and end of vehicle prop setting, we now contact the client via event to target the owner rather than state bag to prevent the possibility of multiple players attempting to set properties.

**Two Plate Checks**: To verify when the vehicle properties are set the server waits in a loop for the plate to be set to the expected value. This check always passes, even when no client observes the plate change. I suspect this is a FiveM bug where the property is set for a single server frame and not replicated to any clients, then it reverts. https://github.com/citizenfx/fivem/issues/2676
To solve this case, we now check twice that the plate is set correctly, 100ms apart. Doing this seems to guarantee that the server has accepted the new properties, rather than it being a transitory condition.

**Retries**: If setting the vehicle properties fails, it will retry up to 3 times before throwing an error to the caller.

**Reduced Timeout Time**: Observations seemed to indicate that vehicle properties failed fast, so waiting 5 seconds especially with retries seemed like a long time. Reduced the timeout to 1 second as the executed client/server code should be low resource usage, and round trip latency shouldn't exceed this time.

## Checklist

- [x] I have personally loaded this code into an updated Qbox project and checked all of its functionality.
- [x] My pull request fits the contribution guidelines & code conventions.
