### PR TITLE
refactor(lib): use vehicle type when spawning vehicles

### DIFF
--- a/modules/lib.lua
+++ b/modules/lib.lua
@@ -265,11 +265,14 @@ if isServer then
             coords = vec4(pedCoords.x, pedCoords.y, pedCoords.z, GetEntityHeading(source))
         end
 
-        local tempVehicle = CreateVehicle(model, 0, 0, -200, 0, true, true)
-        while not DoesEntityExist(tempVehicle) do Wait(0) end
+        local vehicleType = exports.qbx_core:GetVehiclesByHash(model).type
+        if not vehicleType then
+            local tempVehicle = CreateVehicle(model, 0, 0, -200, 0, true, true)
+            while not DoesEntityExist(tempVehicle) do Wait(0) end
 
-        local vehicleType = GetVehicleType(tempVehicle)
-        DeleteEntity(tempVehicle)
+            vehicleType = GetVehicleType(tempVehicle)
+            DeleteEntity(tempVehicle)
+        end
 
         local attempts = 0
 


### PR DESCRIPTION
Use vehicle type if it exists when spawning vehicles to avoid needing to create a temp vehicle. Still keeping the temp vehicle code as a backup in case users don't update their shared/vehicles to include types.

Dependent on https://github.com/Qbox-project/qbx_core/pull/628