### PR TITLE
fix(server/player): prevent login while already logged in

### DIFF
--- a/server/player.lua
+++ b/server/player.lua
@@ -23,6 +23,19 @@ function Login(source, citizenid, newData)
         return false
     end
 
+    if QBX.Players[source] then
+        DropPlayer(tostring(source), locale('info.exploit_dropped'))
+        logger.log({
+            source = GetInvokingResource() or cache.resource,
+            webhook = config.logging.webhook.anticheat,
+            event = 'Anti-Cheat',
+            color = 'white',
+            tags = config.logging.role,
+            message = ('%s [%s] Dropped for attempting to login twice'):format(GetPlayerName(tostring(source)), tostring(source))
+        })
+        return false
+    end
+
     local license = GetPlayerIdentifierByType(source --[[@as string]], 'license2') or GetPlayerIdentifierByType(source --[[@as string]], 'license')
     local userId = storage.fetchUserByIdentifier(license)
 
@@ -35,7 +48,7 @@ function Login(source, citizenid, newData)
         else
             DropPlayer(tostring(source), locale('info.exploit_dropped'))
             logger.log({
-                source = 'qbx_core',
+                source = GetInvokingResource() or cache.resource,
                 webhook = config.logging.webhook.anticheat,
                 event = 'Anti-Cheat',
                 color = 'white',


### PR DESCRIPTION
## Description

<!-- What does your pull request change? Why should it be merged? Does it fix an issue? -->
We don't check if players are already logged in before letting them log in. This is bad form and lets folks dupe starter items and cause other issues. This checks if players are logged in and drops them for exploiting and triggers a log message.

## Checklist

<!-- Put an x inside the [ ] to check an item, like so: [x] -->

- [ ] I have personally loaded this code into an updated Qbox project and checked all of its functionality.
- [x] My pull request fits the contribution guidelines & code conventions.
