### PR TITLE
feat(server/player): add hooks for add/remove/set money methods

### DIFF
--- a/server/player.lua
+++ b/server/player.lua
@@ -2,6 +2,7 @@ local config = require 'config.server'
 local defaultSpawn = require 'config.shared'.defaultSpawn
 local logger = require 'modules.logger'
 local storage = require 'server.storage.main'
+local triggerEventHooks = require 'modules.hooks'
 local maxJobsPerPlayer = GetConvarInt('qbx:max_jobs_per_player', 1)
 local maxGangsPerPlayer = GetConvarInt('qbx:max_gangs_per_player', 1)
 local setJobReplaces = GetConvar('qbx:setjob_replaces', 'true') == 'true'
@@ -1208,6 +1209,12 @@ function AddMoney(identifier, moneyType, amount, reason)
 
     if amount < 0 or not player.PlayerData.money[moneyType] then return false end
 
+    if not triggerEventHooks('addMoney', {
+        source = player.PlayerData.source,
+        moneyType = moneyType,
+        amount = amount
+    }) then return false end
+
     player.PlayerData.money[moneyType] += amount
 
     if not player.Offline then
@@ -1248,6 +1255,12 @@ function RemoveMoney(identifier, moneyType, amount, reason)
     amount = qbx.math.round(tonumber(amount) --[[@as number]])
 
     if amount < 0 or not player.PlayerData.money[moneyType] then return false end
+
+    if not triggerEventHooks('removeMoney', {
+        source = player.PlayerData.source,
+        moneyType = moneyType,
+        amount = amount
+    }) then return false end
 
     for _, mType in pairs(config.money.dontAllowMinus) do
         if mType == moneyType then
@@ -1297,6 +1310,12 @@ function SetMoney(identifier, moneyType, amount, reason)
     amount = qbx.math.round(tonumber(amount) --[[@as number]])
 
     if amount < 0 or not player.PlayerData.money[moneyType] then return false end
+
+    if not triggerEventHooks('setMoney', {
+        source = player.PlayerData.source,
+        moneyType = moneyType,
+        amount = amount
+    }) then return false end
 
     player.PlayerData.money[moneyType] = amount
 


### PR DESCRIPTION
## Description
This PR would add simple `addMoney`, `removeMoney`, `setMoney` hooks for player money methods. It's quite useful, especially for bankings or even other resources who work with money. 

Main reason is because at the moment to support something like `freezing player account`, we've to override `AddMoney`, `RemoveMoney` methods using `AddPlayerMethod` to override those, while trying to keep up with all the compatibility and original code support. With these hooks, new implementation would be simple:

```lua
exports.qbx_core:registerHook('addMoney', function(data)
    if data.moneyType ~= 'bank' then return true end
    
    -- check if account should be frozen, from source `data.source`
    -- return result
    
    return false
end)
```

## Checklist

- [x] I have personally loaded this code into an updated Qbox project and checked all of its functionality.
- [x] My pull request fits the contribution guidelines & code conventions.
