### PR TITLE
fix(client): ensure tutorial sessions

### DIFF
--- a/client/character.lua
+++ b/client/character.lua
@@ -102,6 +102,8 @@ local randomPeds = {
     }
 }
 
+NetworkStartSoloTutorialSession()
+
 local nationalities = {}
 
 if config.characters.limitNationalities then
@@ -370,8 +372,10 @@ local function chooseCharacter()
     SetEntityCoords(cache.ped, randomLocation.pedCoords.x, randomLocation.pedCoords.y, randomLocation.pedCoords.z, false, false, false, false)
     SetEntityHeading(cache.ped, randomLocation.pedCoords.w)
 
-    if not NetworkIsInTutorialSession() then
-        NetworkStartSoloTutorialSession()
+    NetworkStartSoloTutorialSession()
+
+    while not NetworkIsInTutorialSession() do
+        Wait(0)
     end
 
     Wait(1500)

--- a/client/events.lua
+++ b/client/events.lua
@@ -8,8 +8,10 @@ RegisterNetEvent('QBCore:Client:OnPlayerLoaded', function()
         NetworkSetFriendlyFireOption(true)
     end
 
-    if NetworkIsInTutorialSession() then
-        NetworkEndTutorialSession()
+    NetworkEndTutorialSession()
+
+    while NetworkIsInTutorialSession() do
+        Wait(0)
     end
 
     local motd = GetConvar('qbx:motd', '')


### PR DESCRIPTION
## Description

The tutorial natives still seem to be causing issues as we're still getting reports of people unable to see other players. This edit forces the script to wait until the player is in or out of the session before it continues. I've tested this on local but not with other players.

I'm unsure why we're having such a hard time with these TutorialSession natives as ox_core uses them perfectly fine.

## Checklist

- [x] I have personally loaded this code into an updated Qbox project and checked all of its functionality.
- [x] My pull request fits the contribution guidelines & code conventions.
