### PR TITLE
fix(server/player): license login check passes for license and license2

### DIFF
--- a/server/player.lua
+++ b/server/player.lua
@@ -38,8 +38,8 @@ function Login(source, citizenid, newData)
     end
 
     local license, license2 = GetPlayerIdentifierByType(source --[[@as string]], 'license'), GetPlayerIdentifierByType(source --[[@as string]], 'license2')
-    local userId = storage.fetchUserByIdentifier(license2 or license)
-
+    local userId = storage.fetchUserByIdentifier(license2) or storage.fetchUserByIdentifier(license)
+    assert(userId ~= nil, ('User does not exist. Licenses checked %s, %s'):format(license2, license))
     if citizenid then
         local playerData = storage.fetchPlayerEntity(citizenid)
         if playerData and (playerData.license == license2 or playerData.license == license) then

--- a/server/player.lua
+++ b/server/player.lua
@@ -39,7 +39,10 @@ function Login(source, citizenid, newData)
 
     local license, license2 = GetPlayerIdentifierByType(source --[[@as string]], 'license'), GetPlayerIdentifierByType(source --[[@as string]], 'license2')
     local userId = storage.fetchUserByIdentifier(license2) or storage.fetchUserByIdentifier(license)
-    assert(userId ~= nil, ('User does not exist. Licenses checked %s, %s'):format(license2, license))
+    if not userId then
+        lib.print.error('User does not exist. Licenses checked:', license2, license)
+        return false
+    end
     if citizenid then
         local playerData = storage.fetchPlayerEntity(citizenid)
         if playerData and (playerData.license == license2 or playerData.license == license) then

--- a/server/player.lua
+++ b/server/player.lua
@@ -37,15 +37,14 @@ function Login(source, citizenid, newData)
         return false
     end
 
-    local license = GetPlayerIdentifierByType(source --[[@as string]], 'license2') or GetPlayerIdentifierByType(source --[[@as string]], 'license')
-    local userId = storage.fetchUserByIdentifier(license)
+    local license, license2 = GetPlayerIdentifierByType(source --[[@as string]], 'license'), GetPlayerIdentifierByType(source --[[@as string]], 'license2')
+    local userId = storage.fetchUserByIdentifier(license2 or license)
 
     if citizenid then
         local playerData = storage.fetchPlayerEntity(citizenid)
-        if playerData and license == playerData.license then
+        if playerData and (playerData.license == license2 or playerData.license == license) then
             playerData.userId = userId
-
-            return not not CheckPlayerData(source, playerData)
+            return CheckPlayerData(source, playerData) ~= nil
         else
             DropPlayer(tostring(source), locale('info.exploit_dropped'))
             logger.log({


### PR DESCRIPTION
Fixes regression introduced by #618 which kicks players who have a license stored in database, since it doesn't check for db license matching license, only license2.