### PR TITLE
chore(fxmanifest): bump minimum required artifact version to 10731

### DIFF
--- a/fxmanifest.lua
+++ b/fxmanifest.lua
@@ -63,7 +63,7 @@ files {
 }
 
 dependencies {
-    '/server:7290',
+    '/server:10731',
     '/onesync',
     'ox_lib',
     'oxmysql',


### PR DESCRIPTION
This is the minimum version which has orphan mode, which we want to use for vehicle persistence