### PR TITLE
fix(modules/lib): set entity orphan mode on spawned vehicles to improve vehicle persistence

### DIFF
--- a/modules/lib.lua
+++ b/modules/lib.lua
@@ -341,6 +341,8 @@ if isServer then
             error('unable to successfully spawn vehicle after 3 attempts')
         end
 
+        --- prevent server from deleting a vehicle without an owner
+        SetEntityOrphanMode(veh, 2)
         exports.qbx_core:EnablePersistence(veh)
         return netId, veh
     end


### PR DESCRIPTION
This should prevent the most common cause of vehicles being deleted, increasing reliability of persistence. Dependent on https://github.com/Qbox-project/qbx_core/pull/638

Since this is a new native, it's not in the docs nor known by the linter. Added in https://github.com/citizenfx/fivem/pull/2893