### PR TITLE
Update vehicle-persistence.lua

### DIFF
--- a/server/vehicle-persistence.lua
+++ b/server/vehicle-persistence.lua
@@ -1,3 +1,7 @@
+if GetConvar('qbx:enableVehiclePersistence', 'false') == 'false' then return end
+
+assert(lib.checkDependency('qbx_vehicles', '1.4.1', true))
+
 ---A persisted vehicle will respawn when deleted. Only works for player owned vehicles.
 ---Vehicles spawned using lib are automatically persisted
 ---@param vehicle number
@@ -14,10 +18,6 @@ function DisablePersistence(vehicle)
 end
 
 exports('DisablePersistence', DisablePersistence)
-
-if GetConvar('qbx:enableVehiclePersistence', 'false') == 'false' then return end
-
-assert(lib.checkDependency('qbx_vehicles', '1.4.1', true))
 
 local function getVehicleId(vehicle)
     return Entity(vehicle).state.vehicleid or exports.qbx_vehicles:GetVehicleIdByPlate(GetVehicleNumberPlateText(vehicle))


### PR DESCRIPTION
change check if "qbx:enable Vehicle Persistence" is turned on at the beginning of the script, thus not setting state with it disabled.

## Description

<!-- What does your pull request change? Why should it be merged? Does it fix an issue? -->

## Checklist

<!-- Put an x inside the [ ] to check an item, like so: [x] -->

- [x] I have personally loaded this code into an updated Qbox project and checked all of its functionality.
- [x] My pull request fits the contribution guidelines & code conventions.
