### PR TITLE
Remove server branding from locale

### DIFF
--- a/locales/nl.json
+++ b/locales/nl.json
@@ -41,7 +41,7 @@
         "checking_whitelisted": "Hallo %s. We zijn je even aan het controleren.",
         "exploit_banned": "Je bent gebanned voor cheating. Kijk op onze discord voor meer informatie: %s",
         "exploit_dropped": "Je bent gekickt voor exploiting",
-        "multichar_title": "Infinity Multicharacter",
+        "multichar_title": "Qbox Multicharacter",
         "multichar_new_character": "Nieuw karakter #%s",
         "char_male": "Man",
         "char_female": "Vrouw",


### PR DESCRIPTION
## Description
Currently in the dutch language file there is branding for a server called "Infinity", I replaced this 3d party branding with Qbox.
