### PR TITLE
fix(lib/spawn): retrieve vehicle type

### DIFF
--- a/modules/lib.lua
+++ b/modules/lib.lua
@@ -339,6 +339,18 @@ if isServer then
         return netId, veh
     end
 else
+    ---@param model number|string
+    ---@return string
+    lib.callback.register('qbx_core:client:getVehicleType', function(model)
+        model = lib.requestModel(model)
+        local coords = GetEntityCoords(cache.ped)
+        local tempVehicle = CreateVehicle(model, coords.x, coords.y, coords.z - 20.0, 0, false, false)
+        SetModelAsNoLongerNeeded(model)
+        local type = GetVehicleType(tempVehicle)
+        DeleteEntity(tempVehicle)
+        return type
+    end)
+
     ---@class LibDrawTextParams
     ---@field text string
     ---@field scale? integer default: `0.35`

--- a/modules/lib.lua
+++ b/modules/lib.lua
@@ -265,15 +265,7 @@ if isServer then
             coords = vec4(pedCoords.x, pedCoords.y, pedCoords.z, GetEntityHeading(source))
         end
 
-        local vehicleType = exports.qbx_core:GetVehiclesByHash(model).type
-        if not vehicleType then
-            local tempVehicle = CreateVehicle(model, 0, 0, -200, 0, true, true)
-            while not DoesEntityExist(tempVehicle) do Wait(0) end
-
-            vehicleType = GetVehicleType(tempVehicle)
-            DeleteEntity(tempVehicle)
-        end
-
+        local vehicleType = exports.qbx_core:GetVehiclesByHash(model)?.type or lib.callback.await('qbx_core:client:getVehicleType', math.random(#GetPlayers()), model)
         local attempts = 0
 
         local veh, netId


### PR DESCRIPTION
## Description

- use callback on random client instead of server spawn.
`CreateVehicle` on the server side still depends on the client to spawn. If no client is nearby, it will get stuck in a while loop and vehicle will never exist. Instead, we retrieve the type from a random client, which will definitely exist.

## Checklist
<!-- Put an x inside the [ ] to check an item, like so: [x] -->

- [x] I have personally loaded this code into an updated Qbox project and checked all of its functionality.
- [x] My pull request fits the contribution guidelines & code conventions.
