### PR TITLE
feat(server/player): support getting/setting nested metadata

### DIFF
--- a/server/player.lua
+++ b/server/player.lua
@@ -1124,9 +1124,23 @@ function SetMetadata(identifier, metadata, value)
 
     if not player then return end
 
-    local oldValue = player.PlayerData.metadata[metadata]
+    local oldValue
 
-    player.PlayerData.metadata[metadata] = value
+    if metadata:match('%.') then
+        local metaTable, metaKey = metadata:match('([^%.]+)%.(.+)')
+
+        if metaKey:match('%.') then
+            lib.print.error('cannot get nested metadata more than 1 level deep')
+        end
+
+        oldValue = player.PlayerData.metadata[metaTable][metaKey]
+
+        player.PlayerData.metadata[metaTable][metaKey] = value
+    else
+        oldValue = player.PlayerData.metadata[metadata]
+
+        player.PlayerData.metadata[metadata] = value
+    end
 
     UpdatePlayerData(identifier)
 
@@ -1170,7 +1184,17 @@ function GetMetadata(identifier, metadata)
 
     if not player then return end
 
-    return player.PlayerData.metadata[metadata]
+    if metadata:match('%.') then
+        local metaTable, metaKey = metadata:match('([^%.]+)%.(.+)')
+
+        if metaKey:match('%.') then
+            lib.print.error('cannot get nested metadata more than 1 level deep')
+        end
+
+        return player.PlayerData.metadata[metaTable][metaKey]
+    else
+        return player.PlayerData.metadata[metadata]
+    end
 end
 
 exports('GetMetadata', GetMetadata)

--- a/server/player.lua
+++ b/server/player.lua
@@ -1133,9 +1133,11 @@ function SetMetadata(identifier, metadata, value)
             lib.print.error('cannot get nested metadata more than 1 level deep')
         end
 
-        oldValue = player.PlayerData.metadata[metaTable][metaKey]
+        oldValue = player.PlayerData.metadata[metaTable]
 
         player.PlayerData.metadata[metaTable][metaKey] = value
+
+        metadata = metaTable
     else
         oldValue = player.PlayerData.metadata[metadata]
 


### PR DESCRIPTION
## Description

Handles nested metadata and closes #646. Doesn't allow for more than one level deep. I think there's probably a better way to do this but right now it just checks for periods as seperators.

## Checklist

- [ ] I have personally loaded this code into an updated Qbox project and checked all of its functionality.
- [x] My pull request fits the contribution guidelines & code conventions.
