### PR TITLE
feat(modules/lib): deprecate qbx.playAudio

### DIFF
--- a/modules/lib.lua
+++ b/modules/lib.lua
@@ -578,6 +578,7 @@ else
     ---@field audioSource? number | vector3 entity handle or vector3 coords
     ---@field range? number only used if `audioSource` is a vector3 coordinate
 
+    ---@deprecated use mana_audio instead
     ---Plays a sound with the provided audio name and audio ref.
     ---If `returnSoundId` is false or not specified the soundId is released,
     ---otherwise the function returns the soundId without releasing it.


### PR DESCRIPTION
## Description

Marks `qbx.playAudio` as deprecated since we now utilize `mana_audio`. Closes #492 upon merging.

## Checklist

- [ ] I have personally loaded this code into an updated Qbox project and checked all of its functionality.
- [x] My pull request fits the contribution guidelines & code conventions.
