### PR TITLE
Fixes misidentification of source as an identifier

### DIFF
--- a/server/functions.lua
+++ b/server/functions.lua
@@ -46,8 +46,8 @@ exports('GetUserId', GetUserId)
 ---@param source Source|string source or identifier of the player
 ---@return Player
 function GetPlayer(source)
-    if type(source) == 'number' then
-        return QBX.Players[source]
+    if tonumber(source) ~= nil then
+        return QBX.Players[tonumber(source)]
     else
         return QBX.Players[GetSource(source --[[@as string]])]
     end


### PR DESCRIPTION
## Description

This fixes misidentification of string numbers (e.g. "1", "2", "3"), and correctly converts them to source numbers for indexing rather than interpreting it as an identifier.

## Checklist

- [x] I have personally loaded this code into an updated Qbox project and checked all of its functionality.
- [x] My pull request fits the contribution guidelines & code conventions.
