### PR TITLE
Update Player Data By Key

### DIFF
--- a/client/events.lua
+++ b/client/events.lua
@@ -20,6 +20,18 @@ RegisterNetEvent('QBCore:Client:OnPlayerLoaded', function()
     end
 end)
 
+RegisterNetEvent('qbx_core:client:updatePlayerData', function (key, value)
+    if source == '' then return end
+    QBX.PlayerData[key] = value
+    TriggerEvent('QBCore:Player:SetPlayerData', QBX.PlayerData)
+end)
+
+RegisterNetEvent('qbx_core:client:loadPlayerData', function (val)
+    if source == '' then return end
+    QBX.PlayerData = val
+    TriggerEvent('QBCore:Player:SetPlayerData', QBX.PlayerData)
+end)
+
 ---@param val PlayerData
 RegisterNetEvent('QBCore:Player:SetPlayerData', function(val)
     local invokingResource = GetInvokingResource()

--- a/client/events.lua
+++ b/client/events.lua
@@ -20,9 +20,19 @@ RegisterNetEvent('QBCore:Client:OnPlayerLoaded', function()
     end
 end)
 
-RegisterNetEvent('qbx_core:client:updatePlayerData', function (key, value)
+---@param key string
+---@param value PlayerData
+RegisterNetEvent('qbx_core:client:onUpdatePlayerData', function (key, value)
     if source == '' then return end
     QBX.PlayerData[key] = value
+    TriggerEvent('QBCore:Player:SetPlayerData', QBX.PlayerData)
+end)
+
+---@param key string
+---@param value PlayerMetadata
+RegisterNetEvent('qbx_core:client:onSetMetaData', function(key, _, value)
+    if source == '' then return end
+    QBX.PlayerData.metadata[key] = value
     TriggerEvent('QBCore:Player:SetPlayerData', QBX.PlayerData)
 end)
 

--- a/modules/playerdata.lua
+++ b/modules/playerdata.lua
@@ -9,5 +9,7 @@ RegisterNetEvent('QBCore:Client:OnPlayerUnload', function()
 end)
 
 RegisterNetEvent('QBCore:Player:SetPlayerData', function(value)
+    local invokingResource = GetInvokingResource()
+    if invokingResource and invokingResource ~= GetCurrentResourceName() then return end
     QBX.PlayerData = value
 end)

--- a/server/player.lua
+++ b/server/player.lua
@@ -1105,7 +1105,7 @@ function UpdatePlayerData(identifier, key, value)
         TriggerClientEvent('qbx_core:client:loadPlayerData', player.PlayerData.source, player.PlayerData)
         return
     end
-    TriggerClientEvent('qbx_core:client:updatePlayerData', player.PlayerData.source, key, value)
+    TriggerClientEvent('qbx_core:client:onUpdatePlayerData', player.PlayerData.source, key, value)
 end
 
 ---@param identifier Source | string

--- a/server/player.lua
+++ b/server/player.lua
@@ -800,7 +800,7 @@ function CreatePlayer(playerData, Offline)
         self.PlayerData.metadata[self.PlayerData.job.name].reputation += amount
 
         ---@diagnostic disable-next-line: param-type-mismatch
-        UpdatePlayerData(self.Offline and self.PlayerData.citizenid or self.PlayerData.source)
+        UpdatePlayerData(self.Offline and self.PlayerData.citizenid or self.PlayerData.source, 'metadata', self.PlayerData.metadata)
     end
 
     ---@param moneytype MoneyType
@@ -964,7 +964,7 @@ function CreatePlayer(playerData, Offline)
         end
 
         if not self.Offline then
-            UpdatePlayerData(self.PlayerData.source)
+            UpdatePlayerData(self.PlayerData.source, 'job', self.PlayerData.job)
             TriggerEvent('QBCore:Server:OnJobUpdate', self.PlayerData.source, self.PlayerData.job)
             TriggerClientEvent('QBCore:Client:OnJobUpdate', self.PlayerData.source, self.PlayerData.job)
         end
@@ -1122,11 +1122,10 @@ function SetMetadata(identifier, metadata, value)
 
     player.PlayerData.metadata[metadata] = value
 
-    UpdatePlayerData(identifier, 'metadata', player.PlayerData.metadata)
-
     if not player.Offline then
         local playerState = Player(player.PlayerData.source).state
 
+        TriggerEvent('QBCore:Player:SetPlayerData', player.PlayerData)
         TriggerClientEvent('qbx_core:client:onSetMetaData', player.PlayerData.source, metadata, oldValue, value)
         TriggerEvent('qbx_core:server:onSetMetaData', metadata,  oldValue, value, player.PlayerData.source)
 


### PR DESCRIPTION
## Description
Send player data to client when the key of the data is changing, reducing the traffic from server to client.

## Checklist

- [x] I have personally loaded this code into an updated Qbox project and checked all of its functionality.
- [x] My pull request fits the contribution guidelines & code conventions.
