### PR TITLE
fix(modules/hooks): return proper response, if neither hook fails

### DIFF
--- a/modules/hooks.lua
+++ b/modules/hooks.lua
@@ -26,6 +26,8 @@ local function triggerEventHooks(event, payload)
             return false
         end
     end
+
+    return true
 end
 
 local hookId = 0


### PR DESCRIPTION
## Description
This pretty much fixes wrong hooks response.

TLDR: If neither hook fails, expected response is `true`. With current implementation, it returns `nil` which is considered as `false` and will always fail.

Simple example:
```lua
if not triggerEventHooks('removeMoney', {
  source = player.PlayerData.source,
  moneyType = moneyType,
  amount = amount
}) then return false end
```

If there's any hooks registered for `removeMoney`, it will always fail even though hooks return `true`.

## Checklist

- [x] I have personally loaded this code into an updated Qbox project and checked all of its functionality.
- [x] My pull request fits the contribution guidelines & code conventions.
