### PR TITLE
fix(groups): Client cache group data from server in case of runtime modifications

### DIFF
--- a/client/groups.lua
+++ b/client/groups.lua
@@ -1,8 +1,14 @@
-local jobs = require 'shared.jobs'
-local gangs = require 'shared.gangs'
+local jobs, gangs
+
+local function refreshCache()
+    local groups = lib.callback.await('qbx_core:server:getGroups')
+    jobs = groups.jobs
+    gangs = groups.gangs
+end
 
 ---@return table<string, Job>
 function GetJobs()
+    if not jobs then refreshCache() end
     return jobs
 end
 
@@ -10,6 +16,7 @@ exports('GetJobs', GetJobs)
 
 ---@return table<string, Gang>
 function GetGangs()
+    if not gangs then refreshCache() end
     return gangs
 end
 
@@ -18,6 +25,7 @@ exports('GetGangs', GetGangs)
 ---@param name string
 ---@return Job?
 function GetJob(name)
+    if not jobs then refreshCache() end
     return jobs[name]
 end
 
@@ -26,6 +34,7 @@ exports('GetJob', GetJob)
 ---@param name string
 ---@return Gang?
 function GetGang(name)
+    if not gangs then refreshCache() end
     return gangs[name]
 end
 

--- a/server/groups.lua
+++ b/server/groups.lua
@@ -216,3 +216,12 @@ local function removeGangGrade(name, grade)
 end
 
 exports('RemoveGangGrade', removeGangGrade)
+
+---Allow clients to fetch group cache
+---@return table
+lib.callback.register('qbx_core:server:getGroups', function()
+    return {
+        jobs = jobs,
+        gangs = gangs,
+    }
+end)

--- a/server/player.lua
+++ b/server/player.lua
@@ -419,6 +419,7 @@ function SetPlayerPrimaryGang(citizenid, gangName)
         name = gangName,
         label = gang.label,
         isboss = gang.grades[grade].isboss,
+        bankAuth = gang.grades[grade].bankAuth,
         grade = {
             name = gang.grades[grade].name,
             level = grade
@@ -543,6 +544,7 @@ function RemovePlayerFromGang(citizenid, gangName)
             name = 'none',
             label = gang.label,
             isboss = false,
+            bankAuth = false,
             grade = {
                 name = gang.grades[0].name,
                 level = 0
@@ -668,6 +670,7 @@ function CheckPlayerData(source, playerData)
         type = job.type,
         onduty = playerData.job?.onduty or false,
         isboss = job.grades[jobGrade].isboss or false,
+        bankAuth = job.grades[jobGrade].bankAuth or false,
         grade = {
             name = job.grades[jobGrade].name,
             level = jobGrade,
@@ -685,6 +688,7 @@ function CheckPlayerData(source, playerData)
         name = playerData.gang?.name or 'none',
         label = gang.label,
         isboss = gang.grades[gangGrade].isboss or false,
+        bankAuth = gang.grades[gangGrade].bankAuth or false,
         grade = {
             name = gang.grades[gangGrade].name,
             level = gangGrade
@@ -936,6 +940,7 @@ function CreatePlayer(playerData, Offline)
                 name = 'unemployed',
                 label = 'Civilian',
                 isboss = false,
+                bankAuth = false,
                 onduty = true,
                 payment = 10,
                 grade = {
@@ -953,6 +958,7 @@ function CreatePlayer(playerData, Offline)
                 self.PlayerData.job.grade.name = jobGrade.name
                 self.PlayerData.job.payment = jobGrade.payment or 30
                 self.PlayerData.job.isboss = jobGrade.isboss or false
+                self.PlayerData.job.bankAuth = jobGrade.bankAuth or false
             else
                 self.PlayerData.job.grade = {
                     name = 'No Grades',
@@ -978,6 +984,7 @@ function CreatePlayer(playerData, Offline)
                 name = 'none',
                 label = 'No Gang Affiliation',
                 isboss = false,
+                bankAuth = false,
                 grade = {
                     name = 'none',
                     level = 0
@@ -989,13 +996,16 @@ function CreatePlayer(playerData, Offline)
             local gangGrade = gang.grades[self.PlayerData.gang.grade.level]
 
             if gangGrade then
+                self.PlayerData.gang.grade.name = gangGrade.name
                 self.PlayerData.gang.isboss = gangGrade.isboss or false
+                self.PlayerData.gang.bankAuth = gangGrade.bankAuth or false
             else
                 self.PlayerData.gang.grade = {
                     name = 'No Grades',
                     level = 0,
                 }
                 self.PlayerData.gang.isboss = false
+                self.PlayerData.gang.bankAuth = false
             end
         end
 

--- a/types.lua
+++ b/types.lua
@@ -197,12 +197,14 @@
 ---@field type? string
 ---@field onduty boolean
 ---@field isboss boolean
+---@field bankAuth boolean
 ---@field grade {name: string, level: number}
 
 ---@class PlayerGang
 ---@field name string
 ---@field label string
 ---@field isboss boolean
+---@field bankAuth boolean
 ---@field grade {name: string, level: number}
 
 ---@class PlayerSkin


### PR DESCRIPTION
## Description
- Make client cache group data from the server on first load. Currently, if any runtime modifications are made to groups before client connection, those changes are not seen by client.
- Update gang grade name when `onGangUpdate` net event is triggered
- Include `bankAuth` in `PlayerData` for gang & job

## Checklist

- [x] I have personally loaded this code into an updated Qbox project and checked all of its functionality.
- [x] My pull request fits the contribution guidelines & code conventions.
