### PR TITLE
fix: populate shared.weapons from ox_inventory weapons

### DIFF
--- a/bridge/qb/shared/main.lua
+++ b/bridge/qb/shared/main.lua
@@ -1,6 +1,7 @@
 local qbShared = require 'shared.main'
 
 qbShared.Items = {}
+qbShared.Weapons = {}
 local oxItems = require '@ox_inventory.data.items'
 for item, data in pairs(oxItems) do
     qbShared.Items[item] = {
@@ -31,6 +32,13 @@ for weapon, data in pairs(oxWeapons.Weapons) do
         shouldClose = true,
         combinable = nil,
         description = nil
+    }
+    qbShared.Weapons[weapon] = {
+        name = weapon,
+        label = data.label,
+        weapontype = data.throwable and 'Throwable' or (not data.ammoname and 'Melee' or 'Gun'),
+        ammotype = data.ammoname or nil,
+        damagereason = ''
     }
 end
 for component, data in pairs(oxWeapons.Components) do

--- a/shared/main.lua
+++ b/shared/main.lua
@@ -2,7 +2,6 @@ local qbShared = {}
 qbShared.ForceJobDefaultDutyAtLogin = true -- true: Force duty state to jobdefaultDuty | false: set duty state from database last saved
 qbShared.Locations = require 'shared.locations'
 qbShared.Vehicles = require 'shared.vehicles'
-qbShared.Weapons = require 'shared.weapons'
 
 ---@type table<number, Vehicle>
 qbShared.VehicleHashes = {}

--- a/shared/weapons.lua
+++ b/shared/weapons.lua
@@ -1,3 +1,3 @@
----@deprecated This file is deprecated and will be removed in the future. If you are utilizing QB-Core bridge functionality you will need to populate weapons here for them to be available in QBCore.Shared.Weapons. If not please add your weapons in ox_inventory/data/weapons.lua file. Currently weapons in this file will be converted on next server start.
+---@deprecated This file is deprecated and will be removed in the future. Please add your weapons in ox_inventory/data/weapons.lua file. Currently weapons in this file will be converted on next server start.
 ---@type table<number, Weapon>
 return {}


### PR DESCRIPTION
## Description

This will populate shared.weapons from ox_inventory data/weapons.lua for backwards compatibility.

## Checklist

<!-- Put an x inside the [ ] to check an item, like so: [x] -->

- [x] I have personally loaded this code into an updated Qbox project and checked all of its functionality.
- [x] My pull request fits the contribution guidelines & code conventions.
