### PR TITLE
fix: Add payment protection to pay loop to prevent duplicate paychecks per cycle

### DIFF
--- a/server/loops.lua
+++ b/server/loops.lua
@@ -23,15 +23,23 @@ CreateThread(function()
 end)
 
 local function pay(player)
+    local now = os.time()
+    if player.PlayerData.lastPayCheck and (now - player.PlayerData.lastPayCheck) < (config.money.paycheckTimeout * 60) then
+        return
+    end
+    player.PlayerData.lastPayCheck = now
+
     local job = player.PlayerData.job
     local payment = GetJob(job.name).grades[job.grade.level].payment or job.payment
     if payment <= 0 then return end
     if not GetJob(job.name).offDutyPay and not job.onduty then return end
+
     if not config.money.paycheckSociety then
         config.sendPaycheck(player, payment)
         return
     end
-    local account = config.getSocietyAccount(job.name)
+
+    local account = config.getSocietyAccountMoney(job.name)
     if not account then -- Checks if player is employed by a society
         config.sendPaycheck(player, payment)
         return
@@ -40,6 +48,7 @@ local function pay(player)
         Notify(player.PlayerData.source, locale('error.company_too_poor'), 'error')
         return
     end
+
     config.removeSocietyMoney(job.name, payment)
     config.sendPaycheck(player, payment)
 end


### PR DESCRIPTION
## Description

<!-- What does your pull request change? Why should it be merged? Does it fix an issue? -->

We had an issue where players were being paid because the pay loop was being called twice externally--after some deep digging and debugging, we weren't able to find the root cause, however, I added some protection against this to the pay loop and it fixed the problem.

## Checklist

<!-- Put an x inside the [ ] to check an item, like so: [x] -->

- [x ] I have personally loaded this code into an updated Qbox project and checked all of its functionality.
- [x ] My pull request fits the contribution guidelines & code conventions.
