### PR TITLE
fix(player): Reset Job grade on missing

### DIFF
--- a/server/player.lua
+++ b/server/player.lua
@@ -661,7 +661,10 @@ function CheckPlayerData(source, playerData)
 
     local job = GetJob(playerData.job?.name) or GetJob('unemployed')
     assert(job ~= nil, 'Unemployed job not found. Does it exist in shared/jobs.lua?')
-    local jobGrade = GetJob(playerData.job?.name) and playerData.job.grade.level or 0
+    local jobGrade = 0
+    if job and job.grades and job.grades[playerData.job.grade.level] then
+        jobGrade = playerData.job.grade.level
+    end
 
     playerData.job = {
         name = playerData.job?.name or 'unemployed',


### PR DESCRIPTION
## Description
Resets a players grade to `0` as a failsafe if the job the player had still exists in the shared, but the grade the player had was deleted.
Closes #682 

<!-- What does your pull request change? Why should it be merged? Does it fix an issue? -->

## Checklist

<!-- Put an x inside the [ ] to check an item, like so: [x] -->

- [x] I have personally loaded this code into an updated Qbox project and checked all of its functionality.
- [x] My pull request fits the contribution guidelines & code conventions.
