### PR TITLE
feat: persistent group updates

### DIFF
--- a/modules/lib.lua
+++ b/modules/lib.lua
@@ -136,24 +136,6 @@ function qbx.string.capitalize(str)
     return capitalized
 end
 
---- Removes any quotes to ensure functionality
----@param str string
----@return string
-function qbx.string.ecapeQuotes(str)
-	str = str.gsub(str, '([%c%z\\"\'])', {
-		['\\'] = '\\\\',
-		['"'] = '\\"',
-		['\''] = '\\\'',
-		['\b'] = '\\b',
-		['\f'] = '\\f',
-		['\n'] = '\\n',
-		['\r'] = '\\r',
-		['\t'] = '\\t',
-		['\0'] = '\\0'
-	})
-	return str
-end
-
 ---Rounds and returns the given number.
 ---@param num number
 ---@param decimalPlaces? integer

--- a/modules/lib.lua
+++ b/modules/lib.lua
@@ -136,6 +136,24 @@ function qbx.string.capitalize(str)
     return capitalized
 end
 
+--- Removes any quotes to ensure functionality
+---@param str string
+---@return string
+function qbx.string.ecapeQuotes(str)
+	str = str.gsub(str, '([%c%z\\"\'])', {
+		['\\'] = '\\\\',
+		['"'] = '\\"',
+		['\''] = '\\\'',
+		['\b'] = '\\b',
+		['\f'] = '\\f',
+		['\n'] = '\\n',
+		['\r'] = '\\r',
+		['\t'] = '\\t',
+		['\0'] = '\\0'
+	})
+	return str
+end
+
 ---Rounds and returns the given number.
 ---@param num number
 ---@param decimalPlaces? integer

--- a/modules/utils.lua
+++ b/modules/utils.lua
@@ -122,6 +122,24 @@ function MapTableBySubfield(subfield, table) -- luacheck: ignore
     return qbx.table.mapBySubfield(table, subfield)
 end
 
+--- Removes any quotes to ensure functionality
+---@param inputString string
+---@return string
+function EcapeQuotes(inputString)
+	inputString = inputString.gsub(inputString, '([%c%z\\"\'])', {
+		['\\'] = '\\\\',
+		['"'] = '\\"',
+		['\''] = '\\\'',
+		['\b'] = '\\b',
+		['\f'] = '\\f',
+		['\n'] = '\\n',
+		['\r'] = '\\r',
+		['\t'] = '\\t',
+		['\0'] = '\\0'
+	})
+	return inputString
+end
+
 if isServer then
     ---@deprecated use qbx.spawnVehicle from modules/lib.lua
     -- Server side vehicle creation

--- a/modules/utils.lua
+++ b/modules/utils.lua
@@ -122,24 +122,6 @@ function MapTableBySubfield(subfield, table) -- luacheck: ignore
     return qbx.table.mapBySubfield(table, subfield)
 end
 
---- Removes any quotes to ensure functionality
----@param inputString string
----@return string
-function EcapeQuotes(inputString)
-	inputString = inputString.gsub(inputString, '([%c%z\\"\'])', {
-		['\\'] = '\\\\',
-		['"'] = '\\"',
-		['\''] = '\\\'',
-		['\b'] = '\\b',
-		['\f'] = '\\f',
-		['\n'] = '\\n',
-		['\r'] = '\\r',
-		['\t'] = '\\t',
-		['\0'] = '\\0'
-	})
-	return inputString
-end
-
 if isServer then
     ---@deprecated use qbx.spawnVehicle from modules/lib.lua
     -- Server side vehicle creation

--- a/server/groups.lua
+++ b/server/groups.lua
@@ -22,6 +22,24 @@ for name in pairs(gangs) do
     end
 end
 
+--- Removes any quotes to ensure functionality
+---@param str string
+---@return string
+local function ecapeQuotes(str)
+	str = str.gsub(str, '([%c%z\\"\'])', {
+		['\\'] = '\\\\',
+		['"'] = '\\"',
+		['\''] = '\\\'',
+		['\b'] = '\\b',
+		['\f'] = '\\f',
+		['\n'] = '\\n',
+		['\r'] = '\\r',
+		['\t'] = '\\t',
+		['\0'] = '\\0'
+	})
+	return str
+end
+
 -- Converts groups to plain text for committing to shared file
 ---@param groupTable table<string, Job>
 ---@param type string
@@ -39,7 +57,7 @@ local function convertGroupsToPlainText(groupTable, type)
         table.insert(lines, groupLine)
 
         -- Add group label
-        local labelLine = string.format("        label = '%s',", qbx.string.escapeQuotes(groupData.label))
+        local labelLine = string.format("        label = '%s',", escapeQuotes(groupData.label))
         table.insert(lines, labelLine)
 
         if type == 'Job' then
@@ -58,7 +76,7 @@ local function convertGroupsToPlainText(groupTable, type)
         table.insert(lines, "        grades = {")
         for gradeIndex, gradeData in pairs(groupData.grades) do
             -- Start the grade entry
-            local gradeLine = string.format("            [%d] = { name = '%s'", gradeIndex, qbx.string.escapeQuotes(gradeData.name))
+            local gradeLine = string.format("            [%d] = { name = '%s'", gradeIndex, escapeQuotes(gradeData.name))
 
             if type == 'Job' then
                 gradeLine = string.fromat(gradeLine .. ', payment = %d', gradeData.payment)

--- a/server/groups.lua
+++ b/server/groups.lua
@@ -25,7 +25,7 @@ end
 --- Removes any quotes to ensure functionality
 ---@param str string
 ---@return string
-local function ecapeQuotes(str)
+local function escapeQuotes(str)
 	str = str.gsub(str, '([%c%z\\"\'])', {
 		['\\'] = '\\\\',
 		['"'] = '\\"',

--- a/server/groups.lua
+++ b/server/groups.lua
@@ -39,7 +39,7 @@ local function convertGroupsToPlainText(groupTable, type)
         table.insert(lines, groupLine)
 
         -- Add group label
-        local labelLine = string.format("        label = '%s',", EscapeQuotes(groupData.label))
+        local labelLine = string.format("        label = '%s',", qbx.string.escapeQuotes(groupData.label))
         table.insert(lines, labelLine)
 
         if type == 'Job' then
@@ -58,7 +58,7 @@ local function convertGroupsToPlainText(groupTable, type)
         table.insert(lines, "        grades = {")
         for gradeIndex, gradeData in pairs(groupData.grades) do
             -- Start the grade entry
-            local gradeLine = string.format("            [%d] = { name = '%s'", gradeIndex, EscapeQuotes(gradeData.name))
+            local gradeLine = string.format("            [%d] = { name = '%s'", gradeIndex, qbx.string.escapeQuotes(gradeData.name))
 
             if type == 'Job' then
                 gradeLine = string.fromat(gradeLine .. ', payment = %d', gradeData.payment)

--- a/server/groups.lua
+++ b/server/groups.lua
@@ -22,13 +22,81 @@ for name in pairs(gangs) do
     end
 end
 
+-- Converts groups to plain text for committing to shared file
+---@param groupTable table<string, Job>
+---@param type string
+local function convertGroupsToPlainText(groupTable, type)
+    local lines = {
+        '---' .. type .. ' names must be lower case (top level table key)',
+        '---@type table<string, ' .. type .. '>',
+        'return {'
+    }
+
+    -- Iterate through job table and format them according to QBox structure
+    for groupName, groupData in pairs(groupTable) do
+        -- Add group entry (convert to lower case for group name)
+        local groupLine = string.format("    ['%s'] = {", groupName:lower())
+        table.insert(lines, groupLine)
+
+        -- Add group label
+        local labelLine = string.format("        label = '%s',", EscapeQuotes(groupData.label))
+        table.insert(lines, labelLine)
+
+        if type == 'Job' then
+            -- Add defaultDuty and offDutyPay
+            if groupData.defaultDuty ~= nil then
+                local defaultDutyLine = string.format("        defaultDuty = %s,", tostring(groupData.defaultDuty))
+                table.insert(lines, defaultDutyLine)
+            end
+            if groupData.offDutyPay ~= nil then
+                local offDutyPayLine = string.format("        offDutyPay = %s,", tostring(groupData.offDutyPay))
+                table.insert(lines, offDutyPayLine)
+            end
+        end
+
+        -- Add grades table
+        table.insert(lines, "        grades = {")
+        for gradeIndex, gradeData in pairs(groupData.grades) do
+            -- Start the grade entry
+            local gradeLine = string.format("            [%d] = { name = '%s'", gradeIndex, EscapeQuotes(gradeData.name))
+
+            if type == 'Job' then
+                gradeLine = string.fromat(gradeLine .. ', payment = %d', gradeData.payment)
+            end
+
+            -- Add isBoss if true
+            if gradeData.isboss then
+                gradeLine = gradeLine .. ", isboss = true"
+            end
+
+            -- Add bankAuth if true
+            if gradeData.bankAuth then
+                gradeLine = gradeLine .. ", bankAuth = true"
+            end
+
+            -- Close the grade entry
+            gradeLine = gradeLine .. " },"
+            table.insert(lines, gradeLine)
+        end
+        table.insert(lines, "        },")
+
+        -- Close the group entry
+        table.insert(lines, "    },")
+    end
+
+    -- Close the groups table
+    table.insert(lines, '}')
+    return table.concat(lines, '\n')
+end
+
 --- Adds or updates a job entry in shared/jobs.lua.
 --- If the job already exists, it will be overwritten.
 --- @param jobName string The unique name of the job.
 --- @param job table The job data containing relevant job properties.
+--- @param commitToFile boolean Whether to commit the job data to the shared file.
 --- @return boolean success Whether the operation was successful.
 --- @return string? message An optional message indicating success or failure.
-function CreateJob(jobName, job)
+function CreateJob(jobName, job, commitToFile)
     -- Validate jobName
     if type(jobName) ~= "string" or jobName:match("^%s*$") then
         return false, "Invalid parameter: jobName must be a non-empty string."
@@ -46,6 +114,12 @@ function CreateJob(jobName, job)
     TriggerEvent('qbx_core:server:onJobUpdate', jobName, job)
     TriggerClientEvent('qbx_core:client:onJobUpdate', -1, jobName, job)
 
+    -- Commit the job data to the shared file
+    if commitToFile then
+        local modifiedData = convertGroupsToPlainText(jobs, 'Job')
+        SaveResourceFile(GetCurrentResourceName(), 'shared/jobs.lua', modifiedData, -1)
+    end
+
     return true, string.format("Job '%s' created/updated successfully.", jobName)
 end
 
@@ -54,9 +128,10 @@ exports('CreateJob', CreateJob)
 --- Adds or updates multiple jobs in shared/jobs.lua.
 --- Calls CreateJob for each job in the provided table.
 --- @param newJobs table<string, table> A table where keys are job names and values are job data tables.
+--- @param commitToFile boolean Whether to commit the job data to the shared file.
 --- @return boolean success Whether all jobs were successfully created/updated.
 --- @return string? message An optional message indicating success or failure.
-function CreateJobs(newJobs)
+function CreateJobs(newJobs, commitToFile)
     -- Validate input type
     if type(newJobs) ~= "table" then
         return false, "Invalid parameter: newJobs must be a table."
@@ -79,6 +154,12 @@ function CreateJobs(newJobs)
         return false, string.format("Some jobs failed to create: %s", table.concat(failedJobs, ", "))
     end
 
+    -- Commit the job data to the shared file
+    if commitToFile then
+        local modifiedData = convertGroupsToPlainText(jobs, 'Job')
+        SaveResourceFile(GetCurrentResourceName(), 'shared/jobs.lua', modifiedData, -1)
+    end
+
     return true, "All jobs created/updated successfully."
 end
 
@@ -86,9 +167,10 @@ exports('CreateJobs', CreateJobs)
 
 -- Single Remove Job
 ---@param jobName string
+---@param commitToFile boolean Whether to commit the job data to the shared file.
 ---@return boolean success
 ---@return string message
-function RemoveJob(jobName)
+function RemoveJob(jobName, commitToFile)
     if type(jobName) ~= 'string' then
         return false, 'invalid_job_name'
     end
@@ -100,6 +182,11 @@ function RemoveJob(jobName)
     jobs[jobName] = nil
     TriggerEvent('qbx_core:server:onJobUpdate', jobName, nil)
     TriggerClientEvent('qbx_core:client:onJobUpdate', -1, jobName, nil)
+
+    if commitToFile then
+        local modifiedData = convertGroupsToPlainText(jobs, 'Job')
+        SaveResourceFile(GetCurrentResourceName(), 'shared/jobs.lua', modifiedData, -1)
+    end
     return true, 'success'
 end
 
@@ -107,11 +194,17 @@ exports('RemoveJob', RemoveJob)
 
 ---Adds or overwrites gangs in shared/gangs.lua
 ---@param newGangs table<string, Gang>
-function CreateGangs(newGangs)
+---@param commitToFile boolean Whether to commit the gang data to the shared file.
+function CreateGangs(newGangs, commitToFile)
     for gangName, gang in pairs(newGangs) do
         gangs[gangName] = gang
         TriggerEvent('qbx_core:server:onGangUpdate', gangName, gang)
         TriggerClientEvent('qbx_core:client:onGangUpdate', -1, gangName, gang)
+    end
+
+    if commitToFile then
+        local modifiedData = convertGroupsToPlainText(gangs, 'Gang')
+        SaveResourceFile(GetCurrentResourceName(), 'shared/gangs.lua', modifiedData, -1)
     end
 end
 
@@ -119,9 +212,10 @@ exports('CreateGangs', CreateGangs)
 
 -- Single Remove Gang
 ---@param gangName string
+---@param commitToFile boolean Whether to commit the gang data to the shared file.
 ---@return boolean success
 ---@return string message
-function RemoveGang(gangName)
+function RemoveGang(gangName, commitToFile)
     if type(gangName) ~= 'string' then
         return false, 'invalid_gang_name'
     end
@@ -134,6 +228,11 @@ function RemoveGang(gangName)
 
     TriggerEvent('qbx_core:server:onGangUpdate', gangName, nil)
     TriggerClientEvent('qbx_core:client:onGangUpdate', -1, gangName, nil)
+
+    if commitToFile then
+        local modifiedData = convertGroupsToPlainText(gangs, 'Gang')
+        SaveResourceFile(GetCurrentResourceName(), 'shared/gangs.lua', modifiedData, -1)
+    end
     return true, 'success'
 end
 
@@ -171,7 +270,8 @@ exports('GetGang', GetGang)
 
 ---@param name string
 ---@param data JobData
-local function upsertJobData(name, data)
+---@param commitToFile boolean Whether to commit the job data to the shared file.
+local function upsertJobData(name, data, commitToFile)
     if jobs[name] then
         jobs[name].defaultDuty = data.defaultDuty
         jobs[name].label = data.label
@@ -188,13 +288,18 @@ local function upsertJobData(name, data)
     end
     TriggerEvent('qbx_core:server:onJobUpdate', name, jobs[name])
     TriggerClientEvent('qbx_core:client:onJobUpdate', -1, name, jobs[name])
+    if commitToFile then
+        local modifiedData = convertGroupsToPlainText(jobs, 'Job')
+        SaveResourceFile(GetCurrentResourceName(), 'shared/jobs.lua', modifiedData, -1)
+    end
 end
 
 exports('UpsertJobData', upsertJobData)
 
 ---@param name string
 ---@param data GangData
-local function upsertGangData(name, data)
+---@param commitToFile boolean Whether to commit the gang data to the shared file.
+local function upsertGangData(name, data, commitToFile)
     if gangs[name] then
         gangs[name].label = data.label
     else
@@ -205,6 +310,10 @@ local function upsertGangData(name, data)
     end
     TriggerEvent('qbx_core:server:onGangUpdate', name, gangs[name])
     TriggerClientEvent('qbx_core:client:onGangUpdate', -1, name, gangs[name])
+    if commitToFile then
+        local modifiedData = convertGroupsToPlainText(gangs, 'Gang')
+        SaveResourceFile(GetCurrentResourceName(), 'shared/gangs.lua', modifiedData, -1)
+    end
 end
 
 exports('UpsertGangData', upsertGangData)
@@ -212,7 +321,8 @@ exports('UpsertGangData', upsertGangData)
 ---@param name string
 ---@param grade integer
 ---@param data JobGradeData
-local function upsertJobGrade(name, grade, data)
+---@param commitToFile boolean Whether to commit the job data to the shared file.
+local function upsertJobGrade(name, grade, data, commitToFile)
     if not jobs[name] then
         lib.print.error('Job must exist to edit grades. Not found:', name)
         return
@@ -220,6 +330,10 @@ local function upsertJobGrade(name, grade, data)
     jobs[name].grades[grade] = data
     TriggerEvent('qbx_core:server:onJobUpdate', name, jobs[name])
     TriggerClientEvent('qbx_core:client:onJobUpdate', -1, name, jobs[name])
+    if commitToFile then
+        local modifiedData = convertGroupsToPlainText(jobs, 'Job')
+        SaveResourceFile(GetCurrentResourceName(), 'shared/jobs.lua', modifiedData, -1)
+    end
 end
 
 exports('UpsertJobGrade', upsertJobGrade)
@@ -227,7 +341,8 @@ exports('UpsertJobGrade', upsertJobGrade)
 ---@param name string
 ---@param grade integer
 ---@param data GangGradeData
-local function upsertGangGrade(name, grade, data)
+---@param commitToFile boolean Whether to commit the gang data to the shared file.
+local function upsertGangGrade(name, grade, data, commitToFile)
     if not gangs[name] then
         lib.print.error('Gang must exist to edit grades. Not found:', name)
         return
@@ -235,13 +350,18 @@ local function upsertGangGrade(name, grade, data)
     gangs[name].grades[grade] = data
     TriggerEvent('qbx_core:server:onGangUpdate', name, gangs[name])
     TriggerClientEvent('qbx_core:client:onGangUpdate', -1, name, gangs[name])
+    if commitToFile then
+        local modifiedData = convertGroupsToPlainText(gangs, 'Gang')
+        SaveResourceFile(GetCurrentResourceName(), 'shared/gangs.lua', modifiedData, -1)
+    end
 end
 
 exports('UpsertGangGrade', upsertGangGrade)
 
 ---@param name string
 ---@param grade integer
-local function removeJobGrade(name, grade)
+---@param commitToFile boolean Whether to commit the job data to the shared file.
+local function removeJobGrade(name, grade, commitToFile)
     if not jobs[name] then
         lib.print.error('Job must exist to edit grades. Not found:', name)
         return
@@ -249,13 +369,18 @@ local function removeJobGrade(name, grade)
     jobs[name].grades[grade] = nil
     TriggerEvent('qbx_core:server:onJobUpdate', name, jobs[name])
     TriggerClientEvent('qbx_core:client:onJobUpdate', -1, name, jobs[name])
+    if commitToFile then
+        local modifiedData = convertGroupsToPlainText(jobs, 'Job')
+        SaveResourceFile(GetCurrentResourceName(), 'shared/jobs.lua', modifiedData, -1)
+    end
 end
 
 exports('RemoveJobGrade', removeJobGrade)
 
 ---@param name string
 ---@param grade integer
-local function removeGangGrade(name, grade)
+---@param commitToFile boolean Whether to commit the gang data to the shared file.
+local function removeGangGrade(name, grade, commitToFile)
     if not gangs[name] then
         lib.print.error('Gang must exist to edit grades. Not found:', name)
         return
@@ -263,6 +388,10 @@ local function removeGangGrade(name, grade)
     gangs[name].grades[grade] = nil
     TriggerEvent('qbx_core:server:onGangUpdate', name, gangs[name])
     TriggerClientEvent('qbx_core:client:onGangUpdate', -1, name, gangs[name])
+    if commitToFile then
+        local modifiedData = convertGroupsToPlainText(gangs, 'Gang')
+        SaveResourceFile(GetCurrentResourceName(), 'shared/gangs.lua', modifiedData, -1)
+    end
 end
 
 exports('RemoveGangGrade', removeGangGrade)


### PR DESCRIPTION
## Description
Allows group updates via server/groups.lua to be committed to the shared resource file(s), allowing for external resources to add persistent changes to groups instead of working around the FiveM sandbox limitations with saving other resource files. Use-case for this can be a server management panel that manages jobs & gangs.

## Checklist
- [X] I have personally loaded this code into an updated Qbox project and checked all of its functionality.
- [X] My pull request fits the contribution guidelines & code conventions.
