### PR TITLE
fix(modules/lib): finding the vehicle type in a function for CreateVehicleServerSetter

### DIFF
--- a/modules/lib.lua
+++ b/modules/lib.lua
@@ -296,8 +296,11 @@ if isServer then
             coords = vec4(pedCoords.x, pedCoords.y, pedCoords.z, GetEntityHeading(source))
         end
 
-        local vehicleType = exports.qbx_core:GetVehiclesByHash(model).type
+        local vehicleType = exports.qbx_core:GetVehiclesByHash(joaat(model)).type
         if not vehicleType then
+            warn(('No vehicle type found for model: %s temp vehicle was created and taken in type'):format(
+                model))
+                
             local tempVehicle = CreateVehicle(model, 0, 0, -200, 0, true, true)
             while not DoesEntityExist(tempVehicle) do Wait(0) end
 


### PR DESCRIPTION
## Description

The function constantly create tempvehicle because it cannot find the right hash and return nil

## Checklist

<!-- Put an x inside the [ ] to check an item, like so: [x] -->

- [ ] I have personally loaded this code into an updated Qbox project and checked all of its functionality.
- [x] My pull request fits the contribution guidelines & code conventions.
