### PR TITLE
fix(server/player): Add Missing Exports

### DIFF
--- a/server/player.lua
+++ b/server/player.lua
@@ -1107,6 +1107,8 @@ function SetPlayerData(identifier, key, value)
     UpdatePlayerData(identifier)
 end
 
+exports('SetPlayerData', SetPlayerData)
+
 ---@param identifier Source | string
 function UpdatePlayerData(identifier)
     local player = type(identifier) == 'string' and (GetPlayerByCitizenId(identifier) or GetOfflinePlayer(identifier)) or GetPlayer(identifier)
@@ -1116,6 +1118,8 @@ function UpdatePlayerData(identifier)
     TriggerEvent('QBCore:Player:SetPlayerData', player.PlayerData)
     TriggerClientEvent('QBCore:Player:SetPlayerData', player.PlayerData.source, player.PlayerData)
 end
+
+exports('UpdatePlayerData', UpdatePlayerData)
 
 ---@param identifier Source | string
 ---@param metadata string


### PR DESCRIPTION
## Description
Adds the missing exports for 2 functions: `SetPlayerData` and `UpdatePlayerData` as noted by the docs [here](https://docs.qbox.re/resources/qbx_core/exports/server#setplayerdata) and [here](https://docs.qbox.re/resources/qbx_core/exports/server#updateplayerdata)
<!-- What does your pull request change? Why should it be merged? Does it fix an issue? -->

## Checklist

<!-- Put an x inside the [ ] to check an item, like so: [x] -->

- [ ] I have personally loaded this code into an updated Qbox project and checked all of its functionality.
- [x] My pull request fits the contribution guidelines & code conventions.

Closes: #684 
