### PR TITLE
fix(server): use callbacks for character deletion

### DIFF
--- a/bridge/qb/server/player.lua
+++ b/bridge/qb/server/player.lua
@@ -105,7 +105,7 @@ end
 ---@param source Source
 ---@param citizenid string
 function playerObj.DeleteCharacter(source, citizenid)
-    lib.callback.await('qbx_core:server:deleteCharacter', source, citizenid)
+    return DeleteCharacter(source, citizenid)
 end
 
 ---@param citizenid string

--- a/bridge/qb/server/player.lua
+++ b/bridge/qb/server/player.lua
@@ -105,7 +105,7 @@ end
 ---@param source Source
 ---@param citizenid string
 function playerObj.DeleteCharacter(source, citizenid)
-    DeleteCharacter(source, citizenid)
+    lib.callback.await('qbx_core:server:deleteCharacter', source, citizenid)
 end
 
 ---@param citizenid string

--- a/bridge/qb/server/player.lua
+++ b/bridge/qb/server/player.lua
@@ -102,11 +102,7 @@ function playerObj.SaveOffline(playerData)
     exports.qbx_core:SaveOffline(playerData)
 end
 
----@param source Source
----@param citizenid string
-function playerObj.DeleteCharacter(source, citizenid)
-    return DeleteCharacter(source, citizenid)
-end
+playerObj.DeleteCharacter = DeleteCharacter
 
 ---@param citizenid string
 function playerObj.ForceDeleteCharacter(citizenid)

--- a/client/character.lua
+++ b/client/character.lua
@@ -461,7 +461,7 @@ local function chooseCharacter()
                             })
                             if alert == 'confirm' then
                                 local success = lib.callback.await('qbx_core:server:deleteCharacter', false, character.citizenid)
-                                Notify(success and locale('success.character_deleted') or 'error.character_delete_failed (fill locale later)', success and 'success' or 'error')
+                                Notify(success and locale('success.character_deleted') or locale('error.character_delete_failed'), success and 'success' or 'error')
 
                                 destroyPreviewCam()
                                 chooseCharacter()

--- a/client/character.lua
+++ b/client/character.lua
@@ -460,7 +460,9 @@ local function chooseCharacter()
                                 cancel = true
                             })
                             if alert == 'confirm' then
-                                TriggerServerEvent('qbx_core:server:deleteCharacter', character.citizenid)
+                                local success = lib.callback.await('qbx_core:server:deleteCharacter', false, character.citizenid)
+                                Notify(success and locale('success.character_deleted') or 'error.character_delete_failed (fill locale later)', success and 'success' or 'error')
+
                                 destroyPreviewCam()
                                 chooseCharacter()
                             else

--- a/locales/en.json
+++ b/locales/en.json
@@ -21,7 +21,8 @@
         "connecting_error": "An error occurred while connecting to the server. (Check your server console)",
         "no_match_character_registration": "Anything other than letters aren't allowed, trailing whitespaces aren't allowed either and words must start with a capital letter in input fields. You can however add words with spaces inbetween.",
         "already_in_queue": "You are already in queue.",
-        "no_subqueue": "You were not let in any sub-queue."
+        "no_subqueue": "You were not let in any sub-queue.",
+        "character_delete_failed": "Character deletion failed. Please try again."
     },
     "success": {
         "server_opened": "The server has been opened",

--- a/server/character.lua
+++ b/server/character.lua
@@ -65,9 +65,3 @@ lib.callback.register('qbx_core:server:createCharacter', function(source, data)
     lib.print.info(('%s has created a character'):format(GetPlayerName(source)))
     return newData
 end)
-
-RegisterNetEvent('qbx_core:server:deleteCharacter', function(citizenId)
-    local src = source
-    DeleteCharacter(src --[[@as number]], citizenId)
-    Notify(src, locale('success.character_deleted'), 'success')
-end)

--- a/server/character.lua
+++ b/server/character.lua
@@ -65,3 +65,10 @@ lib.callback.register('qbx_core:server:createCharacter', function(source, data)
     lib.print.info(('%s has created a character'):format(GetPlayerName(source)))
     return newData
 end)
+
+--- Deprecated. This event is kept for backward compatibility only and is no longer used internally.
+RegisterNetEvent('qbx_core:server:deleteCharacter', function(citizenId)
+    local src = source
+    DeleteCharacter(src --[[@as number]], citizenId)
+    Notify(src, locale('success.character_deleted'), 'success')
+end)

--- a/server/player.lua
+++ b/server/player.lua
@@ -1423,9 +1423,9 @@ exports('GetMoney', GetMoney)
 ---@param source Source
 ---@param citizenid string
 ---@return boolean success
-lib.callback.register('qbx_core:server:deleteCharacter', function(source, citizenid)
+function DeleteCharacter(source, citizenid)
     local license, license2 = GetPlayerIdentifierByType(source --[[@as string]], 'license'), GetPlayerIdentifierByType(source --[[@as string]], 'license2')
-    local result, success = storage.fetchPlayerEntity(citizenid).license, false
+    local result, success = storage.fetchPlayerEntity(citizenid)?.license, false
 
     if license == result or license2 == result then
         success = storage.deletePlayer(citizenid)
@@ -1451,6 +1451,13 @@ lib.callback.register('qbx_core:server:deleteCharacter', function(source, citize
     end
 
     return success
+end
+
+---@param source Source
+---@param citizenid string
+---@return boolean success
+lib.callback.register('qbx_core:server:deleteCharacter', function(source, citizenid)
+    return DeleteCharacter(source, citizenid)
 end)
 
 ---@param citizenid string

--- a/server/player.lua
+++ b/server/player.lua
@@ -1422,22 +1422,22 @@ exports('GetMoney', GetMoney)
 
 ---@param source Source
 ---@param citizenid string
-function DeleteCharacter(source, citizenid)
+---@return boolean success
+lib.callback.register('qbx_core:server:deleteCharacter', function(source, citizenid)
     local license, license2 = GetPlayerIdentifierByType(source --[[@as string]], 'license'), GetPlayerIdentifierByType(source --[[@as string]], 'license2')
-    local result = storage.fetchPlayerEntity(citizenid).license
+    local result, success = storage.fetchPlayerEntity(citizenid).license, false
+
     if license == result or license2 == result then
-        CreateThread(function()
-            local success = storage.deletePlayer(citizenid)
-            if success then
-                logger.log({
-                    source = 'qbx_core',
-                    webhook = config.logging.webhook['joinleave'],
-                    event = 'Character Deleted',
-                    color = 'red',
-                    message = ('**%s** deleted **%s**...'):format(GetPlayerName(source), citizenid, source),
-                })
-            end
-        end)
+        success = storage.deletePlayer(citizenid)
+        if success then
+            logger.log({
+                source = 'qbx_core',
+                webhook = config.logging.webhook['joinleave'],
+                event = 'Character Deleted',
+                color = 'red',
+                message = ('**%s** deleted **%s**...'):format(GetPlayerName(source), citizenid, source),
+            })
+        end
     else
         DropPlayer(tostring(source), locale('info.exploit_dropped'))
         logger.log({
@@ -1449,7 +1449,9 @@ function DeleteCharacter(source, citizenid)
             message = ('%s has been dropped for character deleting exploit'):format(GetPlayerName(source)),
         })
     end
-end
+
+    return success
+end)
 
 ---@param citizenid string
 function ForceDeleteCharacter(citizenid)


### PR DESCRIPTION
## Description


This PR fixes the famous delete character bug, the implemented fix replaces the internal function `DeleteCharacter` by a callback `qbx_core:server:deleteCharacter` ; ensuring data is well received before fetching displaying nonexistent characters.

The notification is handled client-side based on the return value, instead of the server

_Error preview:_
![image](https://github.com/user-attachments/assets/c370de24-719e-4f1e-ad65-67cd14f9fad0)

## Checklist

<!-- Put an x inside the [ ] to check an item, like so: [x] -->

- [X] I have personally loaded this code into an updated Qbox project and checked all of its functionality.
- [X] My pull request fits the contribution guidelines & code conventions.
