### PR TITLE
fix(server): set routing bucket in car command and vehicle validation

### DIFF
--- a/modules/lib.lua
+++ b/modules/lib.lua
@@ -300,7 +300,7 @@ if isServer then
         if not vehicleType then
             warn(('No vehicle type found for model: %s temp vehicle was created and taken in type'):format(
                 model))
-                
+
             local tempVehicle = CreateVehicle(model, 0, 0, -200, 0, true, true)
             while not DoesEntityExist(tempVehicle) do Wait(0) end
 
@@ -313,12 +313,13 @@ if isServer then
         local veh, netId
         while attempts < 3 do
             veh = CreateVehicleServerSetter(model, vehicleType, coords.x, coords.y, coords.z, coords.w)
-            while not DoesEntityExist(veh) do Wait(0) end
-            while GetVehicleNumberPlateText(veh) == '' do Wait(0) end
 
             if bucket and bucket > 0 then
                 exports.qbx_core:SetEntityBucket(veh, bucket)
             end
+
+            while not DoesEntityExist(veh) do Wait(0) end
+            while GetVehicleNumberPlateText(veh) == '' do Wait(0) end
 
             if ped then
                 SetPedIntoVehicle(ped, veh, -1)

--- a/server/commands.lua
+++ b/server/commands.lua
@@ -144,7 +144,7 @@ lib.addCommand('car', {
 }, function(source, args)
     if not args then return end
 
-    local ped = GetPlayerPed(source)
+    local ped, bucket = GetPlayerPed(source), GetPlayerRoutingBucket(source)
     local keepCurrentVehicle = args[locale('command.car.params.keepCurrentVehicle.name')]
     local currentVehicle = not keepCurrentVehicle and GetVehiclePedIsIn(ped, false)
     if currentVehicle and currentVehicle ~= 0 then
@@ -155,6 +155,7 @@ lib.addCommand('car', {
         model = args[locale('command.car.params.model.name')],
         spawnSource = ped,
         warp = true,
+        bucket = bucket
     })
 
     local plate = qbx.getVehiclePlate(vehicle)


### PR DESCRIPTION
## Description

Passes the current ped's routing bucket into the `spawnVehicle` function.

Previously, the vehicle's existence was being checked before its routing bucket was set, which resulted in an infinite loop, thus preventing the vehicle from spawning until the player switched back to bucket 0.

Fixes https://github.com/Qbox-project/qbx_core/issues/695

## Checklist

<!-- Put an x inside the [ ] to check an item, like so: [x] -->

- [x] I have personally loaded this code into an updated Qbox project and checked all of its functionality.
- [x] My pull request fits the contribution guidelines & code conventions.
