### PR TITLE
fix: qb-spawn event

### DIFF
--- a/client/character.lua
+++ b/client/character.lua
@@ -287,7 +287,7 @@ local function spawnDefault() -- We use a callback to make the server wait on th
     TriggerEvent('qb-clothes:client:CreateFirstCharacter')
 end
 
-local function spawnLastLocation()
+local function spawnLocation()
     DoScreenFadeOut(500)
 
     while not IsScreenFadedOut() do
@@ -441,9 +441,9 @@ local function chooseCharacter()
                                 TriggerEvent('apartments:client:setupSpawnUI', character.citizenid)
                             elseif GetResourceState('qbx_spawn'):find('start') then
                                 TriggerEvent('qb-spawn:client:setupSpawns', character.citizenid)
-                                TriggerEvent('qb-spawn:client:openUI', true)
+                                spawnLocation()
                             else
-                                spawnLastLocation()
+                                spawnLocation()
                             end
                             destroyPreviewCam()
                         end


### PR DESCRIPTION
## Description

`qb-spawn:client:openUI` doesnt really exist in qbx-spawn, and that causes an issue when you try to run a chat like okok for example. Calling the function instead makes it work, I am pretty sure that it is thanks to calling the exports.spawnmanager:spawnPlayer function. The event called before the function updates the coords you choose on the qbx-spawn map so it always spawns you in the right place. 

## Checklist

- [ x] I have personally loaded this code into an updated Qbox project and checked **the spawn functionality**.
- [x ] My pull request fits the contribution guidelines & code conventions.