### PR TITLE
fix: use correct variable name for function

### DIFF
--- a/server/functions.lua
+++ b/server/functions.lua
@@ -531,7 +531,7 @@ exports("SearchPlayers", searchPlayerEntities)
 local function isGradeBoss(group, grade)
     local groupData = GetJob(group) or GetGang(group)
     if not groupData then return end
-    return groupData[grade].IsBoss
+    return groupData[grade].isboss
 end
 
 exports('IsGradeBoss', isGradeBoss)


### PR DESCRIPTION
## Description

Makes this function return something other than false. Apparently I botched this 10 months ago and it wasn't caught. Per the shared data it is should be `isboss` not `IsBoss`

## Checklist

<!-- Put an x inside the [ ] to check an item, like so: [x] -->

- [x] I have personally loaded this code into an updated Qbox project and checked all of its functionality.
- [x] My pull request fits the contribution guidelines & code conventions.
