### PR TITLE
fixed isGradeBoss exports to return a valid boolean

### DIFF
--- a/server/functions.lua
+++ b/server/functions.lua
@@ -531,7 +531,7 @@ exports("SearchPlayers", searchPlayerEntities)
 local function isGradeBoss(group, grade)
     local groupData = GetJob(group) or GetGang(group)
     if not groupData then return end
-    return groupData[grade].isboss
+    return groupData.grades[grade].isboss
 end
 
 exports('IsGradeBoss', isGradeBoss)


### PR DESCRIPTION
## Description
change the IsGradeBoss from a nil value to a valid value
it should be merged because it fix a valid issue

more info:
invalid table access to the job grades to get whether or the grade has the isboss attr as a truthy value

## Checklist
- [x] I have personally loaded this code into an updated Qbox project and checked all of its functionality.
- [x] My pull request fits the contribution guidelines & code conventions.
