### PR TITLE
fix(shared/vehicles): set proper price, category and type for polterminus

### DIFF
--- a/shared/vehicles.lua
+++ b/shared/vehicles.lua
@@ -4945,9 +4945,9 @@ return {
         name = 'Terminus Patrol',
         brand = 'Canis',
         model = 'polterminus',
-        price = 6293144,
-        category = 'helicopters',
-        type = 'heli',
+        price = 61195,
+        category = 'emergency',
+        type = 'automobile',
         hash = `polterminus`,
     },
     pony = {


### PR DESCRIPTION
## Description

Fix the price, category and type of `polterminus` in shared/vehicles.lua

## Checklist

- [x] I have personally loaded this code into an updated Qbox project and checked all of its functionality.
- [x] My pull request fits the contribution guidelines & code conventions.
