### PR TITLE
fix(types): add missing 'type' field to Vehicle class

### DIFF
--- a/types.lua
+++ b/types.lua
@@ -246,6 +246,7 @@
 ---@field model string
 ---@field price number
 ---@field category string
+---@field type string
 ---@field hash string | integer actually just an integer but string is required for types to align when using `asbo` for example
 
 ---@class Weapon


### PR DESCRIPTION
## Description

Add the missing 'type' field to Vehicle class in types.lua.

## Checklist

- [x] I have personally loaded this code into an updated Qbox project and checked all of its functionality.
- [x] My pull request fits the contribution guidelines & code conventions.
