### PR TITLE
fix(server/player): move health init into OnPlayerLoaded to prevent being dead in spawn selection

### DIFF
--- a/config/server.lua
+++ b/config/server.lua
@@ -98,7 +98,7 @@ return {
         },
 
         defaultNumberOfCharacters = 3, -- Define maximum amount of default characters (maximum 3 characters defined by default)
-        disableSetHealth = false, -- Disables the health initialation on player load, useful if you have a spawn resource that sets health
+        enableHealthInitialization = true, -- Enables the health initialation on player load
     },
 
     -- this configuration is for core events only. putting other webhooks here will have no effect

--- a/config/server.lua
+++ b/config/server.lua
@@ -98,6 +98,7 @@ return {
         },
 
         defaultNumberOfCharacters = 3, -- Define maximum amount of default characters (maximum 3 characters defined by default)
+        disableSetHealth = false, -- Disables the health initialation on player load, useful if you have a spawn resource that sets health
     },
 
     -- this configuration is for core events only. putting other webhooks here will have no effect

--- a/server/events.lua
+++ b/server/events.lua
@@ -1,5 +1,5 @@
 local serverConfig = require 'config.server'.server
-local characterConfig = require 'config.server'.character
+local characterConfig = require 'config.server'.characters
 local loggingConfig = require 'config.server'.logging
 local serverName = require 'config.shared'.serverName
 local storage = require 'server.storage.main'

--- a/server/events.lua
+++ b/server/events.lua
@@ -1,4 +1,5 @@
 local serverConfig = require 'config.server'.server
+local characterConfig = require 'config.server'.character
 local loggingConfig = require 'config.server'.logging
 local serverName = require 'config.shared'.serverName
 local storage = require 'server.storage.main'
@@ -188,6 +189,12 @@ end)
 -- `if Player(source).state.isLoggedIn then` for the server side
 RegisterNetEvent('QBCore:Server:OnPlayerLoaded', function()
     Player(source --[[@as Source]]).state:set('isLoggedIn', true, true)
+    
+    if characterConfig.enableHealthInitialization then
+        local player = GetPlayer(source --[[@as Source]])
+        if not player or not player.PlayerData or not player.PlayerData.metadata then return end
+        lib.callback.await('qbx_core:client:setHealth', source --[[@as Source]], player.PlayerData.metadata.health or 200)
+    end
 end)
 
 ---@param source Source

--- a/server/player.lua
+++ b/server/player.lua
@@ -1024,7 +1024,9 @@ function CreatePlayer(playerData, Offline)
     if not self.Offline then
         QBX.Players[self.PlayerData.source] = self
         local ped = GetPlayerPed(self.PlayerData.source)
-        lib.callback.await('qbx_core:client:setHealth', self.PlayerData.source, self.PlayerData.metadata.health)
+        if GetResourceState('qbx_spawn') ~= 'started' or not config.characters.disableSetHealth then
+            lib.callback.await('qbx_core:client:setHealth', self.PlayerData.source, self.PlayerData.metadata.health)
+        end        
         SetPedArmour(ped, self.PlayerData.metadata.armor)
         -- At this point we are safe to emit new instance to third party resource for load handling
         GlobalState.PlayerCount += 1

--- a/server/player.lua
+++ b/server/player.lua
@@ -1026,7 +1026,7 @@ function CreatePlayer(playerData, Offline)
         local ped = GetPlayerPed(self.PlayerData.source)
         if GetResourceState('qbx_spawn') ~= 'started' or not config.characters.disableSetHealth then
             lib.callback.await('qbx_core:client:setHealth', self.PlayerData.source, self.PlayerData.metadata.health)
-        end        
+        end
         SetPedArmour(ped, self.PlayerData.metadata.armor)
         -- At this point we are safe to emit new instance to third party resource for load handling
         GlobalState.PlayerCount += 1

--- a/server/player.lua
+++ b/server/player.lua
@@ -1024,9 +1024,6 @@ function CreatePlayer(playerData, Offline)
     if not self.Offline then
         QBX.Players[self.PlayerData.source] = self
         local ped = GetPlayerPed(self.PlayerData.source)
-        if GetResourceState('qbx_spawn') ~= 'started' or not config.characters.disableSetHealth then
-            lib.callback.await('qbx_core:client:setHealth', self.PlayerData.source, self.PlayerData.metadata.health)
-        end
         SetPedArmour(ped, self.PlayerData.metadata.armor)
         -- At this point we are safe to emit new instance to third party resource for load handling
         GlobalState.PlayerCount += 1


### PR DESCRIPTION
## Description

<!-- What does your pull request change? Why should it be merged? Does it fix an issue? -->
This PR removes the health initialization from the CreatePlayer() function.  
With a dedicated spawn resource, setting health here is unnecessary and may cause players to spawn dead during selection if their saved health metadata is 0.

It should also address this and related issues but I didn't test it directly for qbx_medical, just encountered a similar issue while developing my own medical resource:   
Fixes Qbox-project/qbx_medical#115
## Checklist

<!-- Put an x inside the [ ] to check an item, like so: [x] -->

- [x] I have personally loaded this code into an updated Qbox project and checked all of its functionality.
- [x] My pull request fits the contribution guidelines & code conventions.
