### PR TITLE
fix(player): correct offline handling in money functions

### DIFF
--- a/server/player.lua
+++ b/server/player.lua
@@ -1276,7 +1276,9 @@ function AddMoney(identifier, moneyType, amount, reason)
 
     player.PlayerData.money[moneyType] += amount
 
-    if not player.Offline then
+    if player.Offline then
+        SaveOffline(player.PlayerData)
+    else
         UpdatePlayerData(identifier)
 
         local tags = amount > 100000 and config.logging.role or nil
@@ -1331,7 +1333,9 @@ function RemoveMoney(identifier, moneyType, amount, reason)
 
     player.PlayerData.money[moneyType] -= amount
 
-    if not player.Offline then
+    if player.Offline then
+        SaveOffline(player.PlayerData)
+    else
         UpdatePlayerData(identifier)
 
         local tags = amount > 100000 and config.logging.role or nil
@@ -1379,7 +1383,9 @@ function SetMoney(identifier, moneyType, amount, reason)
 
     player.PlayerData.money[moneyType] = amount
 
-    if not player.Offline then
+    if player.Offline then
+        SaveOffline(player.PlayerData)
+    else
         UpdatePlayerData(identifier)
 
         local difference = amount - oldAmount


### PR DESCRIPTION
## Description

This PR fixes an issue where AddMoney, RemoveMoney, and SetMoney functions would modify offline player money in memory but does not save the changes to the database. Now these functions properly call SaveOffline() for offline players, ensuring money changes persist.

## Checklist

- [x] I have personally loaded this code into an updated Qbox project and checked all of its functionality.
- [x] My pull request fits the contribution guidelines & code conventions.
