### PR TITLE
feat(modules/lib): add qbx.drawMissionText

### DIFF
--- a/modules/lib.lua
+++ b/modules/lib.lua
@@ -465,6 +465,22 @@ else
         ClearDrawOrigin()
     end
 
+    ---@class LibDrawMissionTextParams
+    ---@field text string
+    ---@field time number default: 5000 - 5s
+
+    ---Draws default GTAV notification text with a given time on the screen.
+    ---@param params LibDrawMissionTextParams
+    function qbx.drawMissionText(params)
+        local text = params.text
+        local time = params.time or 5000
+        ClearPrints()
+        ClearSmallPrints()
+        BeginTextCommandPrint('STRING')
+        AddTextComponentSubstringPlayerName(text)
+        EndTextCommandPrint(time, true)
+    end
+
     ---Gets and returns an entity handle and network id from a state bag name
     ---([source](https://github.com/overextended/ox_core/blob/main/client/utils.lua)).
     ---@async


### PR DESCRIPTION
## qbx.drawMissionText

This PR adds qbx.drawMissionText to modules/lib.lua
```lua
---@class LibDrawMissionTextParams
    ---@field text string
    ---@field time number default: 5000 - 5s

    ---Draws default GTAV notification text with a given time on the screen.
    ---@param params LibDrawMissionTextParams
    function qbx.drawMissionText(params)
        local text = params.text
        local time = params.time or 5000
        ClearPrints()
        ClearSmallPrints()
        BeginTextCommandPrint('STRING')
        AddTextComponentSubstringPlayerName(text)
        EndTextCommandPrint(time, true)
    end
```
Here is a example how to use
```lua
qbx.drawMissionText({ text="QBOX Lover", time=10000 })
```
## Checklist

<!-- Put an x inside the [ ] to check an item, like so: [x] -->

- [x] I have personally loaded this code into an updated Qbox project and checked all of its functionality.
- [x] My pull request fits the contribution guidelines & code conventions.
