### PR TITLE
Modify hasKeys function to check resource state

### DIFF
--- a/config/client.lua
+++ b/config/client.lua
@@ -79,6 +79,6 @@ return {
 
     --- Only used by QB bridge
     hasKeys = function(plate, vehicle)
-        return GetResourceState('qbx-vehiclekeys') ~= 'started' or exports.qbx_vehiclekeys:HasKeys(vehicle)
+        return GetResourceState('qbx_vehiclekeys') ~= 'started' or exports.qbx_vehiclekeys:HasKeys(vehicle)
     end,
 }


### PR DESCRIPTION
## Description

Add check for resource state before accessing vehicle keys.

If I remove/stop `qbx_vehiclekeys`, I see an error everytime I enter a vehicle.

This code prevents the constant errors.

## Checklist

- [x] I have personally loaded this code into an updated Qbox project and checked all of its functionality.
- [x] My pull request fits the contribution guidelines & code conventions.
