### PR TITLE
fix(server/events): move playerConnecting db calls to thread

### DIFF
--- a/locales/en.json
+++ b/locales/en.json
@@ -64,7 +64,9 @@
         "birth_date": "Birth Date",
         "select_gender": "Select your gender...",
         "confirm_delete": "Are you sure you wish to delete this character?",
-        "in_queue": "🐌 You are %s/%s in queue. (%s) %s"
+        "in_queue": "🐌 You are %s/%s in queue. (%s) %s",
+        "fetching_user": "Fetching user...",
+        "creating_user": "Creating user..."
     },
     "command": {
         "tp": {


### PR DESCRIPTION
## Description

<!-- What does your pull request change? Why should it be merged? Does it fix an issue? -->

Move the playerConnecting user DB calls to the dedicated DB thread. This would restore previous functionality, where the request can be timed out, and the player would get an appropriate error message.

Return after calling `deferrals.done`. This prevents the below error from occurring, and instead gives users a message that their license is missing.
```
[qbx_core] [ERROR] @qbx_core/server/storage/players.lua:79: no identifier provided
```

## Checklist

<!-- Put an x inside the [ ] to check an item, like so: [x] -->

- [ ] I have personally loaded this code into an updated Qbox project and checked all of its functionality.
- [x] My pull request fits the contribution guidelines & code conventions.
