### PR TITLE
fix(vehicle-persistence): false positives in diff caused by table reference comparison

### DIFF
--- a/client/vehicle-persistence.lua
+++ b/client/vehicle-persistence.lua
@@ -36,7 +36,10 @@ local function calculateDiff(tbl1, tbl2)
         local val1 = tbl1[key]
         local val2 = tbl2[key]
 
-        if val1 ~= val2 then
+        local bothTables = type(val1) == "table" and type(val2) == "table"
+        local equal = (bothTables and lib.table.matches(val1, val2)) or (val1 == val2)
+
+        if not equal then
             diff[key] = val2 == nil and 'deleted' or val2
             hasChanged = true
         end


### PR DESCRIPTION
## Description

This PR fixes incorrect diff detection preventing database updates every 10 seconds.

Previously, calculateDiff compared tables by reference (val1 ~= val2), which caused false positives whenever two tables had identical content, unchanged vehicle fields such as doors, windows, or tyres were being flagged as modified.

The updated implementation performs a deep comparison when both values are tables, using lib.table.matches. 

The behaviour for non-table values and deleted keys remains unchanged.

## Checklist

<!-- Put an x inside the [ ] to check an item, like so: [x] -->

- [x] I have personally loaded this code into an updated Qbox project and checked all of its functionality.
- [x] My pull request fits the contribution guidelines & code conventions.
