### PR TITLE
fix(shared/vehicles): set proper type 'heli' for blimps

### DIFF
--- a/shared/vehicles.lua
+++ b/shared/vehicles.lua
@@ -609,7 +609,7 @@ return {
         model = 'blimp',
         price = 1024161,
         category = 'planes',
-        type = 'plane',
+        type = 'heli',
         hash = `blimp`,
     },
     blimp2 = {
@@ -618,7 +618,7 @@ return {
         model = 'blimp2',
         price = 1036862,
         category = 'planes',
-        type = 'plane',
+        type = 'heli',
         hash = `blimp2`,
     },
     blimp3 = {
@@ -627,7 +627,7 @@ return {
         model = 'blimp3',
         price = 1024161,
         category = 'planes',
-        type = 'plane',
+        type = 'heli',
         hash = `blimp3`,
     },
     blista = {


### PR DESCRIPTION
## Description

Fix the type of `blimp`, `blimp2` and `blimp3` in shared/vehicles.lua so they can spawn properly.

## Checklist

<!-- Put an x inside the [ ] to check an item, like so: [x] -->

- [x] I have personally loaded this code into an updated Qbox project and checked all of its functionality.
- [x] My pull request fits the contribution guidelines & code conventions.
