### PR TITLE
fix: changed kosatka type to submarine

### DIFF
--- a/shared/vehicles.lua
+++ b/shared/vehicles.lua
@@ -3723,7 +3723,7 @@ return {
         model = 'kosatka',
         price = 624016,
         category = 'boats',
-        type = 'boat',
+        type = 'submarine',
         hash = `kosatka`,
     },
     krieger = {


### PR DESCRIPTION
## Description

Because the [CreateVehicleServerSetter native](https://docs.fivem.net/natives/?_0x6AE51D4B) is very strict about vehicle types, it will spawn a fallback model from the passed type and not actually the requested model. This quick change fixes it, so the kosatka can actually be spawned

## Checklist

<!-- Put an x inside the [ ] to check an item, like so: [x] -->

- [ x ] I have personally loaded this code into an updated Qbox project and checked all of its functionality.
- [ x ] My pull request fits the contribution guidelines & code conventions.
