### PR TITLE
feat: Add cooldown in lib.lua

### DIFF
--- a/modules/lib.lua
+++ b/modules/lib.lua
@@ -704,31 +704,4 @@ else
     end
 end
 
-local _cooldowns = {}
-local function getTimestampMs()
-    if GetGameTimer then
-        return GetGameTimer()
-    end
-    return os.time() * 1000
-end
-
----@param key string
----@param durationMs number?
----@return boolean ready
-function qbx.isCooldownReady(key, durationMs)
-    local now = getTimestampMs()
-    local expires = _cooldowns[key]
-    if not expires or now >= expires then
-        _cooldowns[key] = now + (durationMs or 0)
-        return true
-    end
-    return false
-end
-
----@param key string
----@param durationMs number
-function qbx.setCooldown(key, durationMs)
-    _cooldowns[key] = getTimestampMs() + (durationMs or 0)
-end
-
 _ENV.qbx = qbx

--- a/modules/lib.lua
+++ b/modules/lib.lua
@@ -655,4 +655,31 @@ else
     end
 end
 
+local _cooldowns = {}
+local function getTimestampMs()
+    if GetGameTimer then
+        return GetGameTimer()
+    end
+    return os.time() * 1000
+end
+
+---@param key string
+---@param durationMs number?
+---@return boolean ready
+function qbx.isCooldownReady(key, durationMs)
+    local now = getTimestampMs()
+    local expires = _cooldowns[key]
+    if not expires or now >= expires then
+        _cooldowns[key] = now + (durationMs or 0)
+        return true
+    end
+    return false
+end
+
+---@param key string
+---@param durationMs number
+function qbx.setCooldown(key, durationMs)
+    _cooldowns[key] = getTimestampMs() + (durationMs or 0)
+end
+
 _ENV.qbx = qbx


### PR DESCRIPTION
## Description

Stop flood request to server

- Added cooling helpers to `qbx_core/modules/lib.lua`:
  - `qbx.isCooldownReady` tracks per-key cooldowns and optionally notifies players, with built-in flood control.
  - `qbx.setCooldown` allows manual timestamp updates when needed.
  - Inline docs describe parameters and defaults.

## Checklist

- [x] I have personally loaded this code into an updated Qbox project and checked all of its functionality.
- [x] My pull request fits the contribution guidelines & code conventions.
