### PR TITLE
fix(server/commands): Improve santization on /me command

### DIFF
--- a/server/commands.lua
+++ b/server/commands.lua
@@ -406,6 +406,15 @@ lib.addCommand('ooc', {
     end
 end)
 
+function sanitizeTags(msg)
+    return msg
+        :gsub("&", "&amp;")
+        :gsub("<", "&lt;")
+        :gsub(">", "&gt;")
+        :gsub('"', "&quot;")
+        :gsub("'", "&apos;")
+end
+
 lib.addCommand('me', {
     help = locale('command.me.help'),
     params = {
@@ -415,7 +424,7 @@ lib.addCommand('me', {
     args[1] = args[locale('command.me.params.message.name')]
     args[locale('command.me.params.message.name')] = nil
     if #args < 1 then Notify(source, locale('error.missing_args2'), 'error') return end
-    local msg = table.concat(args, ' '):gsub('[~<].-[>~]', '')
+    local msg = sanitizeTags(table.concat(args, ' '))
     local playerState = Player(source).state
     playerState:set('me', msg, true)
 


### PR DESCRIPTION
## Description
This PR fixes a flaw with the tag sanitization on the /me command, which allowed players to display Scaleform tags in the 3D text.

## Checklist
- [x] I have personally loaded this code into an updated Qbox project and checked all of its functionality.
- [x] My pull request fits the contribution guidelines & code conventions.
