### PR TITLE
fix(server/storage): prevent SQL injection via search filter keys

### DIFF
--- a/server/storage/players.lua
+++ b/server/storage/players.lua
@@ -185,10 +185,12 @@ local function handleSearchFilters(filters)
     if filters.charinfo then
         for key, value in pairs(filters.charinfo) do
             if type(value) == "number" then
-                clauses[#clauses + 1] = 'JSON_EXTRACT(charinfo, "$.' .. key .. '") = ?'
+                clauses[#clauses + 1] = 'JSON_EXTRACT(charinfo, ?) = ?'
+                holders[#holders + 1] = '$.' .. key
                 holders[#holders + 1] = value
             elseif type(value) == "string" then
-                clauses[#clauses + 1] = 'JSON_UNQUOTE(JSON_EXTRACT(charinfo, "$.' .. key .. '")) = ?'
+                clauses[#clauses + 1] = 'JSON_UNQUOTE(JSON_EXTRACT(charinfo, ?)) = ?'
+                holders[#holders + 1] = '$.' .. key
                 holders[#holders + 1] = value
             end
         end
@@ -199,16 +201,19 @@ local function handleSearchFilters(filters)
             if key ~= "strict" then
                 if type(value) == "number" then
                     if strict then
-                        clauses[#clauses + 1] = 'JSON_EXTRACT(metadata, "$.' .. key .. '") = ?'
+                        clauses[#clauses + 1] = 'JSON_EXTRACT(metadata, ?) = ?'
                     else
-                        clauses[#clauses + 1] = 'JSON_EXTRACT(metadata, "$.' .. key .. '") >= ?'
+                        clauses[#clauses + 1] = 'JSON_EXTRACT(metadata, ?) >= ?'
                     end
+                    holders[#holders + 1] = '$.' .. key
                     holders[#holders + 1] = value
                 elseif type(value) == "boolean" then
-                    clauses[#clauses + 1] = 'JSON_EXTRACT(metadata, "$.' .. key .. '") = ?'
+                    clauses[#clauses + 1] = 'JSON_EXTRACT(metadata, ?) = ?'
+                    holders[#holders + 1] = '$.' .. key
                     holders[#holders + 1] = tostring(value)
                 elseif type(value) == "string" then
-                    clauses[#clauses + 1] = 'JSON_UNQUOTE(JSON_EXTRACT(metadata, "$.' .. key .. '")) = ?'
+                    clauses[#clauses + 1] = 'JSON_UNQUOTE(JSON_EXTRACT(metadata, ?)) = ?'
+                    holders[#holders + 1] = '$.' .. key
                     holders[#holders + 1] = value
                 end
             end


### PR DESCRIPTION
## Description

`SearchPlayers` builds its WHERE clause in `handleSearchFilters` by pasting the filter table keys straight into the query:

```sql
JSON_UNQUOTE(JSON_EXTRACT(charinfo, "$.' .. key .. '")) = ?
```

The values are bound, the keys are not. A key containing a quote escapes the JSON path and becomes SQL.

## Proof of concept

`SearchPlayers` is a server export, so a client cannot call it directly. But the moment a resource forwards a client supplied filter into it (an admin player search is the obvious case), the keys are attacker controlled:

```lua
local key = [[x")) = '' OR EXTRACTVALUE(1,CONCAT(0x7e,(SELECT CONCAT_WS(0x3a,current_user(),database())),0x7e)) OR JSON_UNQUOTE(JSON_EXTRACT(charinfo, "$.x]]

exports.qbx_core:SearchPlayers({ charinfo = { [key] = 'x' } })
```

The server leaks its DB user and schema in the error: XPATH syntax error: '~root@localhost:qbx_core...'
That is full read access to any table the MySQL user can reach. On a typical local MariaDB (root, FILE privilege, empty secure_file_priv) it goes further: `INTO DUMPFILE` can write a .lua into a resource folder that the server then runs, which
is remote code execution. So read only at best, and RCE on a common default setup.

## Why this should be fixed in the framework
It is a server export and a caller should sanitize what it forwards, fair. But the docs don't hint that filter keys end up inside raw SQL. Passing a table to a search function looks safe, so an author has no reason to escape a key. Exposing callers to SQL injection because they did not scrub a table key is the framework's problem to fix, and fixing it here covers every caller at
once.


## Fix
Bind the JSON path as a parameter instead of concatenating the key:


```lua
clauses[#clauses + 1] = 'JSON_UNQUOTE(JSON_EXTRACT(charinfo, ?)) = ?'
holders[#holders + 1] = '$.' .. key
holders[#holders + 1] = value
```

The key is now data, never query text. charinfo and metadata were the affected filters. license, job and gang use fixed paths and are untouched.

## Checklist
- [x] I have personally loaded this code into an updated Qbox project and checked all of its functionality.
- [x] My pull request fits the contribution guidelines & code conventions.
