### PR TITLE
fix(bridge): bound SpawnVehicle wait and cap concurrent spawns

### DIFF
--- a/bridge/qb/server/functions.lua
+++ b/bridge/qb/server/functions.lua
@@ -27,8 +27,8 @@ function functions.GetPlayers()
     return sources
 end
 
-local maxConcurrentSpawns <const> = 5
-local spawnTimeoutMs <const> = 5000
+local maxConcurrentSpawns <const> = 20
+local spawnTimeoutMs <const> = 10000
 ---@type table<Source, integer>
 local activeSpawns = {}
 

--- a/bridge/qb/server/functions.lua
+++ b/bridge/qb/server/functions.lua
@@ -27,22 +27,48 @@ function functions.GetPlayers()
     return sources
 end
 
+local maxConcurrentSpawns <const> = 5
+local spawnTimeoutMs <const> = 5000
+---@type table<Source, integer>
+local activeSpawns = {}
+
+---@param source Source
+local function releaseSpawn(source)
+    local count = (activeSpawns[source] or 1) - 1
+    activeSpawns[source] = count > 0 and count or nil
+end
+
 ---@deprecated use qbx.spawnVehicle from modules/lib.lua
 ---@return number?
 function functions.SpawnVehicle(source, model, coords, warp)
+    if (activeSpawns[source] or 0) >= maxConcurrentSpawns then return end
+    activeSpawns[source] = (activeSpawns[source] or 0) + 1
+
     local ped = GetPlayerPed(source)
     model = type(model) == 'string' and joaat(model) or model
     if not coords then coords = GetEntityCoords(ped) end
     local heading = coords.w and coords.w or 0.0
     local veh = CreateVehicle(model, coords.x, coords.y, coords.z, heading, true, true)
-    while not DoesEntityExist(veh) do Wait(0) end
+
+    local spawnTimeout = GetGameTimer() + spawnTimeoutMs
+    while not DoesEntityExist(veh) and GetGameTimer() < spawnTimeout do Wait(0) end
+    if not DoesEntityExist(veh) then
+        releaseSpawn(source)
+        return
+    end
+
     if warp then
-        while GetVehiclePedIsIn(ped, false) ~= veh do
+        local warpTimeout = GetGameTimer() + spawnTimeoutMs
+        while GetVehiclePedIsIn(ped, false) ~= veh and GetGameTimer() < warpTimeout do
             Wait(0)
             TaskWarpPedIntoVehicle(ped, veh, -1)
         end
     end
-    while NetworkGetEntityOwner(veh) ~= source do Wait(0) end
+
+    local ownerTimeout = GetGameTimer() + spawnTimeoutMs
+    while NetworkGetEntityOwner(veh) ~= source and GetGameTimer() < ownerTimeout do Wait(0) end
+
+    releaseSpawn(source)
     return veh
 end
 


### PR DESCRIPTION
## Description

The deprecated qb-compat `SpawnVehicle` runs an unbounded wait after creating the vehicle:
```lua
    local veh = CreateVehicle(model, ...)
    while not DoesEntityExist(veh) do Wait(0) end
```

It is reachable by any client through `QBCore:Server:TriggerCallback` with no auth. If the model is invalid, `CreateVehicle` returns 0 and `DoesEntityExist(0)` is never true, so the handler thread spins on `Wait(0)` forever. Every request leaks one stuck thread, and a client can loop these to climb qbx_core CPU until a restart.

## PoC

Running this a few hundred times from a client leaves that many threads spinning every tick:

```lua
TriggerServerEvent('QBCore:Server:TriggerCallback', 'QBCore:Server:SpawnVehicle', 'not_a_real_model')
```

`resmon` shows qbx_core climbing and never dropping back.

## Fix

1. Every wait loop (creation, warp, owner) now has a timeout, so an invalid model or a
   disconnected player can no longer wedge a thread. If the vehicle never exists, it
   returns early.
2. A per source cap on concurrent in flight spawns, so even within the timeout window a
   flood is rejected instead of stacking threads.


## Checklist

<!-- Put an x inside the [ ] to check an item, like so: [x] -->

- [x] I have personally loaded this code into an updated Qbox project and checked all of its functionality.
- [x] My pull request fits the contribution guidelines & code conventions.
