### PR TITLE
fix(server/character): enforce character limit and protect unique ids

### DIFF
--- a/server/character.lua
+++ b/server/character.lua
@@ -54,6 +54,16 @@ end)
 ---@param data unknown
 ---@return table? newData
 lib.callback.register('qbx_core:server:createCharacter', function(source, data)
+    if type(data) ~= 'table' then return end
+
+    local license2, license = GetPlayerIdentifierByType(source, 'license2'), GetPlayerIdentifierByType(source, 'license')
+    if #storage.fetchAllPlayerEntities(license2, license) >= getAllowedAmountOfCharacters(license2, license) then
+        return
+    end
+
+    data.phone = nil
+    data.account = nil
+
     local newData = {}
     newData.charinfo = data
 


### PR DESCRIPTION
## Description

`createCharacter` takes the client's table as charinfo and never checks the character limit:

```lua
    newData.charinfo = data
```

Two confirmed problems:

1. **No server side character limit.** `getAllowedAmountOfCharacters` is only read by
   `getCharacters` to tell the UI how many slots to draw. The create path never checks
   it, so a client calling the callback directly can create characters past the
   configured limit (one per session, repeatable across relogs).

2. **Client controlled unique identifiers.** `phone` and `account` are meant to be
   generated by `GenerateUniqueIdentifier`, but `CheckPlayerData` only fills them when
   they are missing. A client that sends `phone` or `account` in charinfo keeps its own
   value, which also skips the uniqueness check, so two characters can share the same
   phone number or account number.

## PoC

At the character select screen the client calls the callback directly:

```lua
lib.callback('qbx_core:server:createCharacter', false, function() end, {
    firstname = 'PWNED', lastname = 'PWNED', nationality = 'USA',
    birthdate = '01-01-2000', gender = 0,
    phone = '1337', account = 'ATTACKER-PICKED',
})
```

The created character is saved with `phone = 1337` and `account = ATTACKER-PICKED`. Repeat it and you get more characters than the limit allows, all sharing those values.

## Fix

In `createCharacter`:

1. Reject the call when the account already has the maximum number of characters.
2. Drop `phone` and `account` from the client data so the server always generates them
   through `GenerateUniqueIdentifier` and the uniqueness checks hold.
3. Reject non table data.


## Checklist

<!-- Put an x inside the [ ] to check an item, like so: [x] -->

- [x] I have personally loaded this code into an updated Qbox project and checked all of its functionality.
- [x] My pull request fits the contribution guidelines & code conventions.
