### PR TITLE
fix(server/functions): check discord and ip bans on connect

### DIFF
--- a/server/functions.lua
+++ b/server/functions.lua
@@ -369,30 +369,23 @@ exports('ToggleOptin', ToggleOptin)
 ---@return boolean
 ---@return string? playerMessage
 function IsPlayerBanned(source)
-    local license = GetPlayerIdentifierByType(source --[[@as string]], 'license')
-    local license2 = GetPlayerIdentifierByType(source --[[@as string]], 'license2')
-    local result = license2 and storage.fetchBan({ license = license2 })
+    local request = {
+        { license = GetPlayerIdentifierByType(source --[[@as string]], 'license') },
+        { license = GetPlayerIdentifierByType(source --[[@as string]], 'license2') },
+        { discordId = GetPlayerIdentifierByType(source --[[@as string]], 'discord') },
+        { ip = GetPlayerIdentifierByType(source --[[@as string]], 'ip') },
+    }
 
-    if not result then
-        result = storage.fetchBan({ license = license })
-    end
-
+    local result = storage.fetchBan(request)
     if not result then return false end
 
     if os.time() < result.expire then
         local timeTable = os.date('*t', tonumber(result.expire))
 
         return true, ('You have been banned from the server:\n%s\nYour ban expires in %s/%s/%s %s:%s\n'):format(result.reason, timeTable.day, timeTable.month, timeTable.year, timeTable.hour, timeTable.min)
-    else
-        CreateThread(function()
-            if license2 then
-                storage.deleteBan({ license = license2 })
-            end
-
-            storage.deleteBan({ license = license })
-        end)
     end
 
+    storage.deleteBan(request)
     return false
 end
 

--- a/server/storage/players.lua
+++ b/server/storage/players.lua
@@ -59,36 +59,47 @@ local function insertBan(request)
     return true
 end
 
----@param request GetBanRequest
----@return string column in storage
----@return string value of the id
-local function getBanId(request)
-    if request.license then
-        return 'license', request.license
-    elseif request.discordId then
-        return 'discord', request.discordId
-    elseif request.ip then
-        return 'ip', request.ip
-    else
-        error('no identifier provided', 2)
+local banColumns = {
+    license = 'license',
+    discordId = 'discord',
+    ip = 'ip',
+}
+
+---@param request GetBanRequest | GetBanRequest[]
+---@return string clause, string[] values
+local function buildBanFilter(request)
+    local requests = request[1] and request or { request }
+    local clauses = {}
+    local values = {}
+    for i = 1, #requests do
+        for key, column in pairs(banColumns) do
+            local value = requests[i][key]
+            if value then
+                clauses[#clauses + 1] = column .. ' = ?'
+                values[#values + 1] = value
+            end
+        end
     end
+    return table.concat(clauses, ' OR '), values
 end
 
----@param request GetBanRequest
+---@param request GetBanRequest | GetBanRequest[]
 ---@return BanEntity?
 local function fetchBan(request)
-    local column, value = getBanId(request)
-    local result = MySQL.single.await('SELECT expire, reason FROM bans WHERE ' ..column.. ' = ?', { value })
+    local clause, values = buildBanFilter(request)
+    if clause == '' then return nil end
+    local result = MySQL.single.await('SELECT expire, reason FROM bans WHERE ' .. clause .. ' ORDER BY expire DESC', values)
     return result and {
         expire = result.expire,
         reason = result.reason,
     } or nil
 end
 
----@param request GetBanRequest
+---@param request GetBanRequest | GetBanRequest[]
 local function deleteBan(request)
-    local column, value = getBanId(request)
-    MySQL.query.await('DELETE FROM bans WHERE ' ..column.. ' = ?', { value })
+    local clause, values = buildBanFilter(request)
+    if clause == '' then return end
+    MySQL.query.await('DELETE FROM bans WHERE ' .. clause, values)
 end
 
 ---@param request UpsertPlayerRequest

--- a/types.lua
+++ b/types.lua
@@ -87,8 +87,8 @@
 
 ---@class StorageFunctions
 ---@field insertBan fun(request: InsertBanRequest)
----@field fetchBan fun(request: GetBanRequest): BanEntity?
----@field deleteBan fun(request: GetBanRequest)
+---@field fetchBan fun(request: GetBanRequest | GetBanRequest[]): BanEntity?
+---@field deleteBan fun(request: GetBanRequest | GetBanRequest[])
 ---@field upsertPlayerEntity fun(request: UpsertPlayerRequest)
 ---@field fetchPlayerSkin fun(citizenId: string): PlayerSkin?
 ---@field fetchPlayerEntity fun(citizenId: string): PlayerEntity?


### PR DESCRIPTION

## Description

`IsPlayerBanned` only queries the `license` column:

```lua
    local result = license2 and storage.fetchBan({ license = license2 })
    if not result then
        result = storage.fetchBan({ license = license })
    end
```

Bans can be placed on a discord id or an ip as well. `insertBan` accepts any of the three, and the anti cheat `ExploitBan` writes all three. Because the connect check never looks at the discord or ip columns, those bans are never enforced. A banned player who changes their license (the thing a discord or ip ban exists to catch) reconnects with no ban applied, and a ban placed only on a discord id or ip does nothing from the moment it is created 

## Fix

Check every identifier the player connects with (license2, license, discord, ip) against the bans table, not just the license. If any of them has an active ban the player is refused. Expired bans found during the check are still cleaned up.

`storage.fetchBan` and `storage.deleteBan` now accept either a single request or an array of requests and resolve it in one query, so existing single identifier callers keep working while the connect check passes all identifiers at once.

## Checklist

<!-- Put an x inside the [ ] to check an item, like so: [x] -->

- [x] I have personally loaded this code into an updated Qbox project and checked all of its functionality.
- [x] My pull request fits the contribution guidelines & code conventions.
