### PR TITLE
fix(server/player): reject non-finite money amounts

### DIFF
--- a/modules/lib.lua
+++ b/modules/lib.lua
@@ -146,6 +146,13 @@ function qbx.math.round(num, decimalPlaces)
     return math.floor((num * power) + 0.5) / power
 end
 
+---Returns whether the given value is a finite number (not nil, NaN or infinity).
+---@param value any
+---@return boolean
+function qbx.math.isFinite(value)
+    return type(value) == 'number' and value == value and value ~= math.huge and value ~= -math.huge
+end
+
 ---Returns the number of items in a table. Useful for non-array tables.
 ---@param tbl table
 ---@return integer

--- a/server/player.lua
+++ b/server/player.lua
@@ -1255,6 +1255,14 @@ local function emitMoneyEvents(source, playerMoney, moneyType, amount, actionTyp
     end
 end
 
+local function validateMoneyAmount(value)
+    value = tonumber(value)
+    if not qbx.math.isFinite(value) then return end
+    value = qbx.math.round(value)
+    if value < 0 then return end
+    return value
+end
+
 ---@param identifier Source | string
 ---@param moneyType MoneyType
 ---@param amount number
@@ -1266,9 +1274,11 @@ function AddMoney(identifier, moneyType, amount, reason)
     if not player then return false end
 
     reason = reason or 'unknown'
-    amount = qbx.math.round(tonumber(amount) --[[@as number]])
+    local validAmount = validateMoneyAmount(amount)
 
-    if amount < 0 or not player.PlayerData.money[moneyType] then return false end
+    if not validAmount or not player.PlayerData.money[moneyType] then return false end
+
+    amount = validAmount
 
     if not triggerEventHooks('addMoney', {
         source = player.PlayerData.source,
@@ -1315,9 +1325,11 @@ function RemoveMoney(identifier, moneyType, amount, reason)
     if not player then return false end
 
     reason = reason or 'unknown'
-    amount = qbx.math.round(tonumber(amount) --[[@as number]])
+    local validAmount = validateMoneyAmount(amount)
 
-    if amount < 0 or not player.PlayerData.money[moneyType] then return false end
+    if not validAmount or not player.PlayerData.money[moneyType] then return false end
+
+    amount = validAmount
 
     if not triggerEventHooks('removeMoney', {
         source = player.PlayerData.source,
@@ -1372,10 +1384,12 @@ function SetMoney(identifier, moneyType, amount, reason)
     if not player then return false end
 
     reason = reason or 'unknown'
-    amount = qbx.math.round(tonumber(amount) --[[@as number]])
+    local validAmount = validateMoneyAmount(amount)
     local oldAmount = player.PlayerData.money[moneyType]
 
-    if amount < 0 or not oldAmount then return false end
+    if not validAmount or not oldAmount then return false end
+
+    amount = validAmount
 
     if not triggerEventHooks('setMoney', {
         source = player.PlayerData.source,

--- a/server/player.lua
+++ b/server/player.lua
@@ -1255,6 +1255,8 @@ local function emitMoneyEvents(source, playerMoney, moneyType, amount, actionTyp
     end
 end
 
+---@param value unknown
+---@return number?
 local function validateMoneyAmount(value)
     value = tonumber(value)
     if not qbx.math.isFinite(value) then return end


### PR DESCRIPTION

## Description

`AddMoney`, `RemoveMoney` and `SetMoney` validate the amount with a single `amount < 0` check after rounding:

```lua
    amount = qbx.math.round(tonumber(amount))
    if amount < 0 or not player.PlayerData.money[moneyType] then return false end
```

Every comparison with NaN is false, so `NaN < 0` is false and a NaN amount passes the guard, after which `money - NaN` / `money + NaN` sets the balance to NaN. `+inf` does the same on `AddMoney`/`SetMoney`, which have no balance guard at all. A non numeric string makes `tonumber` return nil, and `qbx.math.round(nil)` then throws instead of returning false.

A NaN balance never depletes on a direct `RemoveMoney` (because `(NaN - x) < 0` is also false), renders as `nan` in UIs, and breaks when the money table is saved as JSON. The money functions are exports, so this is reachable whenever a caller forwards an unvalidated amount into them.

## Fix

Added `qbx.math.isFinite(value)` next to `qbx.math.round`, and a small `validateMoneyAmount` helper that coerces the amount, rejects anything that is not a finite non negative number, then rounds it. `AddMoney`, `RemoveMoney` and `SetMoney` now bail before touching the balance when the amount is invalid. Negative amounts are still rejected, and valid amounts behave exactly as before.

## Checklist

<!-- Put an x inside the [ ] to check an item, like so: [x] -->

- [x] I have personally loaded this code into an updated Qbox project and checked all of its functionality.
- [x] My pull request fits the contribution guidelines & code conventions.
