### PR TITLE
fix(server/player): validate metadata input and fix dead-state key

### DIFF
--- a/server/loops.lua
+++ b/server/loops.lua
@@ -6,8 +6,8 @@ local function removeHungerAndThirst(src, player)
     local newHunger = playerState.hunger - config.player.hungerRate
     local newThirst = playerState.thirst - config.player.thirstRate
 
-    player.Functions.SetMetaData('thirst', math.max(0, newThirst))
-    player.Functions.SetMetaData('hunger', math.max(0, newHunger))
+    player.Functions.SetMetaData('thirst', newThirst)
+    player.Functions.SetMetaData('hunger', newHunger)
 
     player.Functions.Save()
 end

--- a/server/player.lua
+++ b/server/player.lua
@@ -1133,18 +1133,30 @@ function SetMetadata(identifier, metadata, value)
 
     if not player then return end
 
+    if metadata == 'hunger' or metadata == 'thirst' or metadata == 'stress' then
+        value = tonumber(value)
+        if not qbx.math.isFinite(value) then return end
+        value = lib.math.clamp(value, 0, 100)
+    end
+
     local oldValue
 
     if metadata:match('%.') then
         local metaTable, metaKey = metadata:match('([^%.]+)%.(.+)')
 
         if metaKey:match('%.') then
-            lib.print.error('cannot get nested metadata more than 1 level deep')
+            lib.print.error('cannot set nested metadata more than 1 level deep')
+            return
         end
 
-        oldValue = player.PlayerData.metadata[metaTable]
+        local nested = player.PlayerData.metadata[metaTable]
+        if type(nested) ~= 'table' then
+            lib.print.error(('cannot set nested metadata, %s is not a table'):format(metaTable))
+            return
+        end
 
-        player.PlayerData.metadata[metaTable][metaKey] = value
+        oldValue = nested[metaKey]
+        nested[metaKey] = value
 
         metadata = metaTable
     else
@@ -1162,14 +1174,12 @@ function SetMetadata(identifier, metadata, value)
         TriggerEvent('qbx_core:server:onSetMetaData', metadata,  oldValue, value, player.PlayerData.source)
 
         if (metadata == 'hunger' or metadata == 'thirst' or metadata == 'stress') then
-            value = lib.math.clamp(value, 0, 100)
-
             if playerState[metadata] ~= value then
                 playerState:set(metadata, value, true)
             end
         end
 
-        if (metadata == 'dead' or metadata == 'inlaststand') then
+        if (metadata == 'isdead' or metadata == 'inlaststand') then
             playerState:set('canUseWeapons', not value, true)
         end
     end
@@ -1200,9 +1210,13 @@ function GetMetadata(identifier, metadata)
 
         if metaKey:match('%.') then
             lib.print.error('cannot get nested metadata more than 1 level deep')
+            return
         end
 
-        return player.PlayerData.metadata[metaTable][metaKey]
+        local nested = player.PlayerData.metadata[metaTable]
+        if type(nested) ~= 'table' then return end
+
+        return nested[metaKey]
     else
         return player.PlayerData.metadata[metadata]
     end


### PR DESCRIPTION
## Description

Three input handling problems in `SetMetadata` / `GetMetadata`:

1. **Nested key crash.** Both functions resolve `a.b` to
   `metadata[metaTable][metaKey]` with no check that `metaTable` is an existing table.
   `SetMetadata(src, 'nope.key', v)` (or any parent that is nil or not a table) throws
   `attempt to index a nil value` out of the export. The more than one level case
   (`a.b.c`) logged an error but did not return, so it kept going with a bad key.

2. **hunger / thirst / stress accept any value.** These are reachable from the client
   through the player statebag. The handler wrote the raw value into metadata and
   persisted it before clamping, and the clamp only ran on the statebag copy after the
   fact. A non number value (string, table) was stored as is and then `lib.math.clamp`
   threw on it. So a client could persist an out of range or non numeric
   hunger/thirst/stress, or crash the handler.

3. **Weapon lock keyed on the wrong field.** The `canUseWeapons` branch checked
   `metadata == 'dead'`, but the death flag is `isdead` everywhere else: it is the typed
   field (types.lua), it is initialized in `CheckPlayerData`, it is the save trigger in
   this same function, and qbx_medical sets it with `SetMetaData('isdead', ...)`. Nothing
   ever sets `metadata.dead`, so the branch never fired and a dead player kept
   `canUseWeapons` enabled.

## Fix

- Validate `hunger` / `thirst` / `stress` up front: coerce with `tonumber`, reject if not
  finite via `qbx.math.isFinite`, and clamp to 0-100 before the value is written and
  persisted. The later statebag clamp is now redundant and removed.
- Guard the nested path in both `SetMetadata` and `GetMetadata`: return if the key is more
  than one level deep, and return if the parent is not a table, instead of indexing it.
- Check `metadata == 'isdead'` for the weapon lock so it matches the actual death flag.
- With clamping now centralized in `SetMetadata`, drop the redundant `math.max(0, ...)`
  in `removeHungerAndThirst` (server/loops.lua) and let the setter own the bounds. This is
  behavior identical, since that loop only decrements from the already bounded statebag.

## Testing

- `SetMetadata(src, 'hunger', 'abc' / nil / 0/0)` returns without writing or throwing; a
  numeric value is clamped to 0-100 and persisted.
- `SetMetadata` / `GetMetadata` with a nested key whose parent does not exist returns
  cleanly instead of throwing.
- Setting `isdead` true/false now flips `canUseWeapons` as intended; normal metadata
  writes are unchanged.


## Checklist

<!-- Put an x inside the [ ] to check an item, like so: [x] -->

- [x] I have personally loaded this code into an updated Qbox project and checked all of its functionality.
- [x] My pull request fits the contribution guidelines & code conventions.
