### PR TITLE
fix: conditionally register /optin command based on config

### DIFF
--- a/server/commands.lua
+++ b/server/commands.lua
@@ -458,10 +458,12 @@ lib.addCommand('deletechar', {
     Notify(source, locale('success.character_deleted_citizenid', citizenId))
 end)
 
-lib.addCommand('optin', {
-    help = locale('command.optin.help'),
-    restricted = 'group.admin'
-}, function(source, args)
-    ToggleOptin(source)
-    Notify(source, locale('success.optin_set', IsOptin(source) and 'in' or 'out'))
-end)
+if config.server.requireOptIn then
+    lib.addCommand('optin', {
+        help = locale('command.optin.help'),
+        restricted = 'group.admin'
+    }, function(source, args)
+        ToggleOptin(source)
+        Notify(source, locale('success.optin_set', IsOptin(source) and 'in' or 'out'))
+    end)
+end


### PR DESCRIPTION
## Description

This PR conditionally registers the `/optin` command based on the `requireOptIn` setting in the server configuration.

Previously, even if `requireOptIn` was set to `false`, the `/optin` command would still be registered, show up in chat suggestions, and display a state-change success notification when used (despite not actually being required). By wrapping the command registration in an `if config.server.requireOptIn then` check, the command is completely hidden and disabled when the feature is turned off in the config.

## Checklist

- [x] I have personally loaded this code into an updated Qbox project and checked all of its functionality.
- [x] My pull request fits the contribution guidelines & code conventions.
