### PR TITLE
refactor(server/player): drive numeric metadata validation from a lookup table

### DIFF
--- a/server/player.lua
+++ b/server/player.lua
@@ -14,6 +14,15 @@ for i = 1, #accounts do
     accountsAsItems[accounts[i]] = 0
 end
 
+-- Numeric metadata mirrored from client statebags. Values are validated and
+-- clamped before being persisted, so a spoofed statebag can't corrupt or crash
+-- these stats. Add new bounded stats here rather than special-casing them below.
+local numericMetadata = {
+    hunger = { min = 0, max = 100 },
+    thirst = { min = 0, max = 100 },
+    stress = { min = 0, max = 100 },
+}
+
 ---@param source Source
 ---@param citizenid? string
 ---@param newData? PlayerEntity
@@ -1133,10 +1142,14 @@ function SetMetadata(identifier, metadata, value)
 
     if not player then return end
 
-    if metadata == 'hunger' or metadata == 'thirst' or metadata == 'stress' then
+    local numeric = numericMetadata[metadata]
+    if numeric then
         value = tonumber(value)
-        if not qbx.math.isFinite(value) then return end
-        value = lib.math.clamp(value, 0, 100)
+        if not qbx.math.isFinite(value) then
+            lib.print.warn(('rejected non-finite value for metadata "%s"'):format(metadata))
+            return
+        end
+        value = lib.math.clamp(value, numeric.min, numeric.max)
     end
 
     local oldValue
@@ -1173,7 +1186,7 @@ function SetMetadata(identifier, metadata, value)
         TriggerClientEvent('qbx_core:client:onSetMetaData', player.PlayerData.source, metadata, oldValue, value)
         TriggerEvent('qbx_core:server:onSetMetaData', metadata,  oldValue, value, player.PlayerData.source)
 
-        if (metadata == 'hunger' or metadata == 'thirst' or metadata == 'stress') then
+        if numericMetadata[metadata] then
             if playerState[metadata] ~= value then
                 playerState:set(metadata, value, true)
             end


### PR DESCRIPTION
## Description

<!-- What does your pull request change? Why should it be merged? Does it fix an issue? -->

Follow-up to #753.

#753 added input validation for `hunger`/`thirst`/`stress` in `SetMetadata`, 
but spread it across two hardcoded conditionals. This refactors that into a 
single `numericMetadata` lookup table describing each bounded stat's min/max.

Benefits:
- New clamped stats are added in one place instead of editing two `if` chains
- The statebag sync block reuses the same table (single source of truth)
- Logs a warning when a non-finite value is rejected, making statebag 
  tampering easier to spot in server logs

No behavior change for existing stats — purely a maintainability/observability 
improvement on top of #753.

## Checklist

<!-- Put an x inside the [ ] to check an item, like so: [x] -->

- [x] I have personally loaded this code into an updated Qbox project and checked all of its functionality.
- [x] My pull request fits the contribution guidelines & code conventions.
