### PR TITLE
fix(bridge/qb): correct vehicle prop/colour mapping, 12h clock and Ki…

### DIFF
--- a/bridge/qb/client/functions.lua
+++ b/bridge/qb/client/functions.lua
@@ -432,7 +432,7 @@ function functions.SetVehicleProperties(vehicle, props)
 
     -- qb properties converted to ox
     props.modNitrous = props.modNitrous or props.modKit17
-    props.modSubwoofer = props.modSubwoofer or props.modKit17
+    props.modSubwoofer = props.modSubwoofer or props.modKit19
     props.modHydraulics = props.modHydraulics or props.modKit21
     props.modDoorR = props.modDoorR or props.modKit47
     props.modLightbar = props.modLightbar or props.modKit49
@@ -503,7 +503,7 @@ function functions.SetVehicleProperties(vehicle, props)
     if props.color2 then
         if type(props.color2) == 'number' then
             ClearVehicleCustomSecondaryColour(vehicle)
-            SetVehicleColours(vehicle, props.color1 or colorPrimary --[[@as number]], props.color2 --[[@as number]])
+            SetVehicleColours(vehicle, (type(props.color1) == 'number' and props.color1) or colorPrimary --[[@as number]], props.color2 --[[@as number]])
         else
             if props.paintType2 then SetVehicleModColor_2(vehicle, props.paintType2, colorSecondary) end
 
@@ -885,9 +885,16 @@ functions.GetCurrentTime = function()
     obj.min = GetClockMinutes()
     obj.hour = GetClockHours()
 
-    if obj.hour <= 12 then
+    if obj.hour == 0 then
         obj.ampm = 'AM'
-    elseif obj.hour >= 13 then
+        obj.formattedHour = 12
+    elseif obj.hour < 12 then
+        obj.ampm = 'AM'
+        obj.formattedHour = obj.hour
+    elseif obj.hour == 12 then
+        obj.ampm = 'PM'
+        obj.formattedHour = 12
+    else
         obj.ampm = 'PM'
         obj.formattedHour = obj.hour - 12
     end

--- a/bridge/qb/server/functions.lua
+++ b/bridge/qb/server/functions.lua
@@ -108,20 +108,6 @@ functions.Kick = function(source, reason, setKickReason, deferrals)
         if source then
             DropPlayer(source --[[@as string]], reason)
         end
-        for _ = 0, 4 do
-            while true do
-                if source then
-                    if GetPlayerPing(source --[[@as string]]) >= 0 then
-                        break
-                    end
-                    Wait(100)
-                    CreateThread(function()
-                        DropPlayer(source --[[@as string]], reason)
-                    end)
-                end
-            end
-            Wait(5000)
-        end
     end)
 end
 

--- a/modules/utils.lua
+++ b/modules/utils.lua
@@ -736,9 +736,16 @@ else
         obj.min = GetClockMinutes()
         obj.hour = GetClockHours()
 
-        if obj.hour <= 12 then
+        if obj.hour == 0 then
             obj.ampm = 'AM'
-        elseif obj.hour >= 13 then
+            obj.formattedHour = 12
+        elseif obj.hour < 12 then
+            obj.ampm = 'AM'
+            obj.formattedHour = obj.hour
+        elseif obj.hour == 12 then
+            obj.ampm = 'PM'
+            obj.formattedHour = 12
+        else
             obj.ampm = 'PM'
             obj.formattedHour = obj.hour - 12
         end


### PR DESCRIPTION
…ck loop

- modSubwoofer fell back to modKit17 (nitrous) instead of modKit19, so qb props carried the wrong subwoofer mod.
- the secondary-colour path passed props.color1 straight to SetVehicleColours; when color1 is a custom RGB table that is not a valid colour index. Fall back to colorPrimary unless color1 is a number.
- GetCurrentTime reported noon (hour 12) as AM and never set formattedHour for hours 0-12, so midnight/noon and AM hours formatted wrong. Use standard 12-hour conversion.
- Kick ran an unguarded `while true` with no Wait: a nil source spun the thread forever, and a disconnected player (ping < 0) spawned DropPlayer threads every 100ms indefinitely. The retry loop is pointless since DropPlayer already ran once; remove it.

## Description

<!-- What does your pull request change? Why should it be merged? Does it fix an issue? -->

## Checklist

<!-- Put an x inside the [ ] to check an item, like so: [x] -->

- [x] I have personally loaded this code into an updated Qbox project and checked all of its functionality.
- [x] My pull request fits the contribution guidelines & code conventions.
