### PR TITLE
fix(server/player): guard SetJob, SetGang and ForceDeleteCharacter ag…

### DIFF
--- a/server/player.lua
+++ b/server/player.lua
@@ -118,6 +118,12 @@ function SetJob(identifier, jobName, grade)
 
     local player = type(identifier) == 'string' and (GetPlayerByCitizenId(identifier) or GetOfflinePlayer(identifier)) or GetPlayer(identifier)
 
+    if not player then
+        lib.print.error(('cannot set job. no player found for identifier %s'):format(identifier))
+
+        return false
+    end
+
     if setJobReplaces and player.PlayerData.job.name ~= 'unemployed' then
         local success, errorResult = RemovePlayerFromJob(player.PlayerData.citizenid, player.PlayerData.job.name)
 
@@ -371,6 +377,12 @@ function SetGang(identifier, gangName, grade)
     end
 
     local player = type(identifier) == 'string' and (GetPlayerByCitizenId(identifier) or GetOfflinePlayer(identifier)) or GetPlayer(identifier)
+
+    if not player then
+        lib.print.error(('cannot set gang. no player found for identifier %s'):format(identifier))
+
+        return false
+    end
 
     if setGangReplaces and player.PlayerData.gang.name ~= 'none' then
         local success, errorResult = RemovePlayerFromGang(player.PlayerData.citizenid, player.PlayerData.gang.name)
@@ -1508,8 +1520,8 @@ lib.callback.register('qbx_core:server:deleteCharacter', DeleteCharacter)
 
 ---@param citizenid string
 function ForceDeleteCharacter(citizenid)
-    local result = storage.fetchPlayerEntity(citizenid).license
-    if result then
+    local playerEntity = storage.fetchPlayerEntity(citizenid)
+    if playerEntity and playerEntity.license then
         local player = GetPlayerByCitizenId(citizenid)
         if player then
             DropPlayer(player.PlayerData.source --[[@as string]], 'An admin deleted the character which you are currently using')


### PR DESCRIPTION
These three functions resolved a player or player entity from a caller-supplied identifier and then dereferenced the result without a nil check:

- SetJob/SetGang indexed player.PlayerData when GetPlayerByCitizenId/ GetOfflinePlayer/GetPlayer returned nil for an unknown identifier, erroring instead of returning false like their other failure paths.
- ForceDeleteCharacter indexed .license on the return of fetchPlayerEntity, which is nil for an unknown citizenid (e.g. an admin typo), crashing the function.

Return false / bail out cleanly when no player is found.

## Description

<!-- What does your pull request change? Why should it be merged? Does it fix an issue? -->

## Checklist

<!-- Put an x inside the [ ] to check an item, like so: [x] -->

- [x] I have personally loaded this code into an updated Qbox project and checked all of its functionality.
- [x] My pull request fits the contribution guidelines & code conventions.
