### PR TITLE
fix(server/loops): guard paycheck against missing job grade

### DIFF
--- a/server/loops.lua
+++ b/server/loops.lua
@@ -24,9 +24,15 @@ end)
 
 local function pay(player)
     local job = player.PlayerData.job
-    local payment = GetJob(job.name).grades[job.grade.level].payment or job.payment
+    local jobData = GetJob(job.name)
+    local grade = jobData and jobData.grades[job.grade.level]
+    if not grade then
+        lib.print.error(('cannot pay %s. job "%s" does not have grade %s'):format(player.PlayerData.citizenid, job.name, job.grade.level))
+        return
+    end
+    local payment = grade.payment or job.payment
     if payment <= 0 then return end
-    if not GetJob(job.name).offDutyPay and not job.onduty then return end
+    if not jobData.offDutyPay and not job.onduty then return end
     if not config.money.paycheckSociety then
         config.sendPaycheck(player, payment)
         return


### PR DESCRIPTION
pay() indexed GetJob(job.name).grades[job.grade.level].payment with no nil checks. A player whose job or grade no longer exists in shared jobs (removed/renamed job, edited grades) threw an error inside the paycheck loop, which runs unprotected in a while-true thread. That killed the thread and stopped paychecks for every player until a restart.

Resolve the job and grade defensively, log and skip the player when the grade is gone, and reuse the resolved job table for the offDutyPay check instead of looking it up a second time.

## Description

<!-- What does your pull request change? Why should it be merged? Does it fix an issue? -->

## Checklist

<!-- Put an x inside the [ ] to check an item, like so: [x] -->

- [x] I have personally loaded this code into an updated Qbox project and checked all of its functionality.
- [x] My pull request fits the contribution guidelines & code conventions.
