### PR TITLE
fix(data): remove duplicate Nigerian entry in nationalities.lua

### DIFF
--- a/data/nationalities.lua
+++ b/data/nationalities.lua
@@ -134,7 +134,6 @@ return {
     'New Zealander',
     'Nicaraguan',
     'Nigerian',
-    'Nigerian',
     'Niuean',
     'Ni-Vanuatu',
     'Northern Mariana Islander',


### PR DESCRIPTION
## Description

Removes a duplicate 'Nigerian' entry from data/nationalities.lua. This causes "Nigerian" to render twice in any UI that uses this list (i.e., when creating a character and entering a nationality).

## Checklist

- [x] I have personally loaded this code into an updated Qbox project and checked all of its functionality.
- [x] My pull request fits the contribution guidelines & code conventions.