### PR TITLE
fix(bridge): pass anim flag in Progressbar

### DIFF
--- a/bridge/qb/client/functions.lua
+++ b/bridge/qb/client/functions.lua
@@ -125,7 +125,7 @@ function functions.Progressbar(_, label, duration, useWhileDead, canCancel, disa
         anim = {
             dict = animation?.animDict,
             clip = animation?.anim,
-            flags = animation?.flags
+            flag = animation?.flags
         },
         prop = props,
     }) then


### PR DESCRIPTION
## Description

fixed the anim flag not being passed to lib.progressBar. ox_lib's progressBar reads anim.flag but the qb bridge was passing flags.

## Checklist

<!-- Put an x inside the [ ] to check an item, like so: [x] -->

- [x] I have personally loaded this code into an updated Qbox project and checked all of its functionality.
- [x] My pull request fits the contribution guidelines & code conventions.