### PR TITLE
refactor: extract shared helpers to reduce duplication

### DIFF
--- a/bridge/qb/client/functions.lua
+++ b/bridge/qb/client/functions.lua
@@ -1,6 +1,12 @@
 require 'client.functions'
 local functions = {}
 
+---@param coords vector3|table?
+---@return vector3
+local function toCoords(coords)
+    return type(coords) == 'table' and vec3(coords.x, coords.y, coords.z) or coords or GetEntityCoords(cache.ped)
+end
+
 -- Player
 
 ---@deprecated import PlayerData using module 'qbx_core:playerdata' https://docs.qbox.re/resources/qbx_core/modules/playerdata
@@ -185,7 +191,7 @@ end
 ---@return integer closestObj or -1
 ---@return number closestDistance or -1
 local function getClosestEntity(entities, coords) -- luacheck: ignore
-    coords = type(coords) == 'table' and vec3(coords.x, coords.y, coords.z) or coords or GetEntityCoords(cache.ped)
+    coords = toCoords(coords)
     local closestDistance = -1
     local closestEntity = -1
     for i = 1, #entities do
@@ -211,7 +217,7 @@ functions.IsWearingGloves = qbx.isWearingGloves
 
 ---@deprecated use lib.getClosestPlayer from ox_lib
 functions.GetClosestPlayer = function(coords) -- luacheck: ignore
-    coords = type(coords) == 'table' and vec3(coords.x, coords.y, coords.z) or coords or GetEntityCoords(cache.ped)
+    coords = toCoords(coords)
     local playerId, _, playerCoords = lib.getClosestPlayer(coords, 5, false)
     local closestDistance = playerCoords and #(playerCoords - coords) or nil
     return playerId or -1, closestDistance or -1
@@ -219,7 +225,7 @@ end
 
 ---@deprecated use lib.getNearbyPlayers from ox_lib
 functions.GetPlayersFromCoords = function(coords, radius)
-    coords = type(coords) == 'table' and vec3(coords.x, coords.y, coords.z) or coords or GetEntityCoords(cache.ped)
+    coords = toCoords(coords)
     local players = lib.getNearbyPlayers(coords, radius or 5, true)
 
     -- This is for backwards compatability as beforehand it only returned the PlayerId, where Lib returns PlayerPed, PlayerId and PlayerCoords
@@ -328,7 +334,7 @@ end
 
 ---@deprecated use lib.getNearbyVehicles from ox_lib
 functions.SpawnClear = function(coords, radius)
-    coords = type(coords) == 'table' and vec3(coords.x, coords.y, coords.z) or coords or GetEntityCoords(cache.ped)
+    coords = toCoords(coords)
     radius = radius or 5
     local vehicles = GetGamePool('CVehicle')
     local closeVeh = {}
@@ -796,7 +802,7 @@ functions.LoadParticleDictionary = lib.requestNamedPtfxAsset
 
 ---@deprecated use ParticleFx natives directly
 functions.StartParticleAtCoord = function(dict, ptName, looped, coords, rot, scale, alpha, color, duration) -- luacheck: ignore
-    coords = type(coords) == 'table' and vec3(coords.x, coords.y, coords.z) or coords or GetEntityCoords(cache.ped)
+    coords = toCoords(coords)
 
     lib.requestNamedPtfxAsset(dict)
     UseParticleFxAssetNextCall(dict)

--- a/bridge/qb/server/functions.lua
+++ b/bridge/qb/server/functions.lua
@@ -9,7 +9,7 @@ local createQbExport = require 'bridge.qb.shared.export-function'
 
 ---@param name string
 ---@param fn function
-local function registerQbFn(name, fn)
+local function registerQbFunction(name, fn)
     functions[name] = fn
     createQbExport(name, fn)
 end
@@ -174,7 +174,7 @@ local function AddItem(itemName, item)
     return true, 'success'
 end
 
-registerQbFn('AddItem', AddItem)
+registerQbFunction('AddItem', AddItem)
 
 -- Single update item
 ---@deprecated incompatible with ox_inventory. Update ox_inventory item config instead.
@@ -192,7 +192,7 @@ local function UpdateItem(itemName, item)
     return true, 'success'
 end
 
-registerQbFn('UpdateItem', UpdateItem)
+registerQbFunction('UpdateItem', UpdateItem)
 
 -- Multiple Add Items
 ---@deprecated incompatible with ox_inventory. Update ox_inventory item config instead.
@@ -228,7 +228,7 @@ local function AddItems(items)
     return true, message, nil
 end
 
-registerQbFn('AddItems', AddItems)
+registerQbFunction('AddItems', AddItems)
 
 -- Single Remove Item
 ---@deprecated incompatible with ox_inventory. Update ox_inventory item config instead.
@@ -249,7 +249,7 @@ local function RemoveItem(itemName)
     return true, 'success'
 end
 
-registerQbFn('RemoveItem', RemoveItem)
+registerQbFunction('RemoveItem', RemoveItem)
 
 -- Single add job function which should only be used if you planning on adding a single job
 ---@deprecated use export CreateJobs
@@ -508,7 +508,7 @@ local function SetMethod(methodName, handler)
     return true, 'success'
 end
 
-registerQbFn('SetMethod', SetMethod)
+registerQbFunction('SetMethod', SetMethod)
 
 -- Add or change (a) field(s) in the QBCore table
 ---@deprecated

--- a/bridge/qb/server/functions.lua
+++ b/bridge/qb/server/functions.lua
@@ -7,6 +7,13 @@ local disableMethodOverrideWarning = GetConvar('qbx:disableoverridewarning', 'fa
 
 local createQbExport = require 'bridge.qb.shared.export-function'
 
+---@param name string
+---@param fn function
+local function registerQbFn(name, fn)
+    functions[name] = fn
+    createQbExport(name, fn)
+end
+
 ---@deprecated use the GetEntityCoords and GetEntityHeading natives directly
 functions.GetCoords = function(entity)
     local coords = GetEntityCoords(entity)
@@ -167,8 +174,7 @@ local function AddItem(itemName, item)
     return true, 'success'
 end
 
-functions.AddItem = AddItem
-createQbExport('AddItem', AddItem)
+registerQbFn('AddItem', AddItem)
 
 -- Single update item
 ---@deprecated incompatible with ox_inventory. Update ox_inventory item config instead.
@@ -186,8 +192,7 @@ local function UpdateItem(itemName, item)
     return true, 'success'
 end
 
-functions.UpdateItem = UpdateItem
-createQbExport('UpdateItem', UpdateItem)
+registerQbFn('UpdateItem', UpdateItem)
 
 -- Multiple Add Items
 ---@deprecated incompatible with ox_inventory. Update ox_inventory item config instead.
@@ -223,8 +228,7 @@ local function AddItems(items)
     return true, message, nil
 end
 
-functions.AddItems = AddItems
-createQbExport('AddItems', AddItems)
+registerQbFn('AddItems', AddItems)
 
 -- Single Remove Item
 ---@deprecated incompatible with ox_inventory. Update ox_inventory item config instead.
@@ -245,8 +249,7 @@ local function RemoveItem(itemName)
     return true, 'success'
 end
 
-functions.RemoveItem = RemoveItem
-createQbExport('RemoveItem', RemoveItem)
+registerQbFn('RemoveItem', RemoveItem)
 
 -- Single add job function which should only be used if you planning on adding a single job
 ---@deprecated use export CreateJobs
@@ -505,8 +508,7 @@ local function SetMethod(methodName, handler)
     return true, 'success'
 end
 
-functions.SetMethod = SetMethod
-createQbExport('SetMethod', SetMethod)
+registerQbFn('SetMethod', SetMethod)
 
 -- Add or change (a) field(s) in the QBCore table
 ---@deprecated

--- a/client/character.lua
+++ b/client/character.lua
@@ -260,7 +260,8 @@ local function capString(str)
     end)
 end
 
-local function spawnDefault() -- We use a callback to make the server wait on this to be done
+---@param coords vector4
+local function spawnAt(coords)
     DoScreenFadeOut(500)
 
     while not IsScreenFadedOut() do
@@ -270,10 +271,10 @@ local function spawnDefault() -- We use a callback to make the server wait on th
     destroyPreviewCam()
 
     pcall(function() exports.spawnmanager:spawnPlayer({
-        x = defaultSpawn.x,
-        y = defaultSpawn.y,
-        z = defaultSpawn.z,
-        heading = defaultSpawn.w
+        x = coords.x,
+        y = coords.y,
+        z = coords.z,
+        heading = coords.w
     }) end)
 
     TriggerServerEvent('QBCore:Server:OnPlayerLoaded')
@@ -284,33 +285,15 @@ local function spawnDefault() -- We use a callback to make the server wait on th
     while not IsScreenFadedIn() do
         Wait(0)
     end
+end
+
+local function spawnDefault() -- We use a callback to make the server wait on this to be done
+    spawnAt(defaultSpawn)
     TriggerEvent('qb-clothes:client:CreateFirstCharacter')
 end
 
 local function spawnLastLocation()
-    DoScreenFadeOut(500)
-
-    while not IsScreenFadedOut() do
-        Wait(0)
-    end
-
-    destroyPreviewCam()
-
-    pcall(function() exports.spawnmanager:spawnPlayer({
-        x = QBX.PlayerData.position.x,
-        y = QBX.PlayerData.position.y,
-        z = QBX.PlayerData.position.z,
-        heading = QBX.PlayerData.position.w
-    }) end)
-
-    TriggerServerEvent('QBCore:Server:OnPlayerLoaded')
-    TriggerEvent('QBCore:Client:OnPlayerLoaded')
-    TriggerServerEvent('qb-houses:server:SetInsideMeta', 0, false)
-    TriggerServerEvent('qb-apartments:server:SetInsideMeta', 0, 0, false)
-
-    while not IsScreenFadedIn() do
-        Wait(0)
-    end
+    spawnAt(QBX.PlayerData.position)
 end
 
 ---@param cid integer

--- a/server/commands.lua
+++ b/server/commands.lua
@@ -3,6 +3,35 @@ local logger = require 'modules.logger'
 
 GlobalState.PVPEnabled = config.server.pvp
 
+---@param source Source
+---@return boolean
+local function checkOptin(source)
+    if IsOptin(source) then return true end
+    Notify(source, locale('error.not_optin'), 'error')
+    return false
+end
+
+---@param source Source
+---@param player Player?
+---@return boolean
+local function requirePlayer(source, player)
+    if player then return true end
+    Notify(source, locale('error.not_online'), 'error')
+    return false
+end
+
+---@param target Source
+---@param prefix string
+---@param source Source
+---@param message string
+local function addOocMessage(target, prefix, source, message)
+    exports.chat:addMessage(target --[[@as Source]], {
+        color = { 0, 0, 255 },
+        multiline = true,
+        args = { ('%s | %s'):format(prefix, GetPlayerName(source)), message }
+    })
+end
+
 lib.addCommand('tp', {
     help = locale('command.tp.help'),
     params = {
@@ -12,7 +41,7 @@ lib.addCommand('tp', {
     },
     restricted = 'group.admin'
 }, function(source, args)
-    if not IsOptin(source) then Notify(source, locale('error.not_optin'), 'error') return end
+    if not checkOptin(source) then return end
 
     if args[locale('command.tp.params.x.name')] and not args[locale('command.tp.params.y.name')] and not args[locale('command.tp.params.z.name')] then
         local target = GetPlayerPed(tonumber(args[locale('command.tp.params.x.name')]) --[[@as number]])
@@ -42,7 +71,7 @@ lib.addCommand('tpm', {
     help = locale('command.tpm.help'),
     restricted = 'group.admin'
 }, function(source)
-    if not IsOptin(source) then Notify(source, locale('error.not_optin'), 'error') return end
+    if not checkOptin(source) then return end
 
     TriggerClientEvent('QBCore:Command:GoToMarker', source)
 end)
@@ -51,7 +80,7 @@ lib.addCommand('togglepvp', {
     help = locale('command.togglepvp.help'),
     restricted = 'group.admin'
 }, function(source)
-    if not IsOptin(source) then Notify(source, locale('error.not_optin'), 'error') return end
+    if not checkOptin(source) then return end
 
     config.server.pvp = not config.server.pvp
     GlobalState.PVPEnabled = config.server.pvp
@@ -65,14 +94,11 @@ lib.addCommand('addpermission', {
     },
     restricted = 'group.admin'
 }, function(source, args)
-    if not IsOptin(source) then Notify(source, locale('error.not_optin'), 'error') return end
+    if not checkOptin(source) then return end
 
     local player = GetPlayer(args[locale('command.addpermission.params.id.name')])
     local permission = args[locale('command.addpermission.params.permission.name')]
-    if not player then
-        Notify(source, locale('error.not_online'), 'error')
-        return
-    end
+    if not requirePlayer(source, player) then return end
 
     ---@diagnostic disable-next-line: deprecated
     AddPermission(player.PlayerData.source, permission)
@@ -86,14 +112,11 @@ lib.addCommand('removepermission', {
     },
     restricted = 'group.admin'
 }, function(source, args)
-    if not IsOptin(source) then Notify(source, locale('error.not_optin'), 'error') return end
+    if not checkOptin(source) then return end
 
     local player = GetPlayer(args[locale('command.removepermission.params.id.name')])
     local permission = args[locale('command.removepermission.params.permission.name')]
-    if not player then
-        Notify(source, locale('error.not_online'), 'error')
-        return
-    end
+    if not requirePlayer(source, player) then return end
 
     ---@diagnostic disable-next-line: deprecated
     RemovePermission(player.PlayerData.source, permission)
@@ -103,7 +126,7 @@ lib.addCommand('openserver', {
     help = locale('command.openserver.help'),
     restricted = 'group.admin'
 }, function(source)
-    if not IsOptin(source) then Notify(source, locale('error.not_optin'), 'error') return end
+    if not checkOptin(source) then return end
 
     if not config.server.closed then
         Notify(source, locale('error.server_already_open'), 'error')
@@ -125,7 +148,7 @@ lib.addCommand('closeserver', {
     },
     restricted = 'group.admin'
 }, function(source, args)
-    if not IsOptin(source) then Notify(source, locale('error.not_optin'), 'error') return end
+    if not checkOptin(source) then return end
 
     if config.server.closed then
         Notify(source, locale('error.server_already_closed'), 'error')
@@ -156,7 +179,7 @@ lib.addCommand('car', {
     },
     restricted = 'group.admin'
 }, function(source, args)
-    if not IsOptin(source) then Notify(source, locale('error.not_optin'), 'error') return end
+    if not checkOptin(source) then return end
 
     if not args then return end
 
@@ -185,7 +208,7 @@ lib.addCommand('dv', {
     },
     restricted = 'group.admin'
 }, function(source, args)
-    if not IsOptin(source) then Notify(source, locale('error.not_optin'), 'error') return end
+    if not checkOptin(source) then return end
 
     local ped = GetPlayerPed(source)
     local pedCars = {GetVehiclePedIsIn(ped, false)}
@@ -216,13 +239,10 @@ lib.addCommand('givemoney', {
     },
     restricted = 'group.admin'
 }, function(source, args)
-    if not IsOptin(source) then Notify(source, locale('error.not_optin'), 'error') return end
+    if not checkOptin(source) then return end
 
     local player = GetPlayer(args[locale('command.givemoney.params.id.name')])
-    if not player then
-        Notify(source, locale('error.not_online'), 'error')
-        return
-    end
+    if not requirePlayer(source, player) then return end
 
     player.Functions.AddMoney(args[locale('command.givemoney.params.moneytype.name')], args[locale('command.givemoney.params.amount.name')])
 end)
@@ -236,13 +256,10 @@ lib.addCommand('setmoney', {
     },
     restricted = 'group.admin'
 }, function(source, args)
-    if not IsOptin(source) then Notify(source, locale('error.not_optin'), 'error') return end
+    if not checkOptin(source) then return end
 
     local player = GetPlayer(args[locale('command.setmoney.params.id.name')])
-    if not player then
-        Notify(source, locale('error.not_online'), 'error')
-        return
-    end
+    if not requirePlayer(source, player) then return end
 
     player.Functions.SetMoney(args[locale('command.setmoney.params.moneytype.name')], args[locale('command.setmoney.params.amount.name')])
 end)
@@ -263,13 +280,10 @@ lib.addCommand('setjob', {
     },
     restricted = 'group.admin'
 }, function(source, args)
-    if not IsOptin(source) then Notify(source, locale('error.not_optin'), 'error') return end
+    if not checkOptin(source) then return end
 
     local player = GetPlayer(args[locale('command.setjob.params.id.name')])
-    if not player then
-        Notify(source, locale('error.not_online'), 'error')
-        return
-    end
+    if not requirePlayer(source, player) then return end
 
     local success, errorResult = player.Functions.SetJob(args[locale('command.setjob.params.job.name')], args[locale('command.setjob.params.grade.name')] or 0)
     assert(success, json.encode(errorResult))
@@ -283,13 +297,10 @@ lib.addCommand('changejob', {
     },
     restricted = 'group.admin'
 }, function(source, args)
-    if not IsOptin(source) then Notify(source, locale('error.not_optin'), 'error') return end
+    if not checkOptin(source) then return end
 
     local player = GetPlayer(args[locale('command.changejob.params.id.name')])
-    if not player then
-        Notify(source, locale('error.not_online'), 'error')
-        return
-    end
+    if not requirePlayer(source, player) then return end
 
     local success, errorResult = SetPlayerPrimaryJob(player.PlayerData.citizenid, args[locale('command.changejob.params.job.name')])
     assert(success, json.encode(errorResult))
@@ -304,13 +315,10 @@ lib.addCommand('addjob', {
     },
     restricted = 'group.admin'
 }, function(source, args)
-    if not IsOptin(source) then Notify(source, locale('error.not_optin'), 'error') return end
+    if not checkOptin(source) then return end
 
     local player = GetPlayer(args[locale('command.addjob.params.id.name')])
-    if not player then
-        Notify(source, locale('error.not_online'), 'error')
-        return
-    end
+    if not requirePlayer(source, player) then return end
 
     local success, errorResult = AddPlayerToJob(player.PlayerData.citizenid, args[locale('command.addjob.params.job.name')], args[locale('command.addjob.params.grade.name')] or 0)
     assert(success, json.encode(errorResult))
@@ -324,13 +332,10 @@ lib.addCommand('removejob', {
     },
     restricted = 'group.admin'
 }, function(source, args)
-    if not IsOptin(source) then Notify(source, locale('error.not_optin'), 'error') return end
+    if not checkOptin(source) then return end
 
     local player = GetPlayer(args[locale('command.removejob.params.id.name')])
-    if not player then
-        Notify(source, locale('error.not_online'), 'error')
-        return
-    end
+    if not requirePlayer(source, player) then return end
 
     local success, errorResult = RemovePlayerFromJob(player.PlayerData.citizenid, args[locale('command.removejob.params.job.name')])
     assert(success, json.encode(errorResult))
@@ -352,13 +357,10 @@ lib.addCommand('setgang', {
     },
     restricted = 'group.admin'
 }, function(source, args)
-    if not IsOptin(source) then Notify(source, locale('error.not_optin'), 'error') return end
+    if not checkOptin(source) then return end
 
     local player = GetPlayer(args[locale('command.setgang.params.id.name')])
-    if not player then
-        Notify(source, locale('error.not_online'), 'error')
-        return
-    end
+    if not requirePlayer(source, player) then return end
 
     local success, errorResult = player.Functions.SetGang(args[locale('command.setgang.params.gang.name')], args[locale('command.setgang.params.grade.name')] or 0)
     assert(success, json.encode(errorResult))
@@ -375,24 +377,12 @@ lib.addCommand('ooc', {
     local playerCoords = GetEntityCoords(GetPlayerPed(source))
     for _, v in pairs(players) do
         if v == source then
-            exports.chat:addMessage(v --[[@as Source]], {
-                color = { 0, 0, 255},
-                multiline = true,
-                args = {('OOC | %s'):format(GetPlayerName(source)), message}
-            })
+            addOocMessage(v, 'OOC', source, message)
         elseif #(playerCoords - GetEntityCoords(GetPlayerPed(v))) < 20.0 then
-            exports.chat:addMessage(v --[[@as Source]], {
-                color = { 0, 0, 255},
-                multiline = true,
-                args = {('OOC | %s'):format(GetPlayerName(source)), message}
-            })
+            addOocMessage(v, 'OOC', source, message)
         elseif IsPlayerAceAllowed(v --[[@as string]], 'admin') then
             if IsOptin(v --[[@as Source]]) then
-                exports.chat:addMessage(v--[[@as Source]], {
-                    color = { 0, 0, 255},
-                    multiline = true,
-                    args = {('Proximity OOC | %s'):format(GetPlayerName(source)), message}
-                })
+                addOocMessage(v, 'Proximity OOC', source, message)
                 logger.log({
                     source = 'qbx_core',
                     webhook  = 'ooc',
@@ -448,7 +438,7 @@ lib.addCommand('deletechar', {
         { name = 'id', help = locale('info.deletechar_command_arg_player_id'), type = 'number' },
     }
 }, function(source, args)
-    if not IsOptin(source) then Notify(source, locale('error.not_optin'), 'error') return end
+    if not checkOptin(source) then return end
 
     local player = GetPlayer(args.id)
     if not player then return end

--- a/server/functions.lua
+++ b/server/functions.lua
@@ -147,14 +147,15 @@ end
 exports('GetQBPlayers', GetQBPlayers)
 
 ---Gets a list of all on duty players of a specified job and the number
----@param job string name
+---@param field 'name' | 'type'
+---@param value string
 ---@return integer
 ---@return Source[]
-function GetDutyCountJob(job)
+local function getDutyCount(field, value)
     local players = {}
     local count = 0
     for src, player in pairs(QBX.Players) do
-        if player.PlayerData.job.name == job then
+        if player.PlayerData.job[field] == value then
             if player.PlayerData.job.onduty then
                 players[#players + 1] = src
                 count += 1
@@ -164,6 +165,13 @@ function GetDutyCountJob(job)
     return count, players
 end
 
+---@param job string name
+---@return integer
+---@return Source[]
+function GetDutyCountJob(job)
+    return getDutyCount('name', job)
+end
+
 exports('GetDutyCountJob', GetDutyCountJob)
 
 ---Gets a list of all on duty players of a specified job type and the number
@@ -171,17 +179,7 @@ exports('GetDutyCountJob', GetDutyCountJob)
 ---@return integer
 ---@return Source[]
 function GetDutyCountType(type)
-    local players = {}
-    local count = 0
-    for src, player in pairs(QBX.Players) do
-        if player.PlayerData.job.type == type then
-            if player.PlayerData.job.onduty then
-                players[#players + 1] = src
-                count += 1
-            end
-        end
-    end
-    return count, players
+    return getDutyCount('type', type)
 end
 
 exports('GetDutyCountType', GetDutyCountType)
@@ -226,16 +224,16 @@ end
 
 exports('SetEntityBucket', SetEntityBucket)
 
--- Will return an array of all the player ids inside the current bucket
+---@param bucketMap table
 ---@param bucket integer
----@return Source[]|boolean
-function GetPlayersInBucket(bucket)
+---@return table|boolean
+local function getBucketPool(bucketMap, bucket)
     local curr_bucket_pool = {}
-    if not (QBX.Player_Buckets or next(QBX.Player_Buckets)) then
+    if not (bucketMap or next(bucketMap)) then
         return false
     end
 
-    for k, v in pairs(QBX.Player_Buckets) do
+    for k, v in pairs(bucketMap) do
         if v == bucket then
             curr_bucket_pool[#curr_bucket_pool + 1] = k
         end
@@ -244,24 +242,20 @@ function GetPlayersInBucket(bucket)
     return curr_bucket_pool
 end
 
+-- Will return an array of all the player ids inside the current bucket
+---@param bucket integer
+---@return Source[]|boolean
+function GetPlayersInBucket(bucket)
+    return getBucketPool(QBX.Player_Buckets, bucket)
+end
+
 exports('GetPlayersInBucket', GetPlayersInBucket)
 
 -- Will return an array of all the entities inside the current bucket (not for player entities, use GetPlayersInBucket for that)
 ---@param bucket integer
 ---@return boolean | integer[]
 function GetEntitiesInBucket(bucket)
-    local curr_bucket_pool = {}
-    if not (QBX.Entity_Buckets or next(QBX.Entity_Buckets)) then
-        return false
-    end
-
-    for k, v in pairs(QBX.Entity_Buckets) do
-        if v == bucket then
-            curr_bucket_pool[#curr_bucket_pool + 1] = k
-        end
-    end
-
-    return curr_bucket_pool
+    return getBucketPool(QBX.Entity_Buckets, bucket)
 end
 
 exports('GetEntitiesInBucket', GetEntitiesInBucket)

--- a/server/groups.lua
+++ b/server/groups.lua
@@ -107,6 +107,29 @@ local function convertGroupsToPlainText(groupTable, type)
     return table.concat(lines, '\n')
 end
 
+---@param groupType 'Job' | 'Gang'
+---@param name string
+local function notifyGroupUpdate(groupType, name)
+    if groupType == 'Job' then
+        TriggerEvent('qbx_core:server:onJobUpdate', name, jobs[name])
+        TriggerClientEvent('qbx_core:client:onJobUpdate', -1, name, jobs[name])
+    else
+        TriggerEvent('qbx_core:server:onGangUpdate', name, gangs[name])
+        TriggerClientEvent('qbx_core:client:onGangUpdate', -1, name, gangs[name])
+    end
+end
+
+---@param groupType 'Job' | 'Gang'
+---@param commitToFile boolean?
+local function commitGroupToFile(groupType, commitToFile)
+    if not commitToFile then return end
+    if groupType == 'Job' then
+        SaveResourceFile(GetCurrentResourceName(), 'shared/jobs.lua', convertGroupsToPlainText(jobs, 'Job'), -1)
+    else
+        SaveResourceFile(GetCurrentResourceName(), 'shared/gangs.lua', convertGroupsToPlainText(gangs, 'Gang'), -1)
+    end
+end
+
 --- Adds or updates a job entry in shared/jobs.lua.
 --- If the job already exists, it will be overwritten.
 --- @param jobName string The unique name of the job.
@@ -128,15 +151,8 @@ function CreateJob(jobName, job, commitToFile)
     -- Store the job data
     jobs[jobName] = job
 
-    -- Notify server and clients about the job update
-    TriggerEvent('qbx_core:server:onJobUpdate', jobName, job)
-    TriggerClientEvent('qbx_core:client:onJobUpdate', -1, jobName, job)
-
-    -- Commit the job data to the shared file
-    if commitToFile then
-        local modifiedData = convertGroupsToPlainText(jobs, 'Job')
-        SaveResourceFile(GetCurrentResourceName(), 'shared/jobs.lua', modifiedData, -1)
-    end
+    notifyGroupUpdate('Job', jobName)
+    commitGroupToFile('Job', commitToFile)
 
     return true, string.format("Job '%s' created/updated successfully.", jobName)
 end
@@ -172,11 +188,7 @@ function CreateJobs(newJobs, commitToFile)
         return false, string.format("Some jobs failed to create: %s", table.concat(failedJobs, ", "))
     end
 
-    -- Commit the job data to the shared file
-    if commitToFile then
-        local modifiedData = convertGroupsToPlainText(jobs, 'Job')
-        SaveResourceFile(GetCurrentResourceName(), 'shared/jobs.lua', modifiedData, -1)
-    end
+    commitGroupToFile('Job', commitToFile)
 
     return true, "All jobs created/updated successfully."
 end
@@ -198,13 +210,8 @@ function RemoveJob(jobName, commitToFile)
     end
 
     jobs[jobName] = nil
-    TriggerEvent('qbx_core:server:onJobUpdate', jobName, nil)
-    TriggerClientEvent('qbx_core:client:onJobUpdate', -1, jobName, nil)
-
-    if commitToFile then
-        local modifiedData = convertGroupsToPlainText(jobs, 'Job')
-        SaveResourceFile(GetCurrentResourceName(), 'shared/jobs.lua', modifiedData, -1)
-    end
+    notifyGroupUpdate('Job', jobName)
+    commitGroupToFile('Job', commitToFile)
     return true, 'success'
 end
 
@@ -216,14 +223,10 @@ exports('RemoveJob', RemoveJob)
 function CreateGangs(newGangs, commitToFile)
     for gangName, gang in pairs(newGangs) do
         gangs[gangName] = gang
-        TriggerEvent('qbx_core:server:onGangUpdate', gangName, gang)
-        TriggerClientEvent('qbx_core:client:onGangUpdate', -1, gangName, gang)
+        notifyGroupUpdate('Gang', gangName)
     end
 
-    if commitToFile then
-        local modifiedData = convertGroupsToPlainText(gangs, 'Gang')
-        SaveResourceFile(GetCurrentResourceName(), 'shared/gangs.lua', modifiedData, -1)
-    end
+    commitGroupToFile('Gang', commitToFile)
 end
 
 exports('CreateGangs', CreateGangs)
@@ -244,13 +247,8 @@ function RemoveGang(gangName, commitToFile)
 
     gangs[gangName] = nil
 
-    TriggerEvent('qbx_core:server:onGangUpdate', gangName, nil)
-    TriggerClientEvent('qbx_core:client:onGangUpdate', -1, gangName, nil)
-
-    if commitToFile then
-        local modifiedData = convertGroupsToPlainText(gangs, 'Gang')
-        SaveResourceFile(GetCurrentResourceName(), 'shared/gangs.lua', modifiedData, -1)
-    end
+    notifyGroupUpdate('Gang', gangName)
+    commitGroupToFile('Gang', commitToFile)
     return true, 'success'
 end
 
@@ -304,12 +302,8 @@ local function upsertJobData(name, data, commitToFile)
             grades = {},
         }
     end
-    TriggerEvent('qbx_core:server:onJobUpdate', name, jobs[name])
-    TriggerClientEvent('qbx_core:client:onJobUpdate', -1, name, jobs[name])
-    if commitToFile then
-        local modifiedData = convertGroupsToPlainText(jobs, 'Job')
-        SaveResourceFile(GetCurrentResourceName(), 'shared/jobs.lua', modifiedData, -1)
-    end
+    notifyGroupUpdate('Job', name)
+    commitGroupToFile('Job', commitToFile)
 end
 
 exports('UpsertJobData', upsertJobData)
@@ -326,12 +320,8 @@ local function upsertGangData(name, data, commitToFile)
             grades = {},
         }
     end
-    TriggerEvent('qbx_core:server:onGangUpdate', name, gangs[name])
-    TriggerClientEvent('qbx_core:client:onGangUpdate', -1, name, gangs[name])
-    if commitToFile then
-        local modifiedData = convertGroupsToPlainText(gangs, 'Gang')
-        SaveResourceFile(GetCurrentResourceName(), 'shared/gangs.lua', modifiedData, -1)
-    end
+    notifyGroupUpdate('Gang', name)
+    commitGroupToFile('Gang', commitToFile)
 end
 
 exports('UpsertGangData', upsertGangData)
@@ -346,12 +336,8 @@ local function upsertJobGrade(name, grade, data, commitToFile)
         return
     end
     jobs[name].grades[grade] = data
-    TriggerEvent('qbx_core:server:onJobUpdate', name, jobs[name])
-    TriggerClientEvent('qbx_core:client:onJobUpdate', -1, name, jobs[name])
-    if commitToFile then
-        local modifiedData = convertGroupsToPlainText(jobs, 'Job')
-        SaveResourceFile(GetCurrentResourceName(), 'shared/jobs.lua', modifiedData, -1)
-    end
+    notifyGroupUpdate('Job', name)
+    commitGroupToFile('Job', commitToFile)
 end
 
 exports('UpsertJobGrade', upsertJobGrade)
@@ -366,12 +352,8 @@ local function upsertGangGrade(name, grade, data, commitToFile)
         return
     end
     gangs[name].grades[grade] = data
-    TriggerEvent('qbx_core:server:onGangUpdate', name, gangs[name])
-    TriggerClientEvent('qbx_core:client:onGangUpdate', -1, name, gangs[name])
-    if commitToFile then
-        local modifiedData = convertGroupsToPlainText(gangs, 'Gang')
-        SaveResourceFile(GetCurrentResourceName(), 'shared/gangs.lua', modifiedData, -1)
-    end
+    notifyGroupUpdate('Gang', name)
+    commitGroupToFile('Gang', commitToFile)
 end
 
 exports('UpsertGangGrade', upsertGangGrade)
@@ -385,12 +367,8 @@ local function removeJobGrade(name, grade, commitToFile)
         return
     end
     jobs[name].grades[grade] = nil
-    TriggerEvent('qbx_core:server:onJobUpdate', name, jobs[name])
-    TriggerClientEvent('qbx_core:client:onJobUpdate', -1, name, jobs[name])
-    if commitToFile then
-        local modifiedData = convertGroupsToPlainText(jobs, 'Job')
-        SaveResourceFile(GetCurrentResourceName(), 'shared/jobs.lua', modifiedData, -1)
-    end
+    notifyGroupUpdate('Job', name)
+    commitGroupToFile('Job', commitToFile)
 end
 
 exports('RemoveJobGrade', removeJobGrade)
@@ -404,12 +382,8 @@ local function removeGangGrade(name, grade, commitToFile)
         return
     end
     gangs[name].grades[grade] = nil
-    TriggerEvent('qbx_core:server:onGangUpdate', name, gangs[name])
-    TriggerClientEvent('qbx_core:client:onGangUpdate', -1, name, gangs[name])
-    if commitToFile then
-        local modifiedData = convertGroupsToPlainText(gangs, 'Gang')
-        SaveResourceFile(GetCurrentResourceName(), 'shared/gangs.lua', modifiedData, -1)
-    end
+    notifyGroupUpdate('Gang', name)
+    commitGroupToFile('Gang', commitToFile)
 end
 
 exports('RemoveGangGrade', removeGangGrade)

--- a/server/player.lua
+++ b/server/player.lua
@@ -23,6 +23,42 @@ local numericMetadata = {
     stress = { min = 0, max = 100 },
 }
 
+---@param identifier Source | string
+---@return Player?
+local function resolvePlayer(identifier)
+    return type(identifier) == 'string' and (GetPlayerByCitizenId(identifier) or GetOfflinePlayer(identifier)) or GetPlayer(identifier)
+end
+
+---@param player Player
+local function savePlayer(player)
+    if player.Offline then
+        SaveOffline(player.PlayerData)
+    else
+        Save(player.PlayerData.source)
+    end
+end
+
+---@param citizenid string
+---@return false
+---@return ErrorResult
+local function playerNotFound(citizenid)
+    return false, {
+        code = 'player_not_found',
+        message = ('player not found with citizenid %s'):format(citizenid)
+    }
+end
+
+---@param code 'job_not_found' | 'gang_not_found'
+---@param name string
+---@return false
+---@return ErrorResult
+local function groupNotFound(code, name)
+    return false, {
+        code = code,
+        message = ('%s does not exist in core memory'):format(name)
+    }
+end
+
 ---@param source Source
 ---@param citizenid? string
 ---@param newData? PlayerEntity
@@ -116,7 +152,7 @@ function SetJob(identifier, jobName, grade)
         return false
     end
 
-    local player = type(identifier) == 'string' and (GetPlayerByCitizenId(identifier) or GetOfflinePlayer(identifier)) or GetPlayer(identifier)
+    local player = resolvePlayer(identifier)
 
     if not player then
         lib.print.error(('cannot set job. no player found for identifier %s'):format(identifier))
@@ -148,7 +184,7 @@ exports('SetJob', SetJob)
 ---@param identifier Source | string
 ---@param onDuty boolean
 function SetJobDuty(identifier, onDuty)
-    local player = type(identifier) == 'string' and (GetPlayerByCitizenId(identifier) or GetOfflinePlayer(identifier)) or GetPlayer(identifier)
+    local player = resolvePlayer(identifier)
 
     if not player then return end
 
@@ -192,10 +228,7 @@ end
 function SetPlayerPrimaryJob(citizenid, jobName)
     local player = GetPlayerByCitizenId(citizenid) or GetOfflinePlayer(citizenid)
     if not player then
-        return false, {
-            code = 'player_not_found',
-            message = ('player not found with citizenid %s'):format(citizenid)
-        }
+        return playerNotFound(citizenid)
     end
 
     local grade = jobName == 'unemployed' and 0 or player.PlayerData.jobs[jobName]
@@ -208,10 +241,7 @@ function SetPlayerPrimaryJob(citizenid, jobName)
 
     local job = GetJob(jobName)
     if not job then
-        return false, {
-            code = 'job_not_found',
-            message = ('%s does not exist in core memory'):format(jobName)
-        }
+        return groupNotFound('job_not_found', jobName)
     end
 
     assert(job.grades[grade] ~= nil, ('job %s does not have grade %s'):format(jobName, grade))
@@ -252,10 +282,7 @@ function AddPlayerToJob(citizenid, jobName, grade)
 
     local job = GetJob(jobName)
     if not job then
-        return false, {
-            code = 'job_not_found',
-            message = ('%s does not exist in core memory'):format(jobName)
-        }
+        return groupNotFound('job_not_found', jobName)
     end
 
     if not job.grades[grade] then
@@ -267,10 +294,7 @@ function AddPlayerToJob(citizenid, jobName, grade)
 
     local player = GetPlayerByCitizenId(citizenid) or GetOfflinePlayer(citizenid)
     if not player then
-        return false, {
-            code = 'player_not_found',
-            message = ('player not found with citizenid %s'):format(citizenid)
-        }
+        return playerNotFound(citizenid)
     end
 
     if player.PlayerData.jobs[jobName] == grade then
@@ -317,10 +341,7 @@ function RemovePlayerFromJob(citizenid, jobName)
 
     local player = GetPlayerByCitizenId(citizenid) or GetOfflinePlayer(citizenid)
     if not player then
-        return false, {
-            code = 'player_not_found',
-            message = ('player not found with citizenid %s'):format(citizenid)
-        }
+        return playerNotFound(citizenid)
     end
 
     if not player.PlayerData.jobs[jobName] then
@@ -334,11 +355,7 @@ function RemovePlayerFromJob(citizenid, jobName)
         local job = GetJob('unemployed')
         assert(job ~= nil, 'cannot find unemployed job. Does it exist in shared/jobs.lua?')
         player.PlayerData.job = toPlayerJob('unemployed', job, 0)
-        if player.Offline then
-            SaveOffline(player.PlayerData)
-        else
-            Save(player.PlayerData.source)
-        end
+        savePlayer(player)
     end
 
     if not player.Offline then
@@ -376,7 +393,7 @@ function SetGang(identifier, gangName, grade)
         return false
     end
 
-    local player = type(identifier) == 'string' and (GetPlayerByCitizenId(identifier) or GetOfflinePlayer(identifier)) or GetPlayer(identifier)
+    local player = resolvePlayer(identifier)
 
     if not player then
         lib.print.error(('cannot set gang. no player found for identifier %s'):format(identifier))
@@ -413,10 +430,7 @@ exports('SetGang', SetGang)
 function SetPlayerPrimaryGang(citizenid, gangName)
     local player = GetPlayerByCitizenId(citizenid) or GetOfflinePlayer(citizenid)
     if not player then
-        return false, {
-            code = 'player_not_found',
-            message = ('player not found with citizenid %s'):format(citizenid)
-        }
+        return playerNotFound(citizenid)
     end
 
     local grade = gangName == 'none' and 0 or player.PlayerData.gangs[gangName]
@@ -429,10 +443,7 @@ function SetPlayerPrimaryGang(citizenid, gangName)
 
     local gang = GetGang(gangName)
     if not gang then
-        return false, {
-            code = 'gang_not_found',
-            message = ('%s does not exist in core memory'):format(gangName)
-        }
+        return groupNotFound('gang_not_found', gangName)
     end
 
     assert(gang.grades[grade] ~= nil, ('gang %s does not have grade %s'):format(gangName, grade))
@@ -481,10 +492,7 @@ function AddPlayerToGang(citizenid, gangName, grade)
 
     local gang = GetGang(gangName)
     if not gang then
-        return false, {
-            code = 'gang_not_found',
-            message = ('%s does not exist in core memory'):format(gangName)
-        }
+        return groupNotFound('gang_not_found', gangName)
     end
 
     if not gang.grades[grade] then
@@ -496,10 +504,7 @@ function AddPlayerToGang(citizenid, gangName, grade)
 
     local player = GetPlayerByCitizenId(citizenid) or GetOfflinePlayer(citizenid)
     if not player then
-        return false, {
-            code = 'player_not_found',
-            message = ('player not found with citizenid %s'):format(citizenid)
-        }
+        return playerNotFound(citizenid)
     end
 
     if player.PlayerData.gangs[gangName] == grade then
@@ -546,10 +551,7 @@ function RemovePlayerFromGang(citizenid, gangName)
 
     local player = GetPlayerByCitizenId(citizenid) or GetOfflinePlayer(citizenid)
     if not player then
-        return false, {
-            code = 'player_not_found',
-            message = ('player not found with citizenid %s'):format(citizenid)
-        }
+        return playerNotFound(citizenid)
     end
 
     if not player.PlayerData.gangs[gangName] then
@@ -572,11 +574,7 @@ function RemovePlayerFromGang(citizenid, gangName)
                 level = 0
             }
         }
-        if player.Offline then
-            SaveOffline(player.PlayerData)
-        else
-            Save(player.PlayerData.source)
-        end
+        savePlayer(player)
     end
 
     if not player.Offline then
@@ -1123,7 +1121,7 @@ exports('SaveOffline', SaveOffline)
 function SetPlayerData(identifier, key, value)
     if type(key) ~= 'string' then return end
 
-    local player = type(identifier) == 'string' and (GetPlayerByCitizenId(identifier) or GetOfflinePlayer(identifier)) or GetPlayer(identifier)
+    local player = resolvePlayer(identifier)
 
     if not player then return end
 
@@ -1136,7 +1134,7 @@ exports('SetPlayerData', SetPlayerData)
 
 ---@param identifier Source | string
 function UpdatePlayerData(identifier)
-    local player = type(identifier) == 'string' and (GetPlayerByCitizenId(identifier) or GetOfflinePlayer(identifier)) or GetPlayer(identifier)
+    local player = resolvePlayer(identifier)
 
     if not player or player.Offline then return end
 
@@ -1152,7 +1150,7 @@ exports('UpdatePlayerData', UpdatePlayerData)
 function SetMetadata(identifier, metadata, value)
     if type(metadata) ~= 'string' then return end
 
-    local player = type(identifier) == 'string' and (GetPlayerByCitizenId(identifier) or GetOfflinePlayer(identifier)) or GetPlayer(identifier)
+    local player = resolvePlayer(identifier)
 
     if not player then return end
 
@@ -1211,11 +1209,7 @@ function SetMetadata(identifier, metadata, value)
         end
     end
 
-    if player.Offline then
-        SaveOffline(player.PlayerData)
-    else
-        Save(player.PlayerData.source)
-    end
+    savePlayer(player)
 end
 
 exports('SetMetadata', SetMetadata)
@@ -1226,7 +1220,7 @@ exports('SetMetadata', SetMetadata)
 function GetMetadata(identifier, metadata)
     if type(metadata) ~= 'string' then return end
 
-    local player = type(identifier) == 'string' and (GetPlayerByCitizenId(identifier) or GetOfflinePlayer(identifier)) or GetPlayer(identifier)
+    local player = resolvePlayer(identifier)
 
     if not player then return end
 
@@ -1255,7 +1249,7 @@ exports('GetMetadata', GetMetadata)
 function SetCharInfo(identifier, charInfo, value)
     if type(charInfo) ~= 'string' then return end
 
-    local player = type(identifier) == 'string' and (GetPlayerByCitizenId(identifier) or GetOfflinePlayer(identifier)) or GetPlayer(identifier)
+    local player = resolvePlayer(identifier)
 
     if not player then return end
 
@@ -1310,7 +1304,7 @@ end
 ---@param reason? string
 ---@return boolean success if money was added
 function AddMoney(identifier, moneyType, amount, reason)
-    local player = type(identifier) == 'string' and (GetPlayerByCitizenId(identifier) or GetOfflinePlayer(identifier)) or GetPlayer(identifier)
+    local player = resolvePlayer(identifier)
 
     if not player then return false end
 
@@ -1361,7 +1355,7 @@ exports('AddMoney', AddMoney)
 ---@param reason? string
 ---@return boolean success if money was removed
 function RemoveMoney(identifier, moneyType, amount, reason)
-    local player = type(identifier) == 'string' and (GetPlayerByCitizenId(identifier) or GetOfflinePlayer(identifier)) or GetPlayer(identifier)
+    local player = resolvePlayer(identifier)
 
     if not player then return false end
 
@@ -1420,7 +1414,7 @@ exports('RemoveMoney', RemoveMoney)
 ---@param reason? string
 ---@return boolean success if money was set
 function SetMoney(identifier, moneyType, amount, reason)
-    local player = type(identifier) == 'string' and (GetPlayerByCitizenId(identifier) or GetOfflinePlayer(identifier)) or GetPlayer(identifier)
+    local player = resolvePlayer(identifier)
 
     if not player then return false end
 
@@ -1474,7 +1468,7 @@ exports('SetMoney', SetMoney)
 function GetMoney(identifier, moneyType)
     if not moneyType then return false end
 
-    local player = type(identifier) == 'string' and (GetPlayerByCitizenId(identifier) or GetOfflinePlayer(identifier)) or GetPlayer(identifier)
+    local player = resolvePlayer(identifier)
 
     if not player then return false end
 

--- a/server/player.lua
+++ b/server/player.lua
@@ -59,6 +59,32 @@ local function groupNotFound(code, name)
     }
 end
 
+---@param citizenid string
+---@return Player?
+local function getLoadedOrOfflinePlayer(citizenid)
+    return GetPlayerByCitizenId(citizenid) or GetOfflinePlayer(citizenid)
+end
+
+---@param name string
+---@return string
+local function toOxAccountName(name)
+    return name == 'cash' and 'money' or name
+end
+
+---@param source Source
+---@param message string
+local function dropForExploit(source, message)
+    DropPlayer(tostring(source), locale('info.exploit_dropped'))
+    logger.log({
+        source = GetInvokingResource() or cache.resource,
+        webhook = config.logging.webhook.anticheat,
+        event = 'Anti-Cheat',
+        color = 'white',
+        tags = config.logging.role,
+        message = message
+    })
+end
+
 ---@param source Source
 ---@param citizenid? string
 ---@param newData? PlayerEntity
@@ -70,15 +96,7 @@ function Login(source, citizenid, newData)
     end
 
     if QBX.Players[source] then
-        DropPlayer(tostring(source), locale('info.exploit_dropped'))
-        logger.log({
-            source = GetInvokingResource() or cache.resource,
-            webhook = config.logging.webhook.anticheat,
-            event = 'Anti-Cheat',
-            color = 'white',
-            tags = config.logging.role,
-            message = ('%s [%s] Dropped for attempting to login twice'):format(GetPlayerName(tostring(source)), tostring(source))
-        })
+        dropForExploit(source, ('%s [%s] Dropped for attempting to login twice'):format(GetPlayerName(tostring(source)), tostring(source)))
         return false
     end
 
@@ -94,15 +112,7 @@ function Login(source, citizenid, newData)
             playerData.userId = userId
             return CheckPlayerData(source, playerData) ~= nil
         else
-            DropPlayer(tostring(source), locale('info.exploit_dropped'))
-            logger.log({
-                source = GetInvokingResource() or cache.resource,
-                webhook = config.logging.webhook.anticheat,
-                event = 'Anti-Cheat',
-                color = 'white',
-                tags = config.logging.role,
-                message = ('%s has been dropped for character joining exploit'):format(GetPlayerName(source))
-            })
+            dropForExploit(source, ('%s has been dropped for character joining exploit'):format(GetPlayerName(source)))
         end
     else
         newData.userId = userId
@@ -226,7 +236,7 @@ end
 ---@return boolean success
 ---@return ErrorResult? errorResult
 function SetPlayerPrimaryJob(citizenid, jobName)
-    local player = GetPlayerByCitizenId(citizenid) or GetOfflinePlayer(citizenid)
+    local player = getLoadedOrOfflinePlayer(citizenid)
     if not player then
         return playerNotFound(citizenid)
     end
@@ -292,7 +302,7 @@ function AddPlayerToJob(citizenid, jobName, grade)
         }
     end
 
-    local player = GetPlayerByCitizenId(citizenid) or GetOfflinePlayer(citizenid)
+    local player = getLoadedOrOfflinePlayer(citizenid)
     if not player then
         return playerNotFound(citizenid)
     end
@@ -339,7 +349,7 @@ function RemovePlayerFromJob(citizenid, jobName)
         }
     end
 
-    local player = GetPlayerByCitizenId(citizenid) or GetOfflinePlayer(citizenid)
+    local player = getLoadedOrOfflinePlayer(citizenid)
     if not player then
         return playerNotFound(citizenid)
     end
@@ -428,7 +438,7 @@ exports('SetGang', SetGang)
 ---@return boolean success
 ---@return ErrorResult? errorResult
 function SetPlayerPrimaryGang(citizenid, gangName)
-    local player = GetPlayerByCitizenId(citizenid) or GetOfflinePlayer(citizenid)
+    local player = getLoadedOrOfflinePlayer(citizenid)
     if not player then
         return playerNotFound(citizenid)
     end
@@ -502,7 +512,7 @@ function AddPlayerToGang(citizenid, gangName, grade)
         }
     end
 
-    local player = GetPlayerByCitizenId(citizenid) or GetOfflinePlayer(citizenid)
+    local player = getLoadedOrOfflinePlayer(citizenid)
     if not player then
         return playerNotFound(citizenid)
     end
@@ -549,7 +559,7 @@ function RemovePlayerFromGang(citizenid, gangName)
         }
     end
 
-    local player = GetPlayerByCitizenId(citizenid) or GetOfflinePlayer(citizenid)
+    local player = getLoadedOrOfflinePlayer(citizenid)
     if not player then
         return playerNotFound(citizenid)
     end
@@ -874,7 +884,7 @@ function CreatePlayer(playerData, Offline)
     ---@param item string
     ---@return string
     local function oxItemCompat(item)
-        return item == 'cash' and 'money' or item
+        return toOxAccountName(item)
     end
 
     ---@deprecated use ox_inventory exports directly
@@ -1281,7 +1291,7 @@ local function emitMoneyEvents(source, playerMoney, moneyType, amount, actionTyp
         TriggerClientEvent('qb-phone:client:RemoveBankMoney', source, amount)
     end
 
-    local oxMoneyType = moneyType == 'cash' and 'money' or moneyType
+    local oxMoneyType = toOxAccountName(moneyType)
 
     if accountsAsItems[oxMoneyType] then
         exports.ox_inventory:SetItem(source, oxMoneyType, playerMoney[moneyType])


### PR DESCRIPTION
## Description

Pure refactor, no behavior change. Repeated inline code is pulled into small typed helpers so the logic lives in one place. One commit per file.

- `server/player.lua`: player lookup, offline lookup, save branch, cash-to-money map, exploit drop, and error-result helpers.
- `server/groups.lua`: group update-notify and commit-to-file helpers.
- `server/commands.lua`: opt-in guard, player-not-found guard, and OOC message helpers.
- `server/functions.lua`: duty-count and bucket-pool helpers.
- `client/character.lua`: shared spawn sequence helper.
- `bridge/qb/server/functions.lua`: qb export registration helper.
- `bridge/qb/client/functions.lua`: coords normalization helper.

## Checklist

- [ ] I have personally loaded this code into an updated Qbox project and checked all of its functionality.
- [x] My pull request fits the contribution guidelines & code conventions.


## Type of Change

- [ ] Bug fix
- [ ] New feature
- [x] Refactor
- [ ] Breaking change


## Checklist

- [ ] I tested this on a local Qbox server
- [x] My PR title follows [Conventional Commits](https://www.conventionalcommits.org/)
- [x] My changes follow the [contribution guidelines](https://github.com/Qbox-project/.github/blob/main/.github/contributing.md)
- [ ] I fixed any lint issues reported by CI
