### PR TITLE
fix: assign correct cid when creating a new character

### DIFF
--- a/server/character.lua
+++ b/server/character.lua
@@ -27,6 +27,10 @@ end
 
 lib.callback.register('qbx_core:server:getCharacters', function(source)
     local license2, license = GetPlayerIdentifierByType(source, 'license2'), GetPlayerIdentifierByType(source, 'license')
+    -- Heal any account left with a broken cid sequence (duplicates from the
+    -- pre-fix createCharacter bug, or gaps from deleted characters) before
+    -- handing the list to the client, so create-time logic can stay a simple append.
+    storage.normalizeCids(license2, license)
     return storage.fetchAllPlayerEntities(license2, license), getAllowedAmountOfCharacters(license2, license)
 end)
 

--- a/server/character.lua
+++ b/server/character.lua
@@ -88,14 +88,11 @@ local function sanitizeNewCharInfo(data)
     }
 end
 
----@param existingCharacters PlayerEntity[]
+---@param existingCharacters PlayerEntity[] sorted ascending by cid (storage.fetchAllPlayerEntities orders by cid)
 ---@return integer
 local function getNextCid(existingCharacters)
-    local nextCid = 0
-    for i = 1, #existingCharacters do
-        nextCid = math.max(nextCid, existingCharacters[i].charinfo.cid or 0)
-    end
-    return nextCid + 1
+    local lastCharacter = existingCharacters[#existingCharacters]
+    return (lastCharacter and lastCharacter.charinfo.cid or 0) + 1
 end
 
 ---@param data unknown

--- a/server/character.lua
+++ b/server/character.lua
@@ -88,18 +88,35 @@ local function sanitizeNewCharInfo(data)
     }
 end
 
+---@param existingCharacters PlayerEntity[]
+---@return integer
+local function getNextCid(existingCharacters)
+    local nextCid = 0
+    for i = 1, #existingCharacters do
+        nextCid = math.max(nextCid, existingCharacters[i].charinfo.cid or 0)
+    end
+    return nextCid + 1
+end
+
 ---@param data unknown
 ---@return table? newData
 lib.callback.register('qbx_core:server:createCharacter', function(source, data)
     if type(data) ~= 'table' then return end
 
     local license2, license = GetPlayerIdentifierByType(source, 'license2'), GetPlayerIdentifierByType(source, 'license')
-    if #storage.fetchAllPlayerEntities(license2, license) >= getAllowedAmountOfCharacters(license2, license) then
+    local existingCharacters = storage.fetchAllPlayerEntities(license2, license)
+    if #existingCharacters >= getAllowedAmountOfCharacters(license2, license) then
         return
     end
 
     local charinfo = sanitizeNewCharInfo(data)
     if not charinfo then return end
+
+    -- The client sends a cid (its local slot index), but that value is never
+    -- trustworthy: sanitizeNewCharInfo() intentionally drops it, so it must be
+    -- computed server-side from the account's existing characters or every new
+    -- character silently falls back to cid 1 (see CheckPlayerData in player.lua).
+    charinfo.cid = getNextCid(existingCharacters)
 
     local newData = {}
     newData.charinfo = charinfo

--- a/server/storage/players.lua
+++ b/server/storage/players.lua
@@ -163,6 +163,34 @@ local function fetchAllPlayerEntities(license2, license)
     return chars
 end
 
+--- Heals accounts whose cids aren't a clean 1..N sequence (duplicates or gaps
+--- left by the pre-fix createCharacter bug, or by deleted characters). Slots
+--- are reassigned in creation order (`id`) so a character keeps its slot
+--- across logins instead of shuffling, and only rows that actually change are
+--- written.
+---@param license2 string
+---@param license? string
+local function normalizeCids(license2, license)
+    ---@type { id: integer, citizenid: string, cid: integer, charinfo: string }[]
+    local rows = MySQL.query.await('SELECT id, citizenid, cid, charinfo FROM players WHERE license = ? OR license = ? ORDER BY id', {license, license2})
+
+    local updates = {}
+    for i = 1, #rows do
+        if rows[i].cid ~= i then
+            local charinfo = json.decode(rows[i].charinfo)
+            charinfo.cid = i
+            updates[#updates + 1] = {
+                query = 'UPDATE players SET cid = ?, charinfo = ? WHERE citizenid = ?',
+                values = { i, json.encode(charinfo), rows[i].citizenid }
+            }
+        end
+    end
+
+    if #updates > 0 then
+        MySQL.transaction.await(updates)
+    end
+end
+
 ---@param citizenId string
 ---@return PlayerEntity?
 local function fetchPlayerEntity(citizenId)
@@ -446,6 +474,7 @@ return {
     fetchPlayerSkin = fetchPlayerSkin,
     fetchPlayerEntity = fetchPlayerEntity,
     fetchAllPlayerEntities = fetchAllPlayerEntities,
+    normalizeCids = normalizeCids,
     deletePlayer = deletePlayer,
     fetchIsUnique = fetchIsUnique,
     addPlayerToJob = addPlayerToJob,


### PR DESCRIPTION
## Summary
- `createCharacter` never set `charinfo.cid` on a newly created character, because `sanitizeNewCharInfo()` strips the client-supplied `cid` field (correctly, since client input shouldn't be trusted for this).
- `CheckPlayerData` then falls back to `playerData.charinfo?.cid or playerData.cid or 1`, so every new character on an account silently gets `cid = 1`, regardless of how many characters already exist.
- This means a player's 2nd, 3rd, etc. character all end up with the same `cid`, instead of an incrementing per-account slot number.

## Fix
Compute the next `cid` server-side from the account's existing characters (`max(existing cids) + 1`), reusing the character list that's already fetched for the character-limit check in `createCharacter`. Using `max + 1` rather than `count + 1` avoids collisions if a character in the middle of the sequence was previously deleted.

## Test plan
- [ ] Create a fresh account, create 2+ characters, confirm `cid` in the `players` table increments (1, 2, 3, ...) instead of staying at 1
- [ ] Delete a character mid-sequence (e.g. cid 2 of 1/2/3) and create a new one, confirm it gets cid 4 (no collision with existing cid 3)
- [ ] Confirm character list ordering (`ORDER BY cid`) in the multichar UI still reflects creation order