### PR TITLE
fix: normalize account cids to a clean 1..N sequence on load

### DIFF
--- a/server/character.lua
+++ b/server/character.lua
@@ -27,6 +27,10 @@ end
 
 lib.callback.register('qbx_core:server:getCharacters', function(source)
     local license2, license = GetPlayerIdentifierByType(source, 'license2'), GetPlayerIdentifierByType(source, 'license')
+    -- Heal any account left with a broken cid sequence (duplicates from the
+    -- pre-fix createCharacter bug, or gaps from deleted characters) before
+    -- handing the list to the client, so create-time logic can stay a simple append.
+    storage.normalizeCids(license2, license)
     return storage.fetchAllPlayerEntities(license2, license), getAllowedAmountOfCharacters(license2, license)
 end)
 

--- a/server/character.lua
+++ b/server/character.lua
@@ -88,11 +88,17 @@ local function sanitizeNewCharInfo(data)
     }
 end
 
+--- Returns the lowest unused cid (1-based slot), backfilling gaps left by
+--- deleted characters instead of only ever appending after the highest cid.
 ---@param existingCharacters PlayerEntity[] sorted ascending by cid (storage.fetchAllPlayerEntities orders by cid)
 ---@return integer
 local function getNextCid(existingCharacters)
-    local lastCharacter = existingCharacters[#existingCharacters]
-    return (lastCharacter and lastCharacter.charinfo.cid or 0) + 1
+    for i = 1, #existingCharacters do
+        if existingCharacters[i].charinfo.cid ~= i then
+            return i
+        end
+    end
+    return #existingCharacters + 1
 end
 
 ---@param data unknown

--- a/server/character.lua
+++ b/server/character.lua
@@ -88,17 +88,11 @@ local function sanitizeNewCharInfo(data)
     }
 end
 
---- Returns the lowest unused cid (1-based slot), backfilling gaps left by
---- deleted characters instead of only ever appending after the highest cid.
 ---@param existingCharacters PlayerEntity[] sorted ascending by cid (storage.fetchAllPlayerEntities orders by cid)
 ---@return integer
 local function getNextCid(existingCharacters)
-    for i = 1, #existingCharacters do
-        if existingCharacters[i].charinfo.cid ~= i then
-            return i
-        end
-    end
-    return #existingCharacters + 1
+    local lastCharacter = existingCharacters[#existingCharacters]
+    return (lastCharacter and lastCharacter.charinfo.cid or 0) + 1
 end
 
 ---@param data unknown

--- a/server/character.lua
+++ b/server/character.lua
@@ -88,14 +88,11 @@ local function sanitizeNewCharInfo(data)
     }
 end
 
----@param existingCharacters PlayerEntity[]
+---@param existingCharacters PlayerEntity[] sorted ascending by cid (storage.fetchAllPlayerEntities orders by cid)
 ---@return integer
 local function getNextCid(existingCharacters)
-    local nextCid = 0
-    for i = 1, #existingCharacters do
-        nextCid = math.max(nextCid, existingCharacters[i].charinfo.cid or 0)
-    end
-    return nextCid + 1
+    local lastCharacter = existingCharacters[#existingCharacters]
+    return (lastCharacter and lastCharacter.charinfo.cid or 0) + 1
 end
 
 ---@param data unknown

--- a/server/character.lua
+++ b/server/character.lua
@@ -88,18 +88,35 @@ local function sanitizeNewCharInfo(data)
     }
 end
 
+---@param existingCharacters PlayerEntity[]
+---@return integer
+local function getNextCid(existingCharacters)
+    local nextCid = 0
+    for i = 1, #existingCharacters do
+        nextCid = math.max(nextCid, existingCharacters[i].charinfo.cid or 0)
+    end
+    return nextCid + 1
+end
+
 ---@param data unknown
 ---@return table? newData
 lib.callback.register('qbx_core:server:createCharacter', function(source, data)
     if type(data) ~= 'table' then return end
 
     local license2, license = GetPlayerIdentifierByType(source, 'license2'), GetPlayerIdentifierByType(source, 'license')
-    if #storage.fetchAllPlayerEntities(license2, license) >= getAllowedAmountOfCharacters(license2, license) then
+    local existingCharacters = storage.fetchAllPlayerEntities(license2, license)
+    if #existingCharacters >= getAllowedAmountOfCharacters(license2, license) then
         return
     end
 
     local charinfo = sanitizeNewCharInfo(data)
     if not charinfo then return end
+
+    -- The client sends a cid (its local slot index), but that value is never
+    -- trustworthy: sanitizeNewCharInfo() intentionally drops it, so it must be
+    -- computed server-side from the account's existing characters or every new
+    -- character silently falls back to cid 1 (see CheckPlayerData in player.lua).
+    charinfo.cid = getNextCid(existingCharacters)
 
     local newData = {}
     newData.charinfo = charinfo

--- a/server/storage/players.lua
+++ b/server/storage/players.lua
@@ -163,6 +163,34 @@ local function fetchAllPlayerEntities(license2, license)
     return chars
 end
 
+--- Heals accounts whose cids aren't a clean 1..N sequence (duplicates or gaps
+--- left by the pre-fix createCharacter bug, or by deleted characters). Slots
+--- are reassigned in creation order (`id`) so a character keeps its slot
+--- across logins instead of shuffling, and only rows that actually change are
+--- written.
+---@param license2 string
+---@param license? string
+local function normalizeCids(license2, license)
+    ---@type { id: integer, citizenid: string, cid: integer, charinfo: string }[]
+    local rows = MySQL.query.await('SELECT id, citizenid, cid, charinfo FROM players WHERE license = ? OR license = ? ORDER BY id', {license, license2})
+
+    local updates = {}
+    for i = 1, #rows do
+        if rows[i].cid ~= i then
+            local charinfo = json.decode(rows[i].charinfo)
+            charinfo.cid = i
+            updates[#updates + 1] = {
+                query = 'UPDATE players SET cid = ?, charinfo = ? WHERE citizenid = ?',
+                values = { i, json.encode(charinfo), rows[i].citizenid }
+            }
+        end
+    end
+
+    if #updates > 0 then
+        MySQL.transaction.await(updates)
+    end
+end
+
 ---@param citizenId string
 ---@return PlayerEntity?
 local function fetchPlayerEntity(citizenId)
@@ -446,6 +474,7 @@ return {
     fetchPlayerSkin = fetchPlayerSkin,
     fetchPlayerEntity = fetchPlayerEntity,
     fetchAllPlayerEntities = fetchAllPlayerEntities,
+    normalizeCids = normalizeCids,
     deletePlayer = deletePlayer,
     fetchIsUnique = fetchIsUnique,
     addPlayerToJob = addPlayerToJob,


### PR DESCRIPTION
## Summary
Follow-up to #766, per @Kenshiin13's review there:

> the real problem is corrupted legacy data (many characters at cid 1), and neither append nor backfill heals it, they only avoid adding to it. Instead of deriving the next cid at create time, normalize an account's cids when its character list is loaded (the getCharacters step), independent of creating a new character

- `storage.normalizeCids(license2, license)` fetches an account's characters ordered by `id` (creation order) and checks whether `cid` already forms a clean `1..N` sequence.
- If it does, nothing is written.
- If it doesn't (duplicates from the pre-#766 bug, or gaps left by deleted characters), it reassigns `cid = 1..N` in creation order and persists only the rows that changed (`cid` column + the `charinfo` JSON mirror).
- Called from `qbx_core:server:getCharacters` before the character list is returned to the client, so an account is healed the next time it opens the character-select screen — independent of ever creating a new character.

With this in place, #766's create-time `last + 1` logic is safe to reason about: by the time `createCharacter` runs, cids are already guaranteed clean, so a plain append can't collide or perpetuate old damage.

## Test plan
- [x] Seed an account with several characters all at `cid = 1` (the pre-#766 bug state), call `getCharacters`, confirm cids get rewritten to `1, 2, 3, ...` in original creation (`id`) order and the change persists across a second call (no-op, no extra writes)
- [ ] Seed an account with a gap (e.g. `1, 2, 5` from a deleted character), confirm it normalizes to `1, 2, 3`
- [ ] Seed an already-clean account (`1, 2, 3`), confirm `getCharacters` performs no UPDATE queries
- [ ] Create a new character after normalization, confirm it gets `cid = N + 1` via #766's logic with no collision