### PR TITLE
fix(groups): normalize numeric grade keys

### DIFF
--- a/server/groups.lua
+++ b/server/groups.lua
@@ -22,6 +22,45 @@ for name in pairs(gangs) do
     end
 end
 
+---@param grade unknown
+---@return integer? grade
+local function normalizeGrade(grade)
+    if type(grade) == 'string' then
+        if not grade:match('^%d+$') then return end
+        grade = tonumber(grade)
+    end
+
+    if type(grade) ~= 'number' or grade < 0 or grade % 1 ~= 0 then return end
+
+    return grade
+end
+
+---@param group Job | Gang
+---@return boolean success
+---@return string? message
+local function normalizeGroupGrades(group)
+    if type(group.grades) ~= 'table' then
+        return false, 'Invalid parameter: group grades must be a table.'
+    end
+
+    local grades = {}
+    for grade, data in pairs(group.grades) do
+        local normalizedGrade = normalizeGrade(grade)
+        if not normalizedGrade then
+            return false, ("Invalid grade '%s': grade keys must be non-negative integers."):format(tostring(grade))
+        end
+
+        if grades[normalizedGrade] ~= nil then
+            return false, ("Invalid grade '%s': multiple grade keys resolve to the same integer."):format(tostring(grade))
+        end
+
+        grades[normalizedGrade] = data
+    end
+
+    group.grades = grades
+    return true
+end
+
 --- Removes any quotes to ensure functionality
 ---@param str string
 ---@return string
@@ -148,6 +187,9 @@ function CreateJob(jobName, job, commitToFile)
         return false, "Invalid parameter: job must be a table."
     end
 
+    local gradesValid, gradesError = normalizeGroupGrades(job)
+    if not gradesValid then return false, gradesError end
+
     -- Store the job data
     jobs[jobName] = job
 
@@ -220,13 +262,31 @@ exports('RemoveJob', RemoveJob)
 ---Adds or overwrites gangs in shared/gangs.lua
 ---@param newGangs table<string, Gang>
 ---@param commitToFile boolean Whether to commit the gang data to the shared file.
+---@return boolean success
+---@return string? message
 function CreateGangs(newGangs, commitToFile)
+    if type(newGangs) ~= 'table' then
+        return false, 'Invalid parameter: newGangs must be a table.'
+    end
+
+    for gangName, gang in pairs(newGangs) do
+        if type(gang) ~= 'table' then
+            return false, ("Invalid parameter: gang '%s' must be a table."):format(tostring(gangName))
+        end
+
+        local gradesValid, gradesError = normalizeGroupGrades(gang)
+        if not gradesValid then
+            return false, ("Gang '%s': %s"):format(tostring(gangName), gradesError)
+        end
+    end
+
     for gangName, gang in pairs(newGangs) do
         gangs[gangName] = gang
         notifyGroupUpdate('Gang', gangName)
     end
 
     commitGroupToFile('Gang', commitToFile)
+    return true
 end
 
 exports('CreateGangs', CreateGangs)
@@ -335,7 +395,12 @@ local function upsertJobGrade(name, grade, data, commitToFile)
         lib.print.error('Job must exist to edit grades. Not found:', name)
         return
     end
-    jobs[name].grades[grade] = data
+    local normalizedGrade = normalizeGrade(grade)
+    if not normalizedGrade then
+        lib.print.error('Job grade must be a non-negative integer:', grade)
+        return
+    end
+    jobs[name].grades[normalizedGrade] = data
     notifyGroupUpdate('Job', name)
     commitGroupToFile('Job', commitToFile)
 end
@@ -351,7 +416,12 @@ local function upsertGangGrade(name, grade, data, commitToFile)
         lib.print.error('Gang must exist to edit grades. Not found:', name)
         return
     end
-    gangs[name].grades[grade] = data
+    local normalizedGrade = normalizeGrade(grade)
+    if not normalizedGrade then
+        lib.print.error('Gang grade must be a non-negative integer:', grade)
+        return
+    end
+    gangs[name].grades[normalizedGrade] = data
     notifyGroupUpdate('Gang', name)
     commitGroupToFile('Gang', commitToFile)
 end

--- a/server/player.lua
+++ b/server/player.lua
@@ -1167,7 +1167,8 @@ function SetMetadata(identifier, metadata, value)
     local numeric = numericMetadata[metadata]
     if numeric then
         value = tonumber(value)
-        if not qbx.math.isFinite(value) then
+        -- Defined in modules/lib.lua but not yet included in the external qbox_lib lint standard.
+        if not qbx.math.isFinite(value) then -- luacheck: ignore
             lib.print.warn(('rejected non-finite value for metadata "%s"'):format(metadata))
             return
         end
@@ -1302,7 +1303,8 @@ end
 ---@return number?
 local function validateMoneyAmount(value)
     value = tonumber(value)
-    if not qbx.math.isFinite(value) then return end
+    -- Defined in modules/lib.lua but not yet included in the external qbox_lib lint standard.
+    if not qbx.math.isFinite(value) then return end -- luacheck: ignore
     value = qbx.math.round(value)
     if value < 0 then return end
     return value


### PR DESCRIPTION
## Summary

- convert QB-style numeric string grade keys (for example, `"0"`) to integer keys before caching jobs and gangs
- reject negative, fractional, non-numeric, and colliding grade keys
- apply the same normalization to job and gang grade upserts
- validate gang collections before mutating the shared cache
- acknowledge the two valid `qbx.math.isFinite` calls until the external `qbox_lib` Luacheck standard includes that helper

## Why

Qbox grade lookups use numeric levels, while QB-compatible runtime group definitions can provide string keys. Those definitions were cached unchanged, so commands such as `setgang` could fail to find an otherwise valid grade.

The lint standard currently declares `qbx.math.round` but not `qbx.math.isFinite`, even though `isFinite` is implemented in `modules/lib.lua`. The narrow inline directives prevent those valid calls from failing every repository lint run without changing runtime behavior.

Closes #543

## Validation

- `git diff --check origin/main...HEAD`
- push and pull-request Lua lint workflows completed successfully
- JUnit lint report: 55 passed, 0 failed
- CodeQL completed successfully
- confirmed the pushed branch SHA matches the reviewed local commit
- reviewed all grade lookup and mutation call sites

The repository has no local test harness and no Lua runtime is installed in this workspace, so no package-based Lua checker was invoked.